### PR TITLE
README layout update with logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Autofac
+![Autofac](https://autofac.org/img/carousel-logo.png)
 
 Autofac is an [IoC container](http://martinfowler.com/articles/injection.html) for Microsoft .NET. It manages the dependencies between classes so that **applications stay easy to change as they grow** in size and complexity. This is achieved by treating regular .NET classes as *[components](http://autofac.readthedocs.io/en/latest/glossary.html)*.
 
-[![Build status](https://ci.appveyor.com/api/projects/status/s0vgb4m8tv9ar7we?svg=true)](https://ci.appveyor.com/project/Autofac/autofac)
-
-![MyGet publish status](https://www.myget.org/BuildSource/Badge/autofac?identifier=e0f25040-634c-4b7d-aebe-0f62b9c465a8)
+[![Build status](https://ci.appveyor.com/api/projects/status/s0vgb4m8tv9ar7we?svg=true)](https://ci.appveyor.com/project/Autofac/autofac) ![MyGet publish status](https://www.myget.org/BuildSource/Badge/autofac?identifier=e0f25040-634c-4b7d-aebe-0f62b9c465a8) [![Autofac on Stack Overflow](https://img.shields.io/badge/stack%20overflow-autofac-orange.svg)](http://stackoverflow.com/questions/tagged/autofac) [![Join the chat at https://gitter.im/autofac/autofac](https://img.shields.io/gitter/room/autofac/autofac.svg)](https://gitter.im/autofac/autofac) [![NuGet](https://img.shields.io/nuget/v/Nuget.Core.svg)](https://nuget.org/packages/Autofac)
 
 ## Get Packages
 


### PR DESCRIPTION
Just a spur-of-the-moment change; uses the logo instead of the `H1`, and includes prominent links to the NuGet package, Stack Overflow tag, and Gitter chat.

See the change [rendered in context](https://github.com/nblumhardt/Autofac).

Thoughts? 👍 or 👎 ?

