### PR TITLE
Add property injection control

### DIFF
--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -253,6 +253,15 @@ namespace Autofac.Builder
         IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(PropertyWiringOptions options = PropertyWiringOptions.None);
 
         /// <summary>
+        /// Configure the component so that any properties whose types are registered in the
+        /// container and follow specific criteria will be wired to instances of the appropriate service.
+        /// </summary>
+        /// <param name="propertySelector">Selector to determine which properties should be injected</param>
+        /// <param name="options">Set wiring options such as circular dependency wiring support.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, PropertyWiringOptions options = PropertyWiringOptions.None);
+
+        /// <summary>
         /// Associates data with the component.
         /// </summary>
         /// <param name="key">Key by which the data can be located.</param>

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -246,14 +246,6 @@ namespace Autofac.Builder
 
         /// <summary>
         /// Configure the component so that any properties whose types are registered in the
-        /// container will be wired to instances of the appropriate service.
-        /// </summary>
-        /// <param name="options">Set wiring options such as circular dependency wiring support.</param>
-        /// <returns>A registration builder allowing further configuration of the component.</returns>
-        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(PropertyWiringOptions options = PropertyWiringOptions.None);
-
-        /// <summary>
-        /// Configure the component so that any properties whose types are registered in the
         /// container and follow specific criteria will be wired to instances of the appropriate service.
         /// </summary>
         /// <param name="propertySelector">Selector to determine which properties should be injected</param>

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -248,10 +248,10 @@ namespace Autofac.Builder
         /// Configure the component so that any properties whose types are registered in the
         /// container and follow specific criteria will be wired to instances of the appropriate service.
         /// </summary>
-        /// <param name="propertySelector">Selector to determine which properties should be injected</param>
-        /// <param name="options">Set wiring options such as circular dependency wiring support.</param>
+        /// <param name="propertySelector">Selector to determine which properties should be injected.</param>
+        /// <param name="allowCircularDependencies">Determine if circular dependencies should be allowed or not.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
-        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, PropertyWiringOptions options = PropertyWiringOptions.None);
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, bool allowCircularDependencies = false);
 
         /// <summary>
         /// Associates data with the component.

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -363,12 +363,10 @@ namespace Autofac.Builder
         /// container and follow specific criteria will be wired to instances of the appropriate service.
         /// </summary>
         /// <param name="propertySelector">Selector to determine which properties should be injected</param>
-        /// <param name="wiringFlags">Set wiring options such as circular dependency wiring support.</param>
+        /// <param name="allowCircularDependencies">Determine if circular dependencies should be allowed or not.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
-        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, PropertyWiringOptions wiringFlags)
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, bool allowCircularDependencies)
         {
-            var allowCircularDependencies = (int)(wiringFlags & PropertyWiringOptions.AllowCircularDependencies) != 0;
-
             if (allowCircularDependencies)
                 RegistrationData.ActivatedHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, propertySelector));
             else

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -360,21 +360,6 @@ namespace Autofac.Builder
 
         /// <summary>
         /// Configure the component so that any properties whose types are registered in the
-        /// container will be wired to instances of the appropriate service.
-        /// </summary>
-        /// <param name="wiringFlags">Set wiring options such as circular dependency wiring support.</param>
-        /// <returns>A registration builder allowing further configuration of the component.</returns>
-        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(PropertyWiringOptions wiringFlags)
-        {
-            var preserveSetValues = (int)(wiringFlags & PropertyWiringOptions.PreserveSetValues) != 0;
-
-            PropertiesAutowired(new DefaultPropertySelector(preserveSetValues), wiringFlags);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Configure the component so that any properties whose types are registered in the
         /// container and follow specific criteria will be wired to instances of the appropriate service.
         /// </summary>
         /// <param name="propertySelector">Selector to determine which properties should be injected</param>

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -366,13 +366,28 @@ namespace Autofac.Builder
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(PropertyWiringOptions wiringFlags)
         {
-            var allowCircularDependencies = (int)(wiringFlags & PropertyWiringOptions.AllowCircularDependencies) != 0;
             var preserveSetValues = (int)(wiringFlags & PropertyWiringOptions.PreserveSetValues) != 0;
 
+            PropertiesAutowired(new DefaultPropertySelector(preserveSetValues), wiringFlags);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configure the component so that any properties whose types are registered in the
+        /// container and follow specific criteria will be wired to instances of the appropriate service.
+        /// </summary>
+        /// <param name="propertySelector">Selector to determine which properties should be injected</param>
+        /// <param name="wiringFlags">Set wiring options such as circular dependency wiring support.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, PropertyWiringOptions wiringFlags)
+        {
+            var allowCircularDependencies = (int)(wiringFlags & PropertyWiringOptions.AllowCircularDependencies) != 0;
+
             if (allowCircularDependencies)
-                RegistrationData.ActivatedHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
+                RegistrationData.ActivatedHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, propertySelector));
             else
-                RegistrationData.ActivatingHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, !preserveSetValues));
+                RegistrationData.ActivatingHandlers.Add((s, e) => AutowiringPropertyInjector.InjectProperties(e.Context, e.Instance, propertySelector));
 
             return this;
         }

