### PR TITLE
Resolved localization failure reported in issue #597

### DIFF
--- a/Core/Tests/Autofac.Tests/Core/DependencyResolutionExceptionTests.cs
+++ b/Core/Tests/Autofac.Tests/Core/DependencyResolutionExceptionTests.cs
@@ -1,15 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Autofac.Core;
+﻿using Autofac.Core;
 using NUnit.Framework;
+using System.IO;
 
 namespace Autofac.Tests.Core
 {
     [TestFixture]
     public class DependencyResolutionExceptionTests
     {
+        [SetUp]
+        public void SetUp()
+        {
+            //Explicitly set culture for comparison of Exception strings
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+            System.Threading.Thread.CurrentThread.CurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+        }
+
         [Test(Description = "Issue 343: The inner exception message should be included in the main exception message.")]
         public void Message_InnerExceptionMessageIncluded()
         {


### PR DESCRIPTION
<b>Introduction:</b>
I'm trying to start contributing to Autofac and grabed the simplest issue first to get everything setup on my machine. So please feel free to suggest anything I maybe do the wrong way.

<b>Fixed Issue:</b>
As reported in the original issue #597 a single unit test fails executing on a machine with different localization than English. I implemented and tested the code provided by @MircoBabin. As a result all of the non-ignored unit tests run successfully on a localized machine.