### PR TITLE
Fix for #529 (RegisterDecorator does not play nicely when decorating items registered with .As<IFoo>())

### DIFF
--- a/Core/Tests/Autofac.Tests/Features/LightweightAdapters/LightweightAdapterRegistrationExtensionsTests.cs
+++ b/Core/Tests/Autofac.Tests/Features/LightweightAdapters/LightweightAdapterRegistrationExtensionsTests.cs
@@ -162,7 +162,6 @@ namespace Autofac.Tests.Features.LightweightAdapters
             }
 
             [Test]
-            [Ignore("Issue #529")]
             public void InstanceWithDefaultImplementationIsDecorated()
             {
                 var decorator = _container.Resolve<IService>();


### PR DESCRIPTION
Fix for #529.
I've added an exceptional case for `LightweightAdapterRegistrationSource` to `ComponentRegistry` which override existing registrations. The fix is quite dirty and I don't like it but couldn't find a better solution. At least it does its job. Any thoughts about a better way?
