### PR TITLE
Provide a way to register property injection

### DIFF
--- a/src/Autofac/Builder/ConcreteReflectionActivatorData.cs
+++ b/src/Autofac/Builder/ConcreteReflectionActivatorData.cs
@@ -50,6 +50,7 @@ namespace Autofac.Builder
             ImplementationType,
             ConstructorFinder,
             ConstructorSelector,
+            PropertyFinder,
             ConfiguredParameters,
             ConfiguredProperties);
     }

--- a/src/Autofac/Builder/ReflectionActivatorData.cs
+++ b/src/Autofac/Builder/ReflectionActivatorData.cs
@@ -37,6 +37,7 @@ namespace Autofac.Builder
     {
         Type _implementer;
         IConstructorFinder _constructorFinder = new DefaultConstructorFinder();
+        IPropertyFinder _propertyFinder = new DefaultPropertyFinder();
         IConstructorSelector _constructorSelector = new MostParametersConstructorSelector();
 
         /// <summary>
@@ -87,6 +88,19 @@ namespace Autofac.Builder
             {
                 if (value == null) throw new ArgumentNullException(nameof(value));
                 _constructorSelector = value;
+            }
+        }
+
+        /// <summary>
+        /// The property selector for the registration
+        /// </summary>
+        public IPropertyFinder PropertyFinder
+        {
+            get { return _propertyFinder; }
+            set
+            {
+                if (value == null) throw new ArgumentNullException(nameof(value));
+                _propertyFinder = value;
             }
         }
 

--- a/src/Autofac/Core/Activators/Reflection/DefaultPropertyFinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/DefaultPropertyFinder.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Reflection;
+
+namespace Autofac.Core.Activators.Reflection
+{
+    public class DefaultPropertyFinder : IPropertyFinder
+    {
+        private static readonly PropertyInfo[] s_empty = new PropertyInfo[] { };
+
+        public PropertyInfo[] FindProperties(Type type)
+        {
+            return s_empty;
+        }
+    }
+}

--- a/src/Autofac/Core/Activators/Reflection/DelegatePropertyFinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/DelegatePropertyFinder.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Reflection;
+
+namespace Autofac.Core.Activators.Reflection
+{
+    public class DelegatePropertyFinder : IPropertyFinder
+    {
+        private readonly Func<Type, PropertyInfo[]> _finder;
+
+        public DelegatePropertyFinder(Func<Type, PropertyInfo[]> finder)
+        {
+            if (finder == null) throw new ArgumentNullException(nameof(finder));
+
+            _finder = finder; 
+        }
+
+        public PropertyInfo[] FindProperties(Type type)
+        {
+            return _finder(type);
+        }
+    }
+}

--- a/src/Autofac/Core/Activators/Reflection/IPropertyFinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/IPropertyFinder.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Reflection;
+
+namespace Autofac.Core.Activators.Reflection
+{
+    /// <summary>
+    /// Find suitable properties to inject
+    /// </summary>
+    public interface IPropertyFinder
+    {
+        /// <summary>
+        /// Determine which properties on a type should be injected
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        PropertyInfo[] FindProperties(Type type);
+    }
+}

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -55,18 +55,21 @@ namespace Autofac.Core.Activators.Reflection
             Type implementationType,
             IConstructorFinder constructorFinder,
             IConstructorSelector constructorSelector,
