### PR TITLE
Replace standard library meta package with only necessary packages

### DIFF
--- a/src/Autofac/project.json
+++ b/src/Autofac/project.json
@@ -29,8 +29,21 @@
     "net4.5": {},
     "netstandard1.1": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "System.ComponentModel": "4.0.1"
+        "System.Collections": "4.0.11",
+        "System.Collections.Concurrent": "4.0.12",
+        "System.ComponentModel": "4.0.1",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Diagnostics.Tools": "4.0.1",
+        "System.Globalization": "4.0.11",
+        "System.Linq": "4.1.0",
+        "System.Linq.Expressions": "4.1.0",
+        "System.Reflection": "4.1.0",
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Reflection.Primitives": "4.0.1",
+        "System.Resources.ResourceManager": "4.0.1",
+        "System.Runtime": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Threading": "4.0.11"
       }
     }
   },


### PR DESCRIPTION
The .NET Standard 1.6 library package is a meta package that includes a
number of assemblies that are not needed in Autofac. This change
specifies only the assemblies needed to run autofac.