### PR TITLE
Ignore compiler generated classes on autoregistration

### DIFF
--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -84,6 +84,7 @@ namespace Autofac.Features.Scanning
                     !t.GetTypeInfo().IsAbstract &&
                     !t.GetTypeInfo().IsGenericTypeDefinition &&
                     !t.IsDelegate() &&
+                    !t.IsCompilerGenerated() &&
                     rb.ActivatorData.Filters.All(p => p(t))))
             {
                 var scanned = RegistrationBuilder.ForType(t)

--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Autofac.Util
 {
@@ -185,6 +186,13 @@ namespace Autofac.Util
                    || type.IsGenericTypeDefinedBy(typeof(ICollection<>))
                    || (ReadOnlyCollectionType != null && type.IsGenericTypeDefinedBy(ReadOnlyCollectionType))
                    || (ReadOnlyListType != null && type.IsGenericTypeDefinedBy(ReadOnlyListType));
+        }
+
+        public static bool IsCompilerGenerated(this Type type)
+        {
+            if (type == null) throw new ArgumentNullException(nameof(type));
+
+            return type.GetTypeInfo().GetCustomAttributes<CompilerGeneratedAttribute>().Any();
         }
     }
 }

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/HasDeferredEnumerable.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/HasDeferredEnumerable.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public class HasDeferredEnumerable : IHaveDeferredEnumerable
+    {
+        public IEnumerable<IHaveDeferredEnumerable> Get()
+        {
+            yield return null;
+        }
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/IHaveDeferredEnumerable.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/IHaveDeferredEnumerable.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public interface IHaveDeferredEnumerable
+    {
+        IEnumerable<IHaveDeferredEnumerable> Get();
+    }
+}

--- a/test/Autofac.Test/Features/Scanning/ScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/ScanningRegistrationTests.cs
@@ -438,7 +438,7 @@ namespace Autofac.Test.Features.Scanning
         }
 
         [Fact]
-        public void DefferedEnumerableHelperClassDoesNotGetRegistered()
+        public void DeferredEnumerableHelperClassDoesNotGetRegistered()
         {
             var c = RegisterScenarioAssembly(a => a.AsImplementedInterfaces());
 

--- a/test/Autofac.Test/Features/Scanning/ScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/ScanningRegistrationTests.cs
@@ -436,5 +436,15 @@ namespace Autofac.Test.Features.Scanning
             }));
             Assert.True(c.IsRegisteredWithKey<IAService>(k));
         }
+
+        [Fact]
+        public void DefferedEnumerableHelperClassDoesNotGetRegistered()
+        {
+            var c = RegisterScenarioAssembly(a => a.AsImplementedInterfaces());
+
+            var implementations = c.Resolve<IEnumerable<IHaveDeferredEnumerable>>();
+
+            Assert.Equal(1, implementations.Count());
+        }
     }
 }


### PR DESCRIPTION
When dealing with deferred IEnumerables (using yield return/break) the compiler generates a helper class to handle the deferred execution. Autoregistration discovers this class and registers it as a provider for IEnumerable<T> thus preventing the user from being able to resolve all implementations of T.

