### PR TITLE
Removed unnecessary finalizers

### DIFF
--- a/Core/Source/Autofac.Integration.Wcf/AutofacInstanceContext.cs
+++ b/Core/Source/Autofac.Integration.Wcf/AutofacInstanceContext.cs
@@ -106,14 +106,6 @@ namespace Autofac.Integration.Wcf
             this.OperationLifetime = container.BeginLifetimeScope();
         }
 
-		/// <summary>
-		/// Finalizes an instance of the <see cref="AutofacInstanceContext"/> class.
-		/// </summary>
-        ~AutofacInstanceContext()
-        {
-            this.Dispose(false);
-        }
-
         /// <summary>
         /// Enables an extension object to find out when it has been aggregated.
         /// Called when the extension is added to the

--- a/Core/Source/Autofac.Integration.WebApi/AutofacWebApiDependencyResolver.cs
+++ b/Core/Source/Autofac.Integration.WebApi/AutofacWebApiDependencyResolver.cs
@@ -54,15 +54,6 @@ namespace Autofac.Integration.WebApi
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="AutofacWebApiDependencyResolver"/> class.
-        /// </summary>
-        [SecuritySafeCritical]
-        ~AutofacWebApiDependencyResolver()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
         /// Gets the root container provided to the dependency resolver.
         /// </summary>
         public ILifetimeScope Container

--- a/Core/Source/Autofac.Integration.WebApi/AutofacWebApiDependencyScope.cs
+++ b/Core/Source/Autofac.Integration.WebApi/AutofacWebApiDependencyScope.cs
@@ -53,15 +53,6 @@ namespace Autofac.Integration.WebApi
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="AutofacWebApiDependencyScope"/> class.
-        /// </summary>
-        [SecuritySafeCritical]
-        ~AutofacWebApiDependencyScope()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
         /// Gets the lifetime scope for the current dependency scope.
         /// </summary>
         public ILifetimeScope LifetimeScope

--- a/Extras/Source/Autofac.Extras.FakeItEasy/AutoFake.cs
+++ b/Extras/Source/Autofac.Extras.FakeItEasy/AutoFake.cs
@@ -75,15 +75,6 @@ namespace Autofac.Extras.FakeItEasy
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="AutoFake"/> class.
-        /// </summary>
-        [SecuritySafeCritical]
-        ~AutoFake()
-        {
-            this.Dispose(false);
-        }
-
-        /// <summary>
         /// Gets the <see cref="IContainer"/> that handles the component resolution.
         /// </summary>
         public IContainer Container

--- a/Extras/Source/Autofac.Extras.Moq/AutoMock.cs
+++ b/Extras/Source/Autofac.Extras.Moq/AutoMock.cs
@@ -68,15 +68,6 @@ namespace Autofac.Extras.Moq
         }
 
         /// <summary>
-        /// Finalizes an instance of the <see cref="AutoMock"/> class.
-        /// </summary>
-        [SecuritySafeCritical]
-        ~AutoMock()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
         /// Create new <see cref="AutoMock"/> instance with loose mock behavior.
         /// </summary>
         /// <seealso cref="MockRepository"/>


### PR DESCRIPTION
You shouldn't declare finalizers unless you have to. You should only declare a finalizer if you have unmanaged resources to dispose. The CLR deals with finalizable objects differently, even if SuppressFinalize is called. More info [on msdn](http://msdn.microsoft.com/en-us/library/b1yfkh5e%28v=vs.110%29.aspx)