--- a/src/Autofac/Builder/RegistrationExtensions.cs
+++ b/src/Autofac/Builder/RegistrationExtensions.cs
@@ -171,8 +171,9 @@ namespace Autofac.Builder
                 this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> registration, PropertyWiringOptions wiringFlags = PropertyWiringOptions.None)
         {
             var preserveSetValues = (int)(wiringFlags & PropertyWiringOptions.PreserveSetValues) != 0;
+            var allowCircularDependencies = (int)(wiringFlags & PropertyWiringOptions.AllowCircularDependencies) != 0;
 
-            return registration.PropertiesAutowired(new DefaultPropertySelector(preserveSetValues), wiringFlags);
+            return registration.PropertiesAutowired(new DefaultPropertySelector(preserveSetValues), allowCircularDependencies);
         }
 
         /// <summary>

--- a/src/Autofac/Builder/RegistrationExtensions.cs
+++ b/src/Autofac/Builder/RegistrationExtensions.cs
@@ -160,6 +160,22 @@ namespace Autofac.Builder
         }
 
         /// <summary>
+        /// Configure the component so that any properties whose types are registered in the
+        /// container will be wired to instances of the appropriate service.
+        /// </summary>
+        /// <param name="registration">Registration to auto-wire properties.</param>
+        /// <param name="wiringFlags">Set wiring options such as circular dependency wiring support.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>
+            PropertiesAutowired<TLimit, TActivatorData, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> registration, PropertyWiringOptions wiringFlags = PropertyWiringOptions.None)
+        {
+            var preserveSetValues = (int)(wiringFlags & PropertyWiringOptions.PreserveSetValues) != 0;
+
+            return registration.PropertiesAutowired(new DefaultPropertySelector(preserveSetValues), wiringFlags);
+        }
+
+        /// <summary>
         /// Changes the parameter mapping mode of the supplied delegate type to match
         /// parameters by type.
         /// </summary>

--- a/src/Autofac/Core/Activators/DefaultPropertySelector.cs
+++ b/src/Autofac/Core/Activators/DefaultPropertySelector.cs
@@ -30,11 +30,10 @@ namespace Autofac.Core
         /// Provides default filtering to determine if property should be injected by rejecting
         /// non-public settable properties.
         /// </summary>
-        /// <param name="type">Type of property to be injected</param>
         /// <param name="propertyInfo">Property to be injected</param>
         /// <param name="instance">Instance that has the property to be injected</param>
         /// <returns>Whether property should be injected</returns>
