### PR TITLE
Includes self on GetImplementedInterface calls to interface

### DIFF
--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -611,7 +611,8 @@ namespace Autofac
 
         private static Type[] GetImplementedInterfaces(Type type)
         {
-            return type.GetTypeInfo().ImplementedInterfaces.Where(i => i != typeof(IDisposable)).ToArray();
+            var interfaces = type.GetTypeInfo().ImplementedInterfaces.Where(i => i != typeof(IDisposable));
+            return type.GetTypeInfo().IsInterface ? interfaces.Append(type).ToArray() : interfaces.ToArray();
         }
 
         /// <summary>

--- a/test/Autofac.Test/RegistrationExtensionsTests.cs
+++ b/test/Autofac.Test/RegistrationExtensionsTests.cs
@@ -136,6 +136,21 @@ namespace Autofac.Test
             context.Resolve<IImplementedInterface>();
         }
 
+        IImplementedInterface SelfComponentFactory()
+        {
+            return new SelfComponent();
+        }
+
+        [Fact]
+        public void AsImplementedInterfaces_CanBeAppliedToInstanceRegistrationsOfInterfaces()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register(c => SelfComponentFactory()).AsImplementedInterfaces();
+            var context = builder.Build();
+
+            context.Resolve<IImplementedInterface>();
+        }
+
         [Fact]
         public void AsSelf_CanBeAppliedToInstanceRegistrations()
         {


### PR DESCRIPTION
For situations where an interface is passed to GetImplementedInterfaces
this adds the actual interface to the list of returned values.

This allows for situations such as registering the return value of a
factory method. Prior to this commit to resolve that type you'd have to
use AsSelf() rather than AsImplementedInterfaces().

Resolves issue #770