### PR TITLE
CONVO: Add debugger display to lifetime scopes

### DIFF
--- a/Core/Source/Autofac.Integration.Web/ContainerProviderContainer.cs
+++ b/Core/Source/Autofac.Integration.Web/ContainerProviderContainer.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Autofac.Builder;
 using Autofac.Core;
@@ -37,6 +38,7 @@ namespace Autofac.Integration.Web
     /// Provides an implementation of <see cref="Autofac.IContainer"/> which uses the configured
     /// <see cref="IContainerProvider"/> to route calls to the current request container.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     [SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Disposing of this wrapper container should not result in the whole application container being disposed.")]
     public class ContainerProviderContainer : IContainer
     {
@@ -197,6 +199,11 @@ namespace Autofac.Integration.Web
         [SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Disposing of this wrapper container should not result in the whole application container being disposed.")]
         public void Dispose()
         {
+        }
+
+        string DebuggerDisplay()
+        {
+            return Tag.ToString();
         }
     }
 }

--- a/Core/Source/Autofac/Core/Container.cs
+++ b/Core/Source/Autofac/Core/Container.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Autofac.Core.Activators.Delegate;
 using Autofac.Core.Lifetime;
 using Autofac.Core.Registration;
@@ -36,6 +37,7 @@ namespace Autofac.Core
     /// <summary>
     /// Standard container implementation.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public class Container : Disposable, IContainer, IServiceProvider
     {
         readonly IComponentRegistry _componentRegistry;
@@ -208,6 +210,11 @@ namespace Autofac.Core
         public object GetService(Type serviceType)
         {
             return ((IServiceProvider)_rootLifetimeScope).GetService(serviceType);
+        }
+
+        string DebuggerDisplay()
+        {
+            return Tag.ToString();
         }
     }
 }

--- a/Core/Source/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/Core/Source/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving;
@@ -35,6 +36,7 @@ namespace Autofac.Core.Lifetime
     /// <summary>
     /// Lifetime scope implementation.
     /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
     {
         /// <summary>
@@ -353,5 +355,11 @@ namespace Autofac.Core.Lifetime
         /// Fired when a resolve operation is beginning in this scope.
         /// </summary>
         public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning;
+
+
+        string DebuggerDisplay()
+        {
+            return Tag.ToString();
+        }
     }
 }

--- a/Extras/Source/Autofac.Extras.Multitenant/MultitenantContainer.cs
+++ b/Extras/Source/Autofac.Extras.Multitenant/MultitenantContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Autofac;
@@ -48,6 +49,7 @@ namespace Autofac.Extras.Multitenant
     /// </para>
     /// </remarks>
     /// <seealso cref="Autofac.Extras.Multitenant.ConfigurationActionBuilder"/>
+    [DebuggerDisplay("{DebuggerDisplay()}")]
     public class MultitenantContainer : Disposable, IContainer
     {
         /// <summary>
@@ -417,6 +419,11 @@ namespace Autofac.Extras.Multitenant
         public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
         {
             return this.GetCurrentTenantScope().ResolveComponent(registration, parameters);
+        }
+
+        string DebuggerDisplay()
+        {
+            return Tag.ToString();
         }
     }
 }


### PR DESCRIPTION
I recently went through a bunch of debugging to make sure that I was tracking the right life scopes in various parts of my code base, and having to expand the debugger constantly to check the `Tag` was a very tedious step. By no means is this the end all be all of what could be done, but this small tweak would be very helpful.

for #483