-        public virtual bool InjectProperty(Type type, PropertyInfo propertyInfo, object instance)
+        public virtual bool InjectProperty(PropertyInfo propertyInfo, object instance)
         {
             if (propertyInfo.SetMethod?.IsPublic != true)
                 return false;

--- a/src/Autofac/Core/Activators/DefaultPropertySelector.cs
+++ b/src/Autofac/Core/Activators/DefaultPropertySelector.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Reflection;
+
+namespace Autofac.Core
+{
+    /// <summary>
+    /// Provides default property selector that applies appropriate filters to ensure only
+    /// public settable properties are selected (including filtering for value types and indexed
+    /// properties).
+    /// </summary>
+    public class DefaultPropertySelector : IPropertySelector
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultPropertySelector"/> class
+        /// that provides default selection criteria.
+        /// </summary>
+        /// <param name="preserveSetValues">Determines if values should be preserved or not</param>
+        public DefaultPropertySelector(bool preserveSetValues)
+        {
+            PreserveSetValues = preserveSetValues;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the value should be set if the value is already
+        /// set (ie non-null)
+        /// </summary>
+        public bool PreserveSetValues { get; protected set; }
+
+        /// <summary>
+        /// Provides default filtering to determine if property should be injected by rejecting
+        /// non-public settable properties.
+        /// </summary>
+        /// <param name="type">Type of property to be injected</param>
+        /// <param name="propertyInfo">Property to be injected</param>
+        /// <param name="instance">Instance that has the property to be injected</param>
+        /// <returns>Whether property should be injected</returns>
+        public virtual bool InjectProperty(Type type, PropertyInfo propertyInfo, object instance)
+        {
+            if (propertyInfo.SetMethod?.IsPublic != true)
+                return false;
+
+            if (PreserveSetValues && propertyInfo.CanRead && propertyInfo.CanWrite &&
+                (propertyInfo.GetValue(instance, null) != null))
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/Autofac/Core/Activators/DelegatePropertySelector.cs
+++ b/src/Autofac/Core/Activators/DelegatePropertySelector.cs
@@ -22,9 +22,9 @@ namespace Autofac.Core
             _finder = finder;
         }
 
-        public bool InjectProperty(Type type, PropertyInfo property, object instance)
+        public bool InjectProperty(PropertyInfo property, object instance)
         {
-            return _finder(type, property, instance);
+            return _finder(property, instance);
         }
     }
 }

--- a/src/Autofac/Core/Activators/DelegatePropertySelector.cs
+++ b/src/Autofac/Core/Activators/DelegatePropertySelector.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Reflection;
+
+namespace Autofac.Core
+{
+    /// <summary>
+    /// Provides a property selector that applies a filter defined by a delegate
+    /// </summary>
+    public sealed class DelegatePropertySelector : IPropertySelector
+    {
+        private readonly Func<PropertyInfo, object, bool> _finder;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelegatePropertySelector"/> class
+        /// that invokes a delegate to determine selection
+        /// </summary>
+        /// <param name="finder">Delegate to determine whether a property should be injected</param>
+        public DelegatePropertySelector(Func<PropertyInfo, object, bool> finder)
+        {
+            if (finder == null) throw new ArgumentNullException(nameof(finder));
+
+            _finder = finder;
+        }
+
+        public bool InjectProperty(Type type, PropertyInfo property, object instance)
+        {
+            return _finder(type, property, instance);
+        }
+    }
+}

--- a/src/Autofac/Core/Activators/IPropertySelector.cs
+++ b/src/Autofac/Core/Activators/IPropertySelector.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Reflection;
+
+namespace Autofac.Core
+{
+    /// <summary>
+    /// Find suitable properties to inject
+    /// </summary>
+    public interface IPropertySelector
+    {
+        /// <summary>
+        /// Provides filtering to determine if property should be injected
+        /// </summary>
+        /// <param name="type">Type of property to be injected</param>
+        /// <param name="propertyInfo">Property to be injected</param>
+        /// <param name="instance">Instance that has the property to be injected</param>
+        /// <returns>Whether property should be injected</returns>
+        bool InjectProperty(Type type, PropertyInfo propertyInfo, object instance);
+    }
+}

--- a/src/Autofac/Core/Activators/IPropertySelector.cs
+++ b/src/Autofac/Core/Activators/IPropertySelector.cs
@@ -11,10 +11,9 @@ namespace Autofac.Core
         /// <summary>
         /// Provides filtering to determine if property should be injected
         /// </summary>
-        /// <param name="type">Type of property to be injected</param>
         /// <param name="propertyInfo">Property to be injected</param>
         /// <param name="instance">Instance that has the property to be injected</param>
         /// <returns>Whether property should be injected</returns>
-        bool InjectProperty(Type type, PropertyInfo propertyInfo, object instance);
+        bool InjectProperty(PropertyInfo propertyInfo, object instance);
     }
 }

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -67,7 +67,7 @@ namespace Autofac.Core.Activators.Reflection
                 if (!context.IsRegistered(propertyType))
                     continue;
 
-                if (!propertySelector.InjectProperty(instanceType, property, instance))
+                if (!propertySelector.InjectProperty(property, instance))
                     continue;
 
                 var propertyValue = context.Resolve(propertyType, new NamedParameter(InstanceTypeNamedParameter, instanceType));

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -43,6 +43,7 @@ namespace Autofac.Core.Activators.Reflection
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             if (instance == null) throw new ArgumentNullException(nameof(instance));
+            if (propertySelector == null) throw new ArgumentNullException(nameof(propertySelector));
 
             var instanceType = instance.GetType();
 

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -657,6 +657,24 @@ namespace Autofac
         }
 
         /// <summary>
