### PR TITLE
Better circular dependency handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+copy_debug.bat

--- a/Autofac.sln
+++ b/Autofac.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+VisualStudioVersion = 12.0.30723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{2D17C2B6-9795-40D3-951A-6A62A3A0FA7C}"
 EndProject
@@ -143,6 +143,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Autofac.Tests.Integration.Mvc.Owin", "Core\Tests\Autofac.Tests.Integration.WebApi.Mvc\Autofac.Tests.Integration.Mvc.Owin.csproj", "{C8CA150E-ADBC-47DE-A9EB-AACC4621C091}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OwinWebApi.ConsoleApplication", "Examples\OwinWebApi.ConsoleApplication\OwinWebApi.ConsoleApplication.csproj", "{07EC4968-EE0B-4EA9-9ED8-165CED3BB62B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CircularCrashTest", "CircularCrashTest\CircularCrashTest.csproj", "{82603543-1845-4F4F-82AF-6D767F695013}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -729,6 +731,16 @@ Global
 		{07EC4968-EE0B-4EA9-9ED8-165CED3BB62B}.Release|ARM.ActiveCfg = Release|Any CPU
 		{07EC4968-EE0B-4EA9-9ED8-165CED3BB62B}.Release|x64.ActiveCfg = Release|Any CPU
 		{07EC4968-EE0B-4EA9-9ED8-165CED3BB62B}.Release|x86.ActiveCfg = Release|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Release|ARM.ActiveCfg = Release|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Release|x64.ActiveCfg = Release|Any CPU
+		{82603543-1845-4F4F-82AF-6D767F695013}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -792,6 +804,7 @@ Global
 		{80E903A8-7A29-4B17-B67E-9A769894F415} = {2D17C2B6-9795-40D3-951A-6A62A3A0FA7C}
 		{C8CA150E-ADBC-47DE-A9EB-AACC4621C091} = {531E6E21-94E9-43C7-AF3F-97E78B42D0C8}
 		{07EC4968-EE0B-4EA9-9ED8-165CED3BB62B} = {0822765A-6BFC-4509-ABC7-31443D56B2EF}
+		{82603543-1845-4F4F-82AF-6D767F695013} = {0822765A-6BFC-4509-ABC7-31443D56B2EF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.0\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.ExceptionHandling.5.0.505.0\lib\NET35;packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.2\lib\NET35

--- a/CircularCrashTest/App.config
+++ b/CircularCrashTest/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+</configuration>

--- a/CircularCrashTest/CircularCrashTest.csproj
+++ b/CircularCrashTest/CircularCrashTest.csproj
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{82603543-1845-4F4F-82AF-6D767F695013}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>CircularCrashTest</RootNamespace>
+    <AssemblyName>CircularCrashTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Source\Autofac\Autofac.csproj">
+      <Project>{7D018B3E-34A3-423D-AC35-12731F4E0A2C}</Project>
+      <Name>Autofac</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/CircularCrashTest/Program.cs
+++ b/CircularCrashTest/Program.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Linq;
+using Autofac;
+
+namespace CircularCrashTest
+{
+    public interface IClass1
+    {
+        void DoClass1();
+    }
+
+    public class Class1 : IClass1
+    {
+        public IClass2 Class2 { get; set; }
+
+        public Class1()
+        {
+        }
+
+        public void DoClass1()
+        {
+            Console.WriteLine("DoClass1 called");
+            Class2.DoClass2Extra();
+        }
+    }
+
+    public interface IClass2
+    {
+        void DoClass2();
+        void DoClass2Extra();
+    }
+
+    public class Class2 : IClass2
+    {
+        public IClass1 Class1 { get; set; }
+
+        public Class2()
+        {
+        }
+
+        public void DoClass2()
+        {
+            Console.WriteLine("DoClass2 called");
+            if (Class1 == null) {
+                // This should never happen
+                Console.WriteLine("Cannot call Class1 - it should NOT be null!");
+            } else {
+                Class1.DoClass1();
+            }
+        }
+
+        public void DoClass2Extra()
+        {
+            Console.WriteLine("DoClass2Extra called");
+        }
+    }
+
+    public interface IClass3
+    {
+        void DoClass3();
+    }
+
+    public class Class3 : IClass3
+    {
+        public Class3(
+            IClass2 class2)
+        {
+            // We SHOULD be able to call into class2 here and FULLY expect that it is completely initialized
+            // as this class should NOT have to care how IClass2 is created. It should be fully resolved before
+            // this constructor is called.
+            class2.DoClass2();
+        }
+
+        public void DoClass3()
+        {
+            Console.WriteLine("DoClass3 called");
+        }
+    }
+    
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<Class1>().As<IClass1>().PropertiesAutowired().InstancePerLifetimeScope();
+            builder.RegisterType<Class2>().As<IClass2>().PropertiesAutowired().InstancePerLifetimeScope();
+            builder.RegisterType<Class3>().As<IClass3>().InstancePerLifetimeScope();
+
+            var container = builder.Build();
+            using (var scope = container.BeginLifetimeScope((ContainerBuilder b) => { })) {
+                var class3 = scope.Resolve<IClass3>();
+                class3.DoClass3();
+
+                Console.WriteLine("Press Enter");
+                Console.ReadLine();
+            }
+        }
+    }
+}

