### PR TITLE
Fix parameter name warning

### DIFF
--- a/test/Autofac.Test/Builder/PropertyInjectionTests.cs
+++ b/test/Autofac.Test/Builder/PropertyInjectionTests.cs
@@ -515,7 +515,7 @@ namespace Autofac.Test.Builder
             var obj = new WithPropInjection();
 
             Assert.Null(obj.Prop);
-            c.InjectProperties(obj, new DelegatePropertySelector((p, __) => p.GetCustomAttributes<InjectAttribute>().Any()));
+            c.InjectProperties(obj, new DelegatePropertySelector((p, _) => p.GetCustomAttributes<InjectAttribute>().Any()));
             Assert.Null(obj.Prop);
             Assert.Equal(str, obj.GetProp2());
         }


### PR DESCRIPTION
There's a warning now due to a variable name I had in a recent PR that I hadn't seen. This fixes the warning.