### PR TITLE
added mailmap with entry for Adam Ralph

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Adam Ralph <adam@adamralph.com> Adam Ralph <unknown@kiln.example.com>


### PR DESCRIPTION
It seems something weird happened with the email addresses for the commits in the history. This can be fixed by adding a .mailmap file with appropriate mappings. I've added an entry for myself and I guess other authors can later add mappings for themselves or for others who they are familiar with.

Before:
![image](https://f.cloud.github.com/assets/677704/2323516/b6889724-a3bd-11e3-9f18-40096b6401c6.png)
After:
![image](https://f.cloud.github.com/assets/677704/2323521/c733d444-a3bd-11e3-88e0-608f3759fdcc.png)