--- a/CircularCrashTest/Properties/AssemblyInfo.cs
+++ b/CircularCrashTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("CircularCrashTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("CircularCrashTest")]
+[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bc17d35e-8f64-457d-998c-27193500ba06")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Core/Source/Autofac.Integration.SignalR/Autofac.Integration.SignalR.csproj
+++ b/Core/Source/Autofac.Integration.SignalR/Autofac.Integration.SignalR.csproj
@@ -11,10 +11,14 @@
     <AssemblyName>Autofac.Integration.SignalR</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SccProjectName>&lt;Project Location In Database&gt;</SccProjectName>
-    <SccLocalPath>&lt;Local Binding Root of Project&gt;</SccLocalPath>
-    <SccAuxPath>&lt;Source Control Database&gt;</SccAuxPath>
-    <SccProvider>Mercurial Source Control Package</SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />

--- a/Core/Source/Autofac/Autofac.csproj
+++ b/Core/Source/Autofac/Autofac.csproj
@@ -54,6 +54,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DependencyResolutionExceptionResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Core\InjectPropertiesEventArgs.cs" />
     <Compile Include="Core\Lifetime\MatchingScopeLifetimeTags.cs" />
     <Compile Include="Core\Registration\IModuleRegistrar.cs" />
     <Compile Include="Core\Registration\ModuleRegistrar.cs" />

--- a/Core/Source/Autofac/Builder/RegistrationBuilder.cs
+++ b/Core/Source/Autofac/Builder/RegistrationBuilder.cs
@@ -198,6 +198,9 @@ namespace Autofac.Builder
             foreach (var ad in data.ActivatedHandlers)
                 registration.Activated += ad;
 
+            foreach (var ij in data.InjectPropertiesHandlers)
+                registration.InjectProperties += ij;
+
             return registration;
         }
 

--- a/Core/Source/Autofac/Builder/RegistrationBuilderOfTLAR.cs
+++ b/Core/Source/Autofac/Builder/RegistrationBuilderOfTLAR.cs
@@ -373,7 +373,7 @@ namespace Autofac.Builder
             if (allowCircularDependencies)
                 RegistrationData.ActivatedHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
             else
-                RegistrationData.ActivatingHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
+                RegistrationData.InjectPropertiesHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
 
             return this;
         }

--- a/Core/Source/Autofac/Builder/RegistrationData.cs
+++ b/Core/Source/Autofac/Builder/RegistrationData.cs
@@ -50,6 +50,7 @@ namespace Autofac.Builder
         readonly ICollection<EventHandler<PreparingEventArgs>> _preparingHandlers = new List<EventHandler<PreparingEventArgs>>();
         readonly ICollection<EventHandler<ActivatingEventArgs<object>>> _activatingHandlers = new List<EventHandler<ActivatingEventArgs<object>>>();
         readonly ICollection<EventHandler<ActivatedEventArgs<object>>> _activatedHandlers = new List<EventHandler<ActivatedEventArgs<object>>>();
+        readonly ICollection<EventHandler<InjectPropertiesEventArgs<object>>> _injectPropertiesHandlers = new List<EventHandler<InjectPropertiesEventArgs<object>>>();
 
         /// <summary>
         /// Construct a RegistrationData instance.
