### PR TITLE
make AutofacServiceProvider disposable to allow WebHost to release resources

### DIFF
--- a/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
+++ b/src/Autofac.Extensions.DependencyInjection/AutofacServiceProvider.cs
@@ -24,11 +24,12 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using Autofac.Util;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Autofac.Extensions.DependencyInjection
 {
-    internal class AutofacServiceProvider : IServiceProvider, ISupportRequiredService
+    internal class AutofacServiceProvider : Disposable, IServiceProvider, ISupportRequiredService
     {
         private readonly IComponentContext _componentContext;
 
@@ -45,6 +46,16 @@ namespace Autofac.Extensions.DependencyInjection
         public object GetRequiredService(Type serviceType)
         {
             return _componentContext.Resolve(serviceType);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                (_componentContext as IDisposable)?.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Hello everybody!

Today I was investigating some failing integration tests for my ASP.NET Core app.
I use TestHost, which creates w WebHost instance, which can be used as regular web app (send some post requests etc). Of course I dispose it once I am done using it. 

The  [current implementation of the WebHost.Dispose](
https://github.com/aspnet/Hosting/blob/e7b8c3f90a781a55658b4245571c5bf5dac5e56e/src/Microsoft.AspNetCore.Hosting/Internal/WebHost.cs#L211-#L217) is following:

```cs
public void Dispose()
{
	_logger?.Shutdown();
	_applicationLifetime.StopApplication();
	(_applicationServices as IDisposable)?.Dispose();
	_applicationLifetime.NotifyStopped();
}
```

So it assumes that custom implementation of `IServiceProvider` does not have to implement `IDisposable`.

The problem is that `AutofacServiceProvider` does not implement `IDisposable`, so the resources are never disposed. Hence my PR.
