### PR TITLE
- Fix resolving generic class

### DIFF
--- a/Core/Source/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/Core/Source/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -124,7 +124,7 @@ namespace Autofac.Features.OpenGenerics
                 .Where(argdef => argdef.Key.IsGenericType && argdef.Value.GetGenericArguments().Length > 0)
                 .Select(argdef => TryFindServiceArgumentForImplementationArgumentDefinition(
                     implementationGenericArgumentDefinition, argdef.Key.GetGenericArguments().Zip(argdef.Value.GetGenericArguments(), (a, b) => new KeyValuePair<Type, Type>(a, b))))
-                .FirstOrDefault();
+                .FirstOrDefault(x => x != null);
         }
 
         public static void EnforceBindable(Type implementationType, IEnumerable<Service> services)

--- a/Core/Tests/Autofac.Tests/Features/OpenGenerics/ComplexGenericsTests.cs
+++ b/Core/Tests/Autofac.Tests/Features/OpenGenerics/ComplexGenericsTests.cs
@@ -12,6 +12,8 @@ namespace Autofac.Tests.Features.OpenGenerics
         public class CReversed<T2, T1> : IDouble<T1, T2> { }
 
         public interface INested<T> { }
+
+        public interface INested<T, D> { }
         public class Wrapper<T> { }
         public class CNested<T> : INested<Wrapper<T>> { }
 
@@ -19,6 +21,8 @@ namespace Autofac.Tests.Features.OpenGenerics
 
         public class CNestedDerivedReversed<TX, TY> : IDouble<TY, INested<Wrapper<TX>>> { }
         public class SameTypes<TA, TB> : IDouble<TA, INested<IDouble<TB, TA>>> { }
+
+        public class SameTypes<TA, TB, TC> : IDouble<INested<TA>, INested<IDouble<TB, TC>>> { }
         // ReSharper restore UnusedTypeParameter, InconsistentNaming
 
         [Test]
@@ -85,6 +89,17 @@ namespace Autofac.Tests.Features.OpenGenerics
 
             var compl = container.Resolve<IDouble<int, INested<Wrapper<string>>>>();
             Assert.IsInstanceOf<CReversed<INested<Wrapper<string>>, int>>(compl);
+        }
+
+        [Test]
+        public void TheSameaceholderWithThreeGenericParametersTypeCanAppearMultipleTimesInTheService()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterGeneric(typeof(SameTypes<,,>)).As(typeof(SameTypes<,,>).GetInterfaces());
+            var container = cb.Build();
+
+            var compl = container.Resolve<IDouble<INested<string>, INested<IDouble<int, long>>>>();
+            Assert.IsInstanceOf<SameTypes<string, int, long>>(compl);
         }
 
         [Test]


### PR DESCRIPTION
If you run `TheSameaceholderWithThreeGenericParametersTypeCanAppearMultipleTimesInTheService` test, it will call  `OpenGenericServiceBinder` class  by `TryFindServiceArgumentForImplementationArgumentDefinition` method and use `FirstOrDefault()`, then test will throw exception : 

```
The requested service 'Autofac.Tests.Features.OpenGenerics.ComplexGenericsTests+IDouble`2[[Autofac.Tests.Features.OpenGenerics.ComplexGenericsTests+INested`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], Autofac.Tests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da],
[Autofac.Tests.Features.OpenGenerics.ComplexGenericsTests+INested`1[[Autofac.Tests.Features.OpenGenerics.ComplexGenericsTests+IDouble`2[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], Autofac.Tests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da]], Autofac.Tests, Version=3.0.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da]]' has not been registered. 
To avoid this exception, either register a component to provide the service, check for service registration using IsRegistered(), or use the ResolveOptional() method to resolve an optional dependency.
```

StackTrace:

```
   at Autofac.ResolutionExtensions.ResolveService(IComponentContext context, Service service, IEnumerable`1 parameters) 
   at Autofac.ResolutionExtensions.Resolve(IComponentContext context, Type serviceType, IEnumerable`1 parameters) 
   at Autofac.ResolutionExtensions.Resolve[TService](IComponentContext context, IEnumerable`1 parameters)
   at Autofac.ResolutionExtensions.Resolve[TService](IComponentContext context)
   at Autofac.Tests.Features.OpenGenerics.ComplexGenericsTests.TheSameaceholderWithThreeGenericParametersTypeCanAppearMultipleTimesInTheService()
```

But if you change `FirstOrDefault()` to `FirstOrDefault(x => x != null)`, then test will pass successful.
In the `TryFindServiceArgumentForImplementationArgumentDefinition` method in the `OpenGenericServiceBinder` class next code returns not empty collection with one not null element, but if not null element is not first in the collection, then this code returns null:

```
return serviceArgumentDefinitionToArgument
                .Where(argdef => argdef.Key.IsGenericType && argdef.Value.GetGenericArguments().Length > 0)
                .Select(argdef => TryFindServiceArgumentForImplementationArgumentDefinition(
                    implementationGenericArgumentDefinition, argdef.Key.GetGenericArguments().Zip(argdef.Value.GetGenericArguments(), (a, b) => new KeyValuePair<Type, Type>(a, b))))
                .FirstOrDefault();
```