@@ -149,6 +150,11 @@ namespace Autofac.Builder
         public ICollection<EventHandler<ActivatedEventArgs<object>>> ActivatedHandlers { get { return _activatedHandlers; } }
 
         /// <summary>
+        /// Handlers for the Inject Circular Properties event.
+        /// </summary>
+        public ICollection<EventHandler<InjectPropertiesEventArgs<object>>> InjectPropertiesHandlers { get { return _injectPropertiesHandlers; } }
+
+        /// <summary>
         /// Copies the contents of another RegistrationData object into this one.
         /// </summary>
         /// <param name="that">The data to copy.</param>
@@ -176,6 +182,7 @@ namespace Autofac.Builder
             AddAll(PreparingHandlers, that.PreparingHandlers);
             AddAll(ActivatingHandlers, that.ActivatingHandlers);
             AddAll(ActivatedHandlers, that.ActivatedHandlers);
+            AddAll(InjectPropertiesHandlers, that.InjectPropertiesHandlers);
         }
 
         static void AddAll<T>(ICollection<T> to, IEnumerable<T> from)

--- a/Core/Source/Autofac/Core/IComponentRegistration.cs
+++ b/Core/Source/Autofac/Core/IComponentRegistration.cs
@@ -123,5 +123,18 @@ namespace Autofac.Core
         /// <param name="instance">The instance.</param>
         [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This is the method that would raise the event.")]
         void RaiseActivated(IComponentContext context, IEnumerable<Parameter> parameters, object instance);
+
+        /// <summary>
+        /// Fired when the activation process is injecting properties when a new instance is created
+        /// </summary>
+        event EventHandler<InjectPropertiesEventArgs<object>> InjectProperties;
+
+        /// <summary>
+        /// Called by the container to inject properties when the object is fully constructed
+        /// </summary>
+        /// <param name="context">The context in which the instance was activated.</param>
+        /// <param name="instance">The instance.</param>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "This is the method that would raise the event.")]
+        void RaiseInjectProperties(IComponentContext context, object instance);
     }
 }

--- a/Core/Source/Autofac/Core/InjectPropertiesEventArgs.cs
+++ b/Core/Source/Autofac/Core/InjectPropertiesEventArgs.cs
@@ -1,0 +1,62 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2011 Autofac Contributors
+// http://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using Autofac.Util;
+
+namespace Autofac.Core
+{
+    /// <summary>
+    /// Fired when injecting properties for a new instance.
+    /// </summary>
+    public class InjectPropertiesEventArgs<T> : EventArgs
+    {
+        readonly IComponentContext _context;
+        readonly T _instance;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InjectPropertiesEventArgs{T}"/> class.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="instance">The instance.</param>
+        public InjectPropertiesEventArgs(IComponentContext context, T instance)
+        {
+            _context = Enforce.ArgumentNotNull(context, "context");
+            if ((object)instance == null) throw new ArgumentNullException("instance");
+            _instance = instance;
+        }
+
+        /// <summary>
+        /// The context in which the activation occurred.
+        /// </summary>
+        public IComponentContext Context { get { return _context; } }
+
+        /// <summary>
+        /// The instance that will be used to satisfy the request.
+        /// </summary>
+        public T Instance { get { return _instance; } }
+    }
+}

--- a/Core/Source/Autofac/Core/Registration/ComponentRegistration.cs
+++ b/Core/Source/Autofac/Core/Registration/ComponentRegistration.cs
@@ -205,6 +205,25 @@ namespace Autofac.Core.Registration
         }
 
         /// <summary>
+        /// Fired when the activation process is injecting properties when a new instance is created
+        /// </summary>
+        public event EventHandler<InjectPropertiesEventArgs<object>> InjectProperties;
+
+        /// <summary>
+        /// Called by the container to inject properties when the object is fully constructed
+        /// </summary>
+        /// <param name="context">The context in which the instance was activated.</param>
+        /// <param name="instance">The instance.</param>
+        public void RaiseInjectProperties(IComponentContext context, object instance)
+        {
+            var handler = InjectProperties;
+            if (handler == null) return;
+
+            var args = new InjectPropertiesEventArgs<object>(context, instance);
+            handler(this, args);
+        }
+
+        /// <summary>
         /// Describes the component in a human-readable form.
         /// </summary>
         /// <returns>A description of the component.</returns>