+            IPropertyFinder propertyFinder,
             IEnumerable<Parameter> configuredParameters,
             IEnumerable<Parameter> configuredProperties)
             : base(implementationType)
         {
             if (constructorFinder == null) throw new ArgumentNullException(nameof(constructorFinder));
             if (constructorSelector == null) throw new ArgumentNullException(nameof(constructorSelector));
+            if (propertyFinder == null) throw new ArgumentNullException(nameof(propertyFinder));
             if (configuredParameters == null) throw new ArgumentNullException(nameof(configuredParameters));
             if (configuredProperties == null) throw new ArgumentNullException(nameof(configuredProperties));
 
             _implementationType = implementationType;
             ConstructorFinder = constructorFinder;
             ConstructorSelector = constructorSelector;
+            PropertyFinder = propertyFinder;
             _configuredProperties = configuredProperties;
 
             _defaultParameters = configuredParameters.Concat(
@@ -82,6 +85,11 @@ namespace Autofac.Core.Activators.Reflection
         /// The constructor selector.
         /// </summary>
         public IConstructorSelector ConstructorSelector { get; }
+
+        /// <summary>
+        /// The property finder
+        /// </summary>
+        public IPropertyFinder PropertyFinder { get; }
 
         /// <summary>
         /// Activate an instance in the provided context.
@@ -153,6 +161,11 @@ namespace Autofac.Core.Activators.Reflection
 
         void InjectProperties(object instance, IComponentContext context, IEnumerable<Parameter> parameters)
         {
+            foreach (var property in PropertyFinder.FindProperties(instance.GetType()))
+            {
+                property.SetValue(instance, context.Resolve(property.PropertyType));
+            }
+
             if (!_configuredProperties.Any() && !parameters.Any())
                 return;
 

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -75,6 +75,7 @@ namespace Autofac.Features.OpenGenerics
                                 constructedImplementationType,
                                 _activatorData.ConstructorFinder,
                                 _activatorData.ConstructorSelector,
+                                _activatorData.PropertyFinder,
                                 AddDecoratedComponentParameter(swt.ServiceType, cr, _activatorData.ConfiguredParameters),
                                 _activatorData.ConfiguredProperties),
                             services));

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
@@ -70,6 +70,7 @@ namespace Autofac.Features.OpenGenerics
                         constructedImplementationType,
                         _activatorData.ConstructorFinder,
                         _activatorData.ConstructorSelector,
+                        _activatorData.PropertyFinder,
                         _activatorData.ConfiguredParameters,
                         _activatorData.ConfiguredProperties),
                     services);

--- a/test/Autofac.Test/Core/Activators/Reflection/DefaultPropertyFinderTests.cs
+++ b/test/Autofac.Test/Core/Activators/Reflection/DefaultPropertyFinderTests.cs
@@ -1,0 +1,26 @@
+﻿using Autofac.Core.Activators.Reflection;
+using Xunit;
+
+namespace Autofac.Test.Core.Activators.Reflection
+{
+    public class DefaultPropertyFinderTests
+    {
+        private class HasProperties
+        {
+            public int PublicProperty { get; set; }
+            public int PropNoSetter { get; }
+            private int PrivateProperty { get; set; }
+        }
+
+        [Fact]
+        public void DoesNotFindPropertiesByDefault()
+        {
+            var finder = new DefaultPropertyFinder();
+            var targetType = typeof(HasProperties);
+
+            var properties = finder.FindProperties(targetType);
+
+            Assert.Empty(properties);
+        }
+    }
+}

--- a/test/Autofac.Test/Core/Activators/Reflection/DelegatePropertyFinderTests.cs
+++ b/test/Autofac.Test/Core/Activators/Reflection/DelegatePropertyFinderTests.cs
@@ -1,0 +1,47 @@
+﻿using Autofac.Core.Activators.Reflection;
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Autofac.Test.Core.Activators.Reflection
+{
+    public class DelegatePropertyFinderTests
+    {
+        private class InjectPropertyAttribute : Attribute { }
+
+        private class HasProperties
+        {
+            [InjectProperty]
+            public int PublicProperty { get; set; }
+            public int PropNoSetter { get; }
+            private int PrivateProperty { get; set; }
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnNull()
+        {
+            Assert.Throws<ArgumentNullException>("finder", () => new DelegatePropertyFinder(null));
+        }
+
+        [Fact]
+        public void UsesDelegatePassedIn()
+        {
+            var finder = new DelegatePropertyFinder(type =>
+            {
+                return type.GetTypeInfo().DeclaredProperties
+                    .Where(prop => prop.GetCustomAttributes<InjectPropertyAttribute>().Any())
+                    .ToArray();
+            });
+
+            var targetType = typeof(HasProperties);
+
+            var properties = finder.FindProperties(targetType);
+
+            Assert.Equal(1, properties.Length);
+
+            var propertyNames = properties.Select(p => p.Name);
+            Assert.Equal(new[] { "PublicProperty" }, propertyNames);
+        }
+    }
+}

--- a/test/Autofac.Test/Core/Activators/Reflection/ReflectionActivatorTests.cs
+++ b/test/Autofac.Test/Core/Activators/Reflection/ReflectionActivatorTests.cs
@@ -18,6 +18,7 @@ namespace Autofac.Test.Core.Activators.Reflection
                 new ReflectionActivator(null,
                     Mocks.GetConstructorFinder(),
                     Mocks.GetConstructorSelector(),
+                    Mocks.GetPropertyFinder(),
                     Factory.NoParameters,
                     Factory.NoProperties);
             });
