### PR TITLE
Preserve correct order of service registrations in the nested component registry

### DIFF
--- a/Core/Source/Autofac/Core/IComponentRegistry.cs
+++ b/Core/Source/Autofac/Core/IComponentRegistry.cs
@@ -73,7 +73,10 @@ namespace Autofac.Core
         /// have been invoked.
         /// </summary>
         /// <param name="service">The service for which registrations are sought.</param>
-        /// <returns>Registrations supporting <paramref name="service"/>.</returns>
+        /// <returns>
+        ///  Registrations supporting <paramref name="service"/>.
+        ///  Default registration for the service must be first in the returned sequence.
+        /// </returns>
         IEnumerable<IComponentRegistration> RegistrationsFor(Service service);
 
         /// <summary>

--- a/Core/Source/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/Core/Source/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -194,13 +194,18 @@ namespace Autofac.Core.Lifetime
                 .Where(src => src.IsAdapterForIndividualComponents))
                 builder.RegisterSource(source);
 
-            var parents = Traverse.Across<ISharingLifetimeScope>(this, s => s.ParentLifetimeScope)
+
+            // Issue #272: Only the most nested parent registry with HasLocalComponents is registered as an external source
+            // It provides all non-adapting registrations from itself and from it's parent registries
+            var parent = Traverse.Across<ISharingLifetimeScope>(this, s => s.ParentLifetimeScope)
                 .Where(s => s.ComponentRegistry.HasLocalComponents)
                 .Select(s => new ExternalRegistrySource(s.ComponentRegistry))
-                .Reverse();
+                .FirstOrDefault();
 
-            foreach (var external in parents)
-                builder.RegisterSource(external);
+            if (parent != null)
+            {
+                builder.RegisterSource(parent);
+            }
 
             configurationAction(builder);
 

--- a/Core/Source/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/Core/Source/Autofac/Core/Registration/ComponentRegistry.cs
@@ -151,17 +151,18 @@ namespace Autofac.Core.Registration
                 registration,
                 adapterServices);
 
+            // adapter registrations come from sources, so they are added with originatedFromSource: true
             var adapters = adaptationSandbox.GetAdapters();
             foreach (var adapter in adapters)
-                AddRegistration(adapter, true);
+                AddRegistration(adapter, preserveDefaults: true, originatedFromSource: true);
         }
 
-        void AddRegistration(IComponentRegistration registration, bool preserveDefaults)
+        void AddRegistration(IComponentRegistration registration, bool preserveDefaults, bool originatedFromSource = false)
         {
             foreach (var service in registration.Services)
             {
                 var info = GetServiceInfo(service);
-                info.AddImplementation(registration, preserveDefaults);
+                info.AddImplementation(registration, preserveDefaults, originatedFromSource);
             }
 
             _registrations.Add(registration);
@@ -283,7 +284,7 @@ namespace Autofac.Core.Registration
                             additionalInfo.SkipSource(next);
                     }
 
-                    AddRegistration(provided, true);
+                    AddRegistration(provided, preserveDefaults: true, originatedFromSource: true);
                 }
             }
 

--- a/Core/Source/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/Core/Source/Autofac/Core/Registration/ComponentRegistry.cs
@@ -275,7 +275,7 @@ namespace Autofac.Core.Registration
                     foreach (var additionalService in provided.Services)
                     {
                         var additionalInfo = GetServiceInfo(additionalService);
-                        if (additionalInfo.IsInitialized) continue;
+                        if (additionalInfo.IsInitialized || additionalInfo == info) continue;
 
                         if (!additionalInfo.IsInitializing)
                             additionalInfo.BeginInitialization(_dynamicRegistrationSources.Where(src => src != next));

--- a/Core/Source/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/Core/Source/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -15,7 +15,23 @@ namespace Autofac.Core.Registration
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification="The _service field is useful in debugging and diagnostics.")]
         readonly Service _service;
 
