### PR TITLE
Bug in CircularDependency tracking

### DIFF
--- a/Core/Source/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/Core/Source/Autofac/Core/Resolving/ResolveOperation.cs
@@ -106,9 +106,9 @@ namespace Autofac.Core.Resolving
         {
             if (_ended) throw new ObjectDisposedException(ResolveOperationResources.TemporaryContextDisposed, innerException: null);
 
-            CircularDependencyDetector.CheckForCircularDependency(registration, _activationStack, ++_callDepth);
-
             var activation = new InstanceLookup(registration, this, currentOperationScope, parameters);
+            
+            CircularDependencyDetector.CheckForCircularDependency(registration, _activationStack, ++_callDepth);
 
             _activationStack.Push(activation);
 


### PR DESCRIPTION
Error in InstanceLookup constructor may result in Exception when attempting to find scope, such an exception cause inconsistent _callDepth value. 
This can cause a CircularDependency exception by reaching the threshold of the max depth.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/autofac/autofac/579)
<!-- Reviewable:end -->
