### PR TITLE
Add delegate to filter which properties are injected

### DIFF
--- a/Core/Source/Autofac/Builder/RegistrationBuilderOfTLAR.cs
+++ b/Core/Source/Autofac/Builder/RegistrationBuilderOfTLAR.cs
@@ -371,9 +371,9 @@ namespace Autofac.Builder
             var preserveSetValues = 0 != (int)(wiringFlags & PropertyWiringOptions.PreserveSetValues);
 
             if (allowCircularDependencies)
-                RegistrationData.ActivatedHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
+                RegistrationData.ActivatedHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues, null));
             else
-                RegistrationData.ActivatingHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
+                RegistrationData.ActivatingHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues, null));
 
             return this;
         }

--- a/Core/Source/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/Core/Source/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -32,7 +32,7 @@ namespace Autofac.Core.Activators.Reflection
 {
     class AutowiringPropertyInjector
     {
-        public static void InjectProperties(IComponentContext context, object instance, bool overrideSetValues)
+        public static void InjectProperties(IComponentContext context, object instance, bool overrideSetValues, Func<PropertyInfo, bool> customPropertyFilter)
         {
             if (context == null) throw new ArgumentNullException("context");
             if (instance == null) throw new ArgumentNullException("instance");
@@ -69,9 +69,19 @@ namespace Autofac.Core.Activators.Reflection
                     (property.GetValue(instance, null) != null))
                     continue;
 
+                var propertyFilter = customPropertyFilter ?? DefaultPropertyFilter;
+
+                if (!propertyFilter(property))
+                    continue;
+
                 var propertyValue = context.Resolve(propertyType);
                 property.SetValue(instance, propertyValue, null);
             }
+        }
+
+        private static bool DefaultPropertyFilter(PropertyInfo propertyInfo)
+        {
+            return true;
         }
     }
 }

--- a/Core/Source/Autofac/ResolutionExtensions.cs
+++ b/Core/Source/Autofac/ResolutionExtensions.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Core.Registration;
@@ -50,7 +51,23 @@ namespace Autofac
         /// <returns><paramref name="instance"/>.</returns>
         public static TService InjectProperties<TService>(this IComponentContext context, TService instance)
         {
-            AutowiringPropertyInjector.InjectProperties(context, instance, true);
+            AutowiringPropertyInjector.InjectProperties(context, instance, true, null);
+            return instance;
+        }
+
+
+        /// <summary>
+        /// Set any properties on <paramref name="instance"/> that can be
+        /// resolved in the context.
+        /// </summary>
+        /// <typeparam name="TService">Type of instance. Used only to provide method chaining.</typeparam>
+        /// <param name="context">The context from which to resolve the service.</param>
+        /// <param name="instance">The instance to inject properties into.</param>
+        /// <param name="propertyFilter">Delegate to filter which properties will be injected.</param>
+        /// <returns><paramref name="instance"/>.</returns>
+        public static TService InjectProperties<TService>(this IComponentContext context, TService instance, Func<PropertyInfo, bool> propertyFilter)
+        {
+            AutowiringPropertyInjector.InjectProperties(context, instance, true, propertyFilter);
             return instance;
         }
 
@@ -64,7 +81,22 @@ namespace Autofac
         /// <returns><paramref name="instance"/>.</returns>
         public static TService InjectUnsetProperties<TService>(this IComponentContext context, TService instance)
         {
-            AutowiringPropertyInjector.InjectProperties(context, instance, false);
+            AutowiringPropertyInjector.InjectProperties(context, instance, false, null);
+            return instance;
+        }
+
+        /// <summary>
+        /// Set any null-valued properties on <paramref name="instance"/> that can be
+        /// resolved by the container.
+        /// </summary>
+        /// <typeparam name="TService">Type of instance. Used only to provide method chaining.</typeparam>
+        /// <param name="context">The context from which to resolve the service.</param>
+        /// <param name="instance">The instance to inject properties into.</param>
+        /// <param name="propertyFilter">Delegate to filter which properties will be injected.</param>
+        /// <returns><paramref name="instance"/>.</returns>
+        public static TService InjectUnsetProperties<TService>(this IComponentContext context, TService instance, Func<PropertyInfo, bool> propertyFilter)
+        {
+            AutowiringPropertyInjector.InjectProperties(context, instance, false, propertyFilter);
             return instance;
         }
 

--- a/Core/Tests/Autofac.Tests/ResolutionExtensionsTests.cs
+++ b/Core/Tests/Autofac.Tests/ResolutionExtensionsTests.cs
@@ -76,7 +76,7 @@ namespace Autofac.Tests
             const string a = "Hello";
             const int b = 42;
             var builder = new ContainerBuilder();
-            
+
             builder.RegisterType<Parameterised>()
                 .WithParameter(
                     (pi, c) => pi.Name == "a",
@@ -89,7 +89,87 @@ namespace Autofac.Tests
             var result = container.Resolve<Parameterised>();
 
             Assert.AreEqual(a, result.A);
-            Assert.AreEqual(b, result.B);            
+            Assert.AreEqual(b, result.B);
+        }
+
+        [Test]
+        public void PropertiesInject()
+        {
+            const string a = "Hello";
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterInstance(a).AsSelf();
+
+            var container = builder.Build();
+            var @class = new ClassWithProperties();
+
+            container.InjectProperties(@class);
+
+            Assert.AreEqual(a, @class.TestStringA);
+        }
+
+        [Test]
+        public void PropertiesInjectWithFilter()
+        {
+            const string a = "Hello";
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterInstance(a).AsSelf();
+
+            var container = builder.Build();
+            var @class = new ClassWithProperties();
+
+            container.InjectProperties(@class, o => false);
+
+            Assert.IsNull(@class.TestStringA);
+        }
+
+        [Test]
+        public void PropertiesInjectUnset()
+        {
+            const string a = "HelloA";
+            const string b = "HelloB";
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterInstance(a).AsSelf();
+
+            var container = builder.Build();
+            var @class = new ClassWithProperties();
+
+            @class.TestStringB = b;
+            container.InjectUnsetProperties(@class);
+
+            Assert.AreEqual(a, @class.TestStringA);
+            Assert.AreEqual(b, @class.TestStringB);
+        }
+
+        [Test]
+        public void PropertiesInjectUnsetWithFilter()
+        {
+            const string a = "HelloA";
+            const string b = "HelloB";
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterInstance(a).AsSelf();
+
+            var container = builder.Build();
+            var @class = new ClassWithProperties();
+
+            @class.TestStringB = b;
+            container.InjectUnsetProperties(@class, o => false);
+
+            Assert.IsNull(@class.TestStringA);
+            Assert.AreEqual(b, @class.TestStringB);
+        }
+
+        private class ClassWithProperties
+        {
+            public string TestStringA { get; set; }
+            public string TestStringB { get; set; }
         }
     }
 }


### PR DESCRIPTION
This adds an overload to ResolutionExtensions.InjectProperties that takes in a delegate that allows custom filtering of properties that will be injected beyond if they are just set or not.

This resolves the issue described in #620 