+        /// Set the policy used to find candidate properties on the implementation type.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+        /// <typeparam name="TStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set policy on.</param>
+        /// <param name="propertySelector">Policy to be used when searching for properties to inject.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public static IRegistrationBuilder<TLimit, TActivatorData, TStyle> PropertiesAutowired<TLimit, TActivatorData, TStyle>(
+            this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration,
+            Func<Type, PropertyInfo, object, bool> propertySelector)
+        {
+            if (registration == null) throw new ArgumentNullException(nameof(registration));
+
+            return registration.PropertiesAutowired(new DelegatePropertySelector(propertySelector));
+        }
+
+        /// <summary>
         /// Set the policy used to select from available constructors on the implementation type.
         /// </summary>
         /// <typeparam name="TLimit">Registration limit type.</typeparam>

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -667,7 +667,7 @@ namespace Autofac
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<TLimit, TActivatorData, TStyle> PropertiesAutowired<TLimit, TActivatorData, TStyle>(
             this IRegistrationBuilder<TLimit, TActivatorData, TStyle> registration,
-            Func<Type, PropertyInfo, object, bool> propertySelector)
+            Func<PropertyInfo, object, bool> propertySelector)
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
 

--- a/test/Autofac.Test/Builder/PropertyInjectionTests.cs
+++ b/test/Autofac.Test/Builder/PropertyInjectionTests.cs
@@ -12,7 +12,7 @@ namespace Autofac.Test.Builder
     {
         public class HasSetter
         {
-           private string _val;
+            private string _val;
 
             public string Val
             {
@@ -455,7 +455,7 @@ namespace Autofac.Test.Builder
 
             var cb = new ContainerBuilder();
             cb.RegisterType<WithPropInjection>()
-                .PropertiesAutowired((type, propInfo, instance) =>
+                .PropertiesAutowired((propInfo, instance) =>
                 {
                     propertyInfos.Add(propInfo);
                     return false;
@@ -479,7 +479,7 @@ namespace Autofac.Test.Builder
 
             var cb = new ContainerBuilder();
             cb.Register(_ => new WithPropInjection())
-                .PropertiesAutowired((type, propInfo, instance) =>
+                .PropertiesAutowired((propInfo, instance) =>
                 {
                     propertyInfos.Add(propInfo);
                     return false;
@@ -534,7 +534,7 @@ namespace Autofac.Test.Builder
 
         private class InjectAttributePropertySelector : IPropertySelector
         {
-            public bool InjectProperty(Type type, PropertyInfo propertyInfo, object instance)
+            public bool InjectProperty(PropertyInfo propertyInfo, object instance)
             {
                 return propertyInfo.GetCustomAttributes<InjectAttribute>().Any();
             }

--- a/test/Autofac.Test/Builder/PropertyInjectionTests.cs
+++ b/test/Autofac.Test/Builder/PropertyInjectionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
+using Autofac.Builder;
 using Autofac.Core;
 using Xunit;
 

--- a/test/Autofac.Test/Builder/PropertyInjectionTests.cs
+++ b/test/Autofac.Test/Builder/PropertyInjectionTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Core.Activators.Reflection;
 using Xunit;
 
 namespace Autofac.Test.Builder
@@ -27,6 +28,24 @@ namespace Autofac.Test.Builder
                     _val = value;
                 }
             }
+        }
+
+        [Fact]
+        public void NullCheckTests()
+        {
+            var ctx = new ContainerBuilder().Build();
+            var instance = new object();
+            var propertySelector = new DefaultPropertySelector(true);
+
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(null, null, null));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(null, null, false));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(ctx, null, null));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(ctx, null, false));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(null, instance, null));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(null, instance, false));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(ctx, instance, null));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(null, instance, propertySelector));
+            Assert.Throws<ArgumentNullException>(() => AutowiringPropertyInjector.InjectProperties(ctx, null, propertySelector));
         }
 
         [Fact]

--- a/test/Autofac.Test/Core/Activators/Reflection/ReflectionActivatorTests.cs
+++ b/test/Autofac.Test/Core/Activators/Reflection/ReflectionActivatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Test.Scenarios.ConstructorSelection;

