### PR TITLE
Fixed race condition in Disposable.Dispose()

### DIFF
--- a/Core/Source/Autofac/Features/OwnedInstances/Owned.cs
+++ b/Core/Source/Autofac/Features/OwnedInstances/Owned.cs
@@ -120,8 +120,7 @@ namespace Autofac.Features.OwnedInstances
         {
             if (disposing)
             {
-                var lt = _lifetime;
-                Interlocked.CompareExchange(ref _lifetime, null, lt);
+                var lt = Interlocked.Exchange(ref _lifetime, null);
                 if (lt != null)
                 {
                     _value = default(T);

--- a/Core/Source/Autofac/Util/Disposable.cs
+++ b/Core/Source/Autofac/Util/Disposable.cs
@@ -43,13 +43,12 @@ namespace Autofac.Util
         [SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "Dispose is implemented correctly, FxCop just doesn't see it.")]
         public void Dispose()
         {
-            var isDisposed = _isDisposed;
-            Interlocked.CompareExchange(ref _isDisposed, DisposedFlag, isDisposed);
-            if (isDisposed == 0)
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
+            var wasDisposed = Interlocked.Exchange(ref _isDisposed, DisposedFlag);
+            if (wasDisposed == DisposedFlag)
+                return;
+
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Disposable.Dispose() and Owned<T>.Dispose(bool) were using
Interlocked.CompareExchange but its return value was not used. The
disposal was driven by a cached local variable instead of cmpxchg result which is the actual synchronized value of the field.
For simplicity I've changed CompareExchange to Exchange only.
