### PR TITLE
Fix for  #484 (RegisterWebApiModelBinders has no effect in Web API 2)

### DIFF
--- a/Core/Source/Autofac.Integration.WebApi/RegistrationExtensions.cs
+++ b/Core/Source/Autofac.Integration.WebApi/RegistrationExtensions.cs
@@ -170,6 +170,7 @@ namespace Autofac.Integration.WebApi
             return builder.RegisterAssemblyTypes(modelBinderAssemblies)
                 .Where(type => type.IsAssignableTo<IModelBinder>())
                 .As<IModelBinder>()
+                .AsSelf()
                 .SingleInstance();
         }
 


### PR DESCRIPTION
Continuing the #527.
Added a registration of model binders AsSelf() as Web API gets binders from the container by binder's type. That solves the issue with `ModelBinderAttribute`.
