### PR TITLE
Fixed KeyNotFoundException in AggregateService resolving open generic via a method call

### DIFF
--- a/Extras/Tests/Autofac.Extras.Tests.AggregateService/AggregateServiceGenericsFixture.cs
+++ b/Extras/Tests/Autofac.Extras.Tests.AggregateService/AggregateServiceGenericsFixture.cs
@@ -1,0 +1,42 @@
+﻿using Autofac.Extras.AggregateService;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Autofac.Extras.Tests.AggregateService
+{
+    [TestFixture]
+    public class AggregateServiceGenericsFixture
+    {
+        private IContainer _container;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterAggregateService<IOpenGenericAggregate>();
+            builder.RegisterGeneric(typeof(OpenGenericImpl<>))
+                .As(typeof(IOpenGeneric<>));
+
+            this._container = builder.Build();
+        }
+
+        /// <summary>
+        /// Attempts to resolve an open generic by a method call
+        /// </summary>
+        [Test]
+        public void Method_ResolveOpenGeneric()
+        {
+            var aggregateService = this._container.Resolve<IOpenGenericAggregate>();
+
+            var generic = aggregateService.GetOpenGeneric<object>();
+            Assert.That(generic, Is.Not.Null);
+
+            var ungeneric = aggregateService.GetResolvedGeneric();
+            Assert.That(ungeneric, Is.Not.Null);
+            Assert.That(ungeneric, Is.Not.SameAs(generic));
+        }
+    }
+}

--- a/Extras/Tests/Autofac.Extras.Tests.AggregateService/Autofac.Extras.Tests.AggregateService.csproj
+++ b/Extras/Tests/Autofac.Extras.Tests.AggregateService/Autofac.Extras.Tests.AggregateService.csproj
@@ -81,10 +81,13 @@
     <Compile Include="..\..\Source\Autofac.Extras.AggregateService\Properties\VersionAssemblyInfo.cs">
       <Link>Properties\VersionAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="AggregateServiceGenericsFixture.cs" />
     <Compile Include="AggregateServiceInheritanceFixture.cs" />
     <Compile Include="ContainerBuilderExtensionsFixture.cs" />
     <Compile Include="AggregateServiceFixture.cs" />
     <Compile Include="AggregateServiceGeneratorFixture.cs" />
+    <Compile Include="IOpenGeneric.cs" />
+    <Compile Include="IOpenGenericAggregate.cs" />
     <Compile Include="ISomeOtherDependency.cs" />
     <Compile Include="ISubService.cs" />
     <Compile Include="IMyService.cs" />
@@ -92,6 +95,7 @@
     <Compile Include="ISuperService.cs" />
     <Compile Include="ISomeDependency.cs" />
     <Compile Include="MyServiceImpl.cs" />
+    <Compile Include="OpenGenericImpl.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Extras/Tests/Autofac.Extras.Tests.AggregateService/IOpenGeneric.cs
+++ b/Extras/Tests/Autofac.Extras.Tests.AggregateService/IOpenGeneric.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Autofac.Extras.Tests.AggregateService
+{
+    /// <summary>
+    /// A sample generic interface for open generic tests
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IOpenGeneric<T>
+    {
+    }
+}

--- a/Extras/Tests/Autofac.Extras.Tests.AggregateService/IOpenGenericAggregate.cs
+++ b/Extras/Tests/Autofac.Extras.Tests.AggregateService/IOpenGenericAggregate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Autofac.Extras.Tests.AggregateService
+{
+    public interface IOpenGenericAggregate
+    {
+        IOpenGeneric<T> GetOpenGeneric<T>();
+
+        IOpenGeneric<string> GetResolvedGeneric();
+    }
+}

--- a/Extras/Tests/Autofac.Extras.Tests.AggregateService/OpenGenericImpl.cs
+++ b/Extras/Tests/Autofac.Extras.Tests.AggregateService/OpenGenericImpl.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Autofac.Extras.Tests.AggregateService
+{
+    public class OpenGenericImpl<T> : IOpenGeneric<T>
+    {
+    }
+}


### PR DESCRIPTION
I was using an AggregateService the other day with a method that was generic with the intention of using it to resolve open generics on the fly. Calling this method resulted in a `KeyNotFoundException`.

```csharp
public interface IOpenGenericAggregate
{
	IOpenGeneric<T> GetOpenGeneric<T>();
}

public class OpenGeneric<T> : IOpenGeneric<T>
{
}
```

Test which fails:

```csharp
var builder = new ContainerBuilder();
builder.RegisterAggregateService<IOpenGenericAggregate>();
builder.RegisterGeneric(typeof(OpenGeneric<>))
	.As(typeof(IOpenGeneric<>));

var container = builder.Build();

var aggregateService = container.Resolve<IOpenGenericAggregate>();

var generic = aggregateService.GetOpenGeneric<object>(); //KeyNotFoundException here
Assert.That(generic, Is.Not.Null);
```

I made a couple changes to fix the issue. If this isn't an intended use of the AggregateService I'm ok with these not being included.

The problem was that the existing interceptor stored the generic method definition in the invocation map, but the filled-in generic method (is there a term for that? Closed generic?) was used in the lookup. My changes do the following:

 * If the invoked method is a generic method, the generic method definition is used in the invocation map lookup instead of directly using the invocation method. This prevents the `KeyNotFoundException`.
 * The `IInvocation.Method.ReturnType` is always used as the argument in the `Resolve()` call since the `returnType` found in the `SetupInvocationMap` method might not match the return type of the method when it is called. This handles the case when the method is called to resolve a concrete type based on an open generic.

All of the tests pass, including the new one I added for testing the resolution of open generics. If there are any issues with the changes I'm more than willing to fix them.

Thanks.