--- a/Core/Source/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
+++ b/Core/Source/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
@@ -99,5 +99,16 @@ namespace Autofac.Core.Registration
         {
             _inner.RaiseActivated(context, parameters, instance);
         }
+
+        public event EventHandler<InjectPropertiesEventArgs<object>> InjectProperties
+        {
+            add { _inner.InjectProperties += value; }
+            remove { _inner.InjectProperties -= value; }
+        }
+
+        public void RaiseInjectProperties(IComponentContext context, object instance)
+        {
+            _inner.RaiseInjectProperties(context, instance);
+        }
     }
 }

--- a/Core/Source/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/Core/Source/Autofac/Core/Resolving/InstanceLookup.cs
@@ -94,6 +94,13 @@ namespace Autofac.Core.Resolving
             return _newInstance;
         }
 
+        public void InjectProperties()
+        {
+            if (!NewInstanceActivated)
+                return;
+            _componentRegistration.RaiseInjectProperties(this, _newInstance);
+        }
+
         public void Complete()
         {
             if (!NewInstanceActivated) return;

--- a/Core/Source/Autofac/PropertyWiringOptions.cs
+++ b/Core/Source/Autofac/PropertyWiringOptions.cs
@@ -35,14 +35,14 @@ namespace Autofac
     public enum PropertyWiringOptions
     {
         /// <summary>
-        /// Default behavior. Circular dependencies are not allowed; existing non-default
-        /// property values are overwritten.
+        /// Default behavior. Circular dependencies are only allowed with property-property dependency
+        /// wiring; existing non-default property values are overwritten.
         /// </summary>
         None = 0,
 
         /// <summary>
         /// Allows property-property and property-constructor circular dependency wiring.
-        /// This flag moves property wiring from the Activating to the Activated event.
+        /// This flag moves property wiring from the InjectProperties to the Activated event.
         /// </summary>
         AllowCircularDependencies = 1,
 

--- a/Core/Tests/Autofac.Tests/Autofac.Tests.csproj
+++ b/Core/Tests/Autofac.Tests/Autofac.Tests.csproj
@@ -17,10 +17,14 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <SccProjectName>&lt;Project Location In Database&gt;</SccProjectName>
-    <SccLocalPath>&lt;Local Binding Root of Project&gt;</SccLocalPath>
-    <SccAuxPath>&lt;Source Control Database&gt;</SccAuxPath>
-    <SccProvider>Mercurial Source Control Package</SccProvider>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Core/Tests/Autofac.Tests/Core/Resolving/CircularDependencyDetectorTests.cs
+++ b/Core/Tests/Autofac.Tests/Core/Resolving/CircularDependencyDetectorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Autofac.Tests.Scenarios.Dependencies;
 using NUnit.Framework;
 using Autofac.Core.Resolving;
 using Autofac.Core;
@@ -17,16 +18,16 @@ namespace Autofac.Tests.Core.Resolving
             try
             {
                 var builder = new ContainerBuilder();
-                builder.Register(c => c.Resolve<object>());
+                builder.RegisterType<DependsByCtor>().SingleInstance();
+                builder.RegisterType<DependsByProp>().SingleInstance().PropertiesAutowired();
 
                 var target = builder.Build();
-                target.Resolve<object>();
+                target.Resolve<DependsByCtor>();
             }
             catch (DependencyResolutionException de)
             {
                 Assert.IsNull(de.InnerException);
-                Assert.IsTrue(de.Message.Contains("System.Object -> System.Object"));
-                Assert.IsFalse(de.Message.Contains("System.Object -> System.Object -> System.Object"));
+                Assert.IsTrue(de.Message.Contains("Autofac.Tests.Scenarios.Dependencies.DependsByCtor -> Autofac.Tests.Scenarios.Dependencies.DependsByCtor"));
                 return;
             }
             catch (Exception ex)


### PR DESCRIPTION
Better circular dependency handling so property injection ALWAYS works with circular dependencies and property injected classes are always properly injected prior to being passed to the constructor of a constructor injection. Hence you can have classes that use constructor injection that can use any instances with circular dependencies passed to them as long as they are using property injection.