@@ -31,6 +32,7 @@ namespace Autofac.Test.Core.Activators.Reflection
                 new ReflectionActivator(typeof(object),
                     Mocks.GetConstructorFinder(),
                     Mocks.GetConstructorSelector(),
+                    Mocks.GetPropertyFinder(),
                     null,
                     Factory.NoProperties);
             });
@@ -44,6 +46,7 @@ namespace Autofac.Test.Core.Activators.Reflection
                 new ReflectionActivator(typeof(object),
                     Mocks.GetConstructorFinder(),
                     Mocks.GetConstructorSelector(),
+                    Mocks.GetPropertyFinder(),
                     Factory.NoParameters,
                     null);
             });
@@ -57,6 +60,7 @@ namespace Autofac.Test.Core.Activators.Reflection
                 new ReflectionActivator(typeof(object),
                     null,
                     Mocks.GetConstructorSelector(),
+                    Mocks.GetPropertyFinder(),
                     Factory.NoParameters,
                     Factory.NoProperties);
             });
@@ -70,6 +74,7 @@ namespace Autofac.Test.Core.Activators.Reflection
                 new ReflectionActivator(typeof(object),
                     Mocks.GetConstructorFinder(),
                     null,
+                    Mocks.GetPropertyFinder(),
                     Factory.NoParameters,
                     Factory.NoProperties);
             });
@@ -106,7 +111,7 @@ namespace Autofac.Test.Core.Activators.Reflection
 
             Assert.Same(o, dependent.TheObject);
             Assert.Same(s, dependent.TheString);
-       }
+        }
 
         [Fact]
         public void ActivateInstance_DependenciesNotAvailable_ThrowsException()
@@ -149,7 +154,7 @@ namespace Autofac.Test.Core.Activators.Reflection
             var container = builder.Build();
 
             var parameterInstance = new object();
-            var parameters = new Parameter[]{ new NamedParameter("p", parameterInstance)};
+            var parameters = new Parameter[] { new NamedParameter("p", parameterInstance) };
 
             var target = Factory.CreateReflectionActivator(typeof(AcceptsObjectParameter), parameters);
 
@@ -326,7 +331,7 @@ namespace Autofac.Test.Core.Activators.Reflection
         {
             const int p1 = 1;
             const int p2 = 2;
-            var properties = new [] {
+            var properties = new[] {
                 new NamedPropertyParameter("P1", p1),
                 new NamedPropertyParameter("P2", p2)
             };

--- a/test/Autofac.Test/Factory.cs
+++ b/test/Autofac.Test/Factory.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Autofac.Builder;
 using Autofac.Core.Registration;
 using Autofac.Core.Lifetime;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Core;
-using System.Reflection;
 using Autofac.Core.Activators.ProvidedInstance;
 
 namespace Autofac.Test
@@ -74,6 +72,7 @@ namespace Autofac.Test
                 implementation,
                 new DefaultConstructorFinder(),
                 new MostParametersConstructorSelector(),
+                new DefaultPropertyFinder(),
                 parameters,
                 properties);
         }

--- a/test/Autofac.Test/Mocks.cs
+++ b/test/Autofac.Test/Mocks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Autofac.Core.Activators.Reflection;
 
@@ -16,9 +17,22 @@ namespace Autofac.Test
             return new MockConstructorSelector();
         }
 
+        public static IPropertyFinder GetPropertyFinder()
+        {
+            return new MockPropertyFinder();
+        }
+
         public static Startable GetStartable()
         {
             return new Startable();
+        }
+    }
+
+    class MockPropertyFinder : IPropertyFinder
+    {
+        public PropertyInfo[] FindProperties(Type properties)
+        {
+            return new PropertyInfo[0];
         }
     }
 


### PR DESCRIPTION
There are times when property injection is needed and there needs to be a way to control which properties are available. This follows the pattern of FindConstructorsWith and IConstructorFinder by creating a FindPropertiesWith method and a IPropertyFinder that can be used to determine which properties should be injected.

Fixes #620