-        readonly LinkedList<IComponentRegistration> _implementations = new LinkedList<IComponentRegistration>();
+        /// <summary>
+        ///  List of explicit default service implementations. Overriding default implementations are appended to the end, 
+        ///  so the enumeration should begin from the end too and the most default implementation is coming last.
+        /// </summary>
+        readonly List<IComponentRegistration> _defaultImplementations = new List<IComponentRegistration>();
+
+        /// <summary>
+        ///  List of service implementations coming from sources. Sources have priority over preserve-default implementations.
+        ///  Implementations from sources are enumerated in preserve-default order, so the most default implementation is coming first.
+        /// </summary>
+        readonly List<IComponentRegistration> _sourceImplementations = new List<IComponentRegistration>(); 
+
+        /// <summary>
+        ///  List of explicit service implementations specified with PreserveExistingDefaults option.
+        ///  Enumerated in preserve-defaults order, so the most default implementation is coming first.
+        /// </summary>
+        readonly List<IComponentRegistration> _preserveDefaultImplementations = new List<IComponentRegistration>();
 
         /// <summary>
         /// Used for bookkeeping so that the same source is not queried twice (may be null.)
@@ -39,14 +55,14 @@ namespace Autofac.Core.Registration
         public bool IsInitialized { get; private set; }
 
         /// <summary>
-        /// The known implementations.
+        /// The known implementations. The first implementation is a default one.
         /// </summary>
         public IEnumerable<IComponentRegistration> Implementations
         {
             get
             {
                 RequiresInitialization();
-                return _implementations;
+                return Enumerable.Reverse(_defaultImplementations).Concat(_sourceImplementations).Concat(_preserveDefaultImplementations);
             }
         }
 
@@ -68,23 +84,50 @@ namespace Autofac.Core.Registration
             }
         }
 
-        bool Any { get { return _implementations.First != null; } }
+        bool Any
+        {
+            get
+            {
+                return _defaultImplementations.Any() || 
+                       _sourceImplementations.Any() ||
+                       _preserveDefaultImplementations.Any();
+            }
+        }
 
-        public void AddImplementation(IComponentRegistration registration, bool preserveDefaults)
+        IComponentRegistration DefaultImplementation
+        {
+            get
+            {
+                return _defaultImplementations.LastOrDefault() ??
+                       _sourceImplementations.FirstOrDefault() ??
+                       _preserveDefaultImplementations.FirstOrDefault();
+            }
+        }
+
+        public void AddImplementation(IComponentRegistration registration, bool preserveDefaults, bool originatedFromSource)
         {
             if (preserveDefaults)
             {
-                _implementations.AddLast(registration);
+                if (originatedFromSource)
+                    _sourceImplementations.Add(registration);
+                else
+                    _preserveDefaultImplementations.Add(registration);
             }
             else
             {
-                if (Any)
+                if (originatedFromSource)
+                    throw new ArgumentOutOfRangeException("originatedFromSource");
+
+#if DEBUG
+                // Is this debug block still required?
+                var defaultImplementation = DefaultImplementation;
+                if (defaultImplementation != null)
                     Debug.WriteLine(String.Format(
                         CultureInfo.InvariantCulture,
                         "[Autofac] Overriding default for: '{0}' with: '{1}' (was '{2}')",
-                        _service, registration, _implementations.First.Value));
-
-                _implementations.AddFirst(registration);
+                        _service, registration, defaultImplementation));
+#endif
+                _defaultImplementations.Add(registration);
             }
         }
 
@@ -92,15 +135,11 @@ namespace Autofac.Core.Registration
         {
             RequiresInitialization();
 
-            if (Any)
-            {
-                registration = _implementations.First.Value;
-                return true;
-            }
-
-            registration = null;
-            return false;
+            registration = DefaultImplementation;
+            return registration != null;
         }
+
+
 
         public void Include(IRegistrationSource source)
         {

--- a/Core/Tests/Autofac.Tests/Core/Lifetime/LifetimeScopeTests.cs
+++ b/Core/Tests/Autofac.Tests/Core/Lifetime/LifetimeScopeTests.cs
@@ -105,7 +105,6 @@ namespace Autofac.Tests.Core.Lifetime
         }
 
         [Test]
-        [Ignore("Issue #272")]
         public void LocalRegistrationCanPreserveParentAsDefault()
         {
             var o = new object();

--- a/Core/Tests/Autofac.Tests/Core/PreserveExistingDefaultsTests.cs
+++ b/Core/Tests/Autofac.Tests/Core/PreserveExistingDefaultsTests.cs
@@ -93,7 +93,6 @@ namespace Autofac.Tests.Core
         }
 
         [Test]
-        [Ignore("Issue #272")]
         public void NestedScope_ComplexConsumerServicesResolve()
         {
             // This is an all-around "integration test" with property injection,
@@ -136,7 +135,6 @@ namespace Autofac.Tests.Core
         }
 
         [Test]