--- a/test/Autofac.Test/Core/DefaultPropertySelectorTests.cs
+++ b/test/Autofac.Test/Core/DefaultPropertySelectorTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Reflection;
+using Autofac.Core;
+using Xunit;
+
+namespace Autofac.Test.Core
+{
+    public class DefaultPropertySelectorTests
+    {
+        private class Test
+        {
+        }
+
+        private class HasProperties
+        {
+            private Test PrivatePropertyWithSet { get; set; }
+
+            private Test PrivatePropertyWithDefault { get; set; } = new Test();
+
+            public Test PublicPropertyNoDefault { get; set; }
+
+            public Test PublicPropertyWithDefault { get; set; } = new Test();
+
+            public Test PublicPropertyNoGet
+            {
+                set { }
+            }
+
+            public Test PublicPropertyNoSet { get; }
+        }
+
+        [InlineData(true, "PrivatePropertyWithSet", false)]
+        [InlineData(false, "PrivatePropertyWithSet", false)]
+        [InlineData(true, "PublicPropertyNoDefault", true)]
+        [InlineData(false, "PublicPropertyNoDefault", true)]
+        [InlineData(true, "PublicPropertyWithDefault", false)]
+        [InlineData(false, "PublicPropertyWithDefault", true)]
+        [InlineData(true, "PublicPropertyNoGet", true)]
+        [InlineData(true, "PublicPropertyNoSet", false)]
+        [Theory]
+        public void DefaultTests(bool preserveSetValue, string propertyName, bool expected)
+        {
+            var finder = new DefaultPropertySelector(preserveSetValue);
+
+            var instance = new HasProperties();
+            var targetType = instance.GetType();
+            var property = targetType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Assert.Equal(expected, finder.InjectProperty(targetType, property, instance));
+        }
+    }
+}

--- a/test/Autofac.Test/Core/DefaultPropertySelectorTests.cs
+++ b/test/Autofac.Test/Core/DefaultPropertySelectorTests.cs
@@ -42,10 +42,9 @@ namespace Autofac.Test.Core
             var finder = new DefaultPropertySelector(preserveSetValue);
 
             var instance = new HasProperties();
-            var targetType = instance.GetType();
-            var property = targetType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var property = instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Assert.Equal(expected, finder.InjectProperty(targetType, property, instance));
+            Assert.Equal(expected, finder.InjectProperty(property, instance));
         }
     }
 }

--- a/test/Autofac.Test/Core/DelegatePropertySelectorTests.cs
+++ b/test/Autofac.Test/Core/DelegatePropertySelectorTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Autofac.Core;
+using Xunit;
+
+namespace Autofac.Test.Core
+{
+    public class DelegatePropertySelectorTests
+    {
+        private class InjectPropertyAttribute : Attribute
+        {
+        }
+
+        private class HasProperties
+        {
+            [InjectProperty]
+            public int PublicProperty { get; set; }
+
+            public int PropNoSetter { get; }
+
+            private int PrivateProperty { get; set; }
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnNull()
+        {
+            Assert.Throws<ArgumentNullException>("finder", () => new DelegatePropertySelector(null));
+        }
+
+        [Fact]
+        public void UsesDelegatePassedIn()
+        {
+            var finder = new DelegatePropertySelector((type, propInfo, instance) =>
+            {
+                return propInfo.GetCustomAttributes<InjectPropertyAttribute>().Any();
+            });
+
+            var targetType = typeof(HasProperties);
+
+            foreach (var propInfo in targetType.GetProperties())
+            {
+                var expected = propInfo.GetCustomAttributes<InjectPropertyAttribute>().Any();
+                Assert.Equal(expected, finder.InjectProperty(targetType, propInfo, null));
+            }
+        }
+    }
+}

--- a/test/Autofac.Test/Core/DelegatePropertySelectorTests.cs
+++ b/test/Autofac.Test/Core/DelegatePropertySelectorTests.cs
@@ -31,17 +31,15 @@ namespace Autofac.Test.Core
         [Fact]
         public void UsesDelegatePassedIn()
         {
-            var finder = new DelegatePropertySelector((type, propInfo, instance) =>
+            var finder = new DelegatePropertySelector((propInfo, instance) =>
             {
                 return propInfo.GetCustomAttributes<InjectPropertyAttribute>().Any();
             });
 
-            var targetType = typeof(HasProperties);
-
-            foreach (var propInfo in targetType.GetProperties())
+            foreach (var propInfo in typeof(HasProperties).GetProperties())
             {
                 var expected = propInfo.GetCustomAttributes<InjectPropertyAttribute>().Any();
-                Assert.Equal(expected, finder.InjectProperty(targetType, propInfo, null));
+                Assert.Equal(expected, finder.InjectProperty(propInfo, null));
             }
         }
     }

--- a/test/Autofac.Test/Core/PreserveExistingDefaultsTests.cs
+++ b/test/Autofac.Test/Core/PreserveExistingDefaultsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autofac.Builder;
 using Xunit;
 
 namespace Autofac.Test.Core


### PR DESCRIPTION
There are times when property injection is needed and there needs to be
a way to control which properties are available. This follows the
pattern of FindConstructorsWith and IConstructorFinder by creating a
FindPropertiesWith method and a IPropertyFinder that can be used to
determine which properties should be injected.

Fixes #620 