### PR TITLE
DI order spec conformance _lite_

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacRegistration.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Autofac.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -39,6 +40,7 @@ namespace Autofac.Extensions.DependencyInjection
         {
             builder.RegisterType<AutofacServiceProvider>().As<IServiceProvider>();
             builder.RegisterType<AutofacServiceScopeFactory>().As<IServiceScopeFactory>();
+            builder.RegisterInstance(descriptors.ToList());
 
             Register(builder, descriptors);
         }

--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
@@ -24,6 +24,10 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Autofac.Extensions.DependencyInjection
@@ -31,20 +35,65 @@ namespace Autofac.Extensions.DependencyInjection
     internal class AutofacServiceProvider : IServiceProvider, ISupportRequiredService
     {
         private readonly IComponentContext _componentContext;
+        private List<OrderedServiceDescriptor> _originalDescriptors;
+        private HashSet<Type> _serviceTypes;
+        private MethodInfo _castMethodInfo;
 
-        public AutofacServiceProvider(IComponentContext componentContext)
+        public AutofacServiceProvider(IComponentContext componentContext, List<ServiceDescriptor> originalDescriptors)
         {
             _componentContext = componentContext;
+            _originalDescriptors = originalDescriptors.Select((d, i) => new OrderedServiceDescriptor
+            {
+                Index = i,
+                ImplementationInstance = d.ImplementationInstance,
+                ImplementationType = d.ImplementationType
+            }).ToList();
+            _serviceTypes = new HashSet<Type>(originalDescriptors.Select(d => d.ServiceType));
+            _castMethodInfo = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod("Cast");
         }
 
         public object GetService(Type serviceType)
         {
-            return _componentContext.ResolveOptional(serviceType);
+            return GetOrdered(serviceType, _componentContext.ResolveOptional(serviceType));
         }
 
         public object GetRequiredService(Type serviceType)
         {
-            return _componentContext.Resolve(serviceType);
+            return GetOrdered(serviceType, _componentContext.Resolve(serviceType));
         }
+
+        private object GetOrdered(Type serviceType, object resolutionResult)
+        {
+            if (serviceType.Name == "IEnumerable`1" && _serviceTypes.Contains(serviceType.GenericTypeArguments[0]))
+            {
+                var actualServiceType = serviceType.GenericTypeArguments[0];
+                var resulutionResultEnumerable = ((IEnumerable)resolutionResult).Cast<object>();
+
+                resulutionResultEnumerable = resulutionResultEnumerable
+                    .Select(rr => new { ResolutionResult = rr, Index = _originalDescriptors.First(original => MatchedServiceDescriptor(rr, original)).Index })
+                    .OrderBy(rr => rr.Index)
+                    .Select(rr => rr.ResolutionResult).ToList();
+
+                var res = _castMethodInfo.MakeGenericMethod(actualServiceType).Invoke(null, new object[] { resulutionResultEnumerable });
+                return res;
+            }
+            else
+            {
+                return resolutionResult;
+            }
+        }
+
+        private static bool MatchedServiceDescriptor(object a, OrderedServiceDescriptor f)
+        {
+            return f.ImplementationInstance == a || (f.ImplementationInstance == null && a.GetType() == f.ImplementationType);
+        }
+    }
+
+    internal class OrderedServiceDescriptor
+    {
+        public int Index { get; set; }
+        public object ImplementationInstance { get; set; }
+        public Type ImplementationType { get; set; }
+
     }
 }

--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
@@ -88,12 +88,4 @@ namespace Autofac.Extensions.DependencyInjection
             return f.ImplementationInstance == a || (f.ImplementationInstance == null && a.GetType() == f.ImplementationType);
         }
     }
-
-    internal class OrderedServiceDescriptor
-    {
-        public int Index { get; set; }
-        public object ImplementationInstance { get; set; }
-        public Type ImplementationType { get; set; }
-
-    }
 }

--- a/src/Autofac.Extensions.DependencyInjection/OrderedServiceDescriptor.cs
+++ b/src/Autofac.Extensions.DependencyInjection/OrderedServiceDescriptor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Autofac.Extensions.DependencyInjection
+{
+    internal class OrderedServiceDescriptor
+    {
+        public int Index { get; set; }
+
+        public object ImplementationInstance { get; set; }
+
+        public Type ImplementationType { get; set; }
+    }
+}


### PR DESCRIPTION
Allright, here is a rough draft of what I was talking about in the discussion over at 
aspnet/DependencyInjection#416 I don't expect it to be merged in its current state but its ment to illustrate what I ment over in that other issue, as well as serve as a basis for discussion

So just to reiterate, This is my interpretations of @halter73 comments: 

> "Registration order" is probably a bit of a misnomer. It's really the order the service definitions occur in the IEnumerable<IServiceDescriptor> passed to container's Populate method. Populate is free to do whatever it wants with this metadata including calling registration methods in whatever order it wants.

With some assumptions on my part that  someone can hopefully confirm or deny:

> Does that mean that actual order given for resolving an IEnumeable<T> is given by the IEnumerable<IServiceDescriptor> passed to Populate?
Also, does it mean that order only has to be tracked for components added by the abstraction/Populate, not for components added via container specific apis?

In this PR I've assumed that the answers to those questions are "yes" and so this adapter would (barring bugs)

* Maintain order of components registered with the DI abstractions
* _Not_ maintain order of components registered with the autofac apis
* Have _unpredictable_ order (or possibly crash right now) for components whos implementations have been registered with a mix of autofac and DI abstraction apis.

So the question then is, would this satisfy the current spec? (or would this be an acceptable future spec?)

Again, though this works with a basic application, I havent tested it very much, its more to illustrate the idea at the moment. (i'll continue to test it, I just wanted to show you what I ment)

cc @tillig @alexmg @halter73 @davidfowl