-        [Ignore("Issue #272")]
         public void NestedScope_PreserveDefaultsCanFallBackToNestedParent()
         {
             var builder = new ContainerBuilder();
@@ -149,7 +147,6 @@ namespace Autofac.Tests.Core
         }
 
         [Test]
-        [Ignore("Issue #272")]
         public void NestedScope_PreserveDefaultsCanFallBackToParent()
         {
             var builder = new ContainerBuilder();
@@ -160,7 +157,6 @@ namespace Autofac.Tests.Core
         }
 
         [Test]
-        [Ignore("Issue #272")]
         public void NestedScope_PreserveDefaultsCanFallBackToParentThroughMultipleNesting()
         {
             var builder = new ContainerBuilder();

--- a/Core/Tests/Autofac.Tests/Core/PreserveExistingDefaultsTests.cs
+++ b/Core/Tests/Autofac.Tests/Core/PreserveExistingDefaultsTests.cs
@@ -200,6 +200,23 @@ namespace Autofac.Tests.Core
             Assert.IsTrue(resolved.Any(s => s == "s4"), "The fourth service wasn't present.");
         }
 
+        [Test]
+        [Ignore("Issue #272")]
+        public void NestedScope_PreserveSameOrderOfAdaptedRegistrations()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterInstance("s1").PreserveExistingDefaults();
+            builder.RegisterAdapter((object from) => "s2_adapted");
+            builder.RegisterInstance(new object());
+            var container = builder.Build();
+            var rootDefault = container.Resolve<string>();
+
+            var scope = container.BeginLifetimeScope(b => { }); // create nested registry
+            var nestedDefault = scope.Resolve<string>();
+
+            Assert.That(nestedDefault, Is.SameAs(rootDefault), "Nested scope should return same default as parent, if there were no overrides");
+        }
+
         private class ComplexConsumer
         {
             public int Number { get; private set; }


### PR DESCRIPTION
This pull request provides the solution for issue #272.

**Requirements**
The key to resolve this issue is to ensure the correct order of the service implementations in `ServiceRegistrationInfo` class, since the first one of them is treated as default one.
To figure out which order is correct I was using the following assumptions:
- *default* registration always override all registrations made before, including those from parent scope
- *preserve-default* registration is always overridden by registrations made before. It's used as default only if there are no registrations made before.

So the correct order is one where in the beginning there are default explicit registrations made in nested scope, then registrations coming from sources, such as parent registry, and then in the end explicit preserve-default registrations.
These implementations in the middle from the parent registries must also be in the correct order, so that in case if the nested scope doesn't override the default implementation, the default one must be same as in the parent registry. The latter requirement was hard to implement due to the way parent registries were queried for registrations. 
A parent registry is added as the `ExternalRegistrySource` to the nested one. The source takes all non-adapting registrations from the registry and wraps them to coerce some of their properties. But this means that on the next level of hierarchy these wrapped registrations are excluded as adapting-ones when being queried by `ExternalRegistrySource` (probably, to prevent double wrapping). Therefore to get the all service implementations you have to traverse up the whole hierarchy and query every parent source for registrations. It becomes very hard to reconstruct the correct order of implementations when adding each provided implementation one by one.

**Changes**
So I've decided to change the way `ExternalRegistrySource` works. Now it doesn't exclude implementations wrapped by the parent registry. To distinguish these wrapped implementation from the adapting ones I've subtyped `ComponentRegistration` class. This also prevents double registration wrapping, 'cause such subtyped `ExternalComponentRegistartion` class can be shared between all the nested registries down to hierarchy.

**Questions**
One thing left unclear to me is the relation between *preserve-defaults* registrations and the registrations originated from sources. There are two mutually exclusive options:
1. Preserve-default registrations are always superseded by the other registrations, even those from sources.
2. The sources are consulted for registration only if there is no any explicit registration made to the registry, including preserve-default one. This means preserve-default registration takes precedence over that which was originated from registration source.
Can someone provide the answer (would be better if it's backed up with the reference to some existing docs)?

In the latter case we'll need to distinguish somehow `ExternalRegistrySource` from the other source types when initializing `ServiceRegistrationInfo`.

**TODOs**
I've introduced a new requirement for `IComponentRegistry.RegistrationsFor` method implementation. It must return the sequence, starting with the default implementation of the service. This requirement was fulfilled de-facto, but I think some new unit tests or assertions in existing tests should be made to ensure the default implementation (`ComponentRegistry`) behavior is correct.