### PR TITLE
Do less work and create less garbage when instantiating components via reflection

### DIFF
--- a/bench/Autofac.Benchmarks/DeepGraphResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/DeepGraphResolveBenchmark.cs
@@ -1,0 +1,67 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+
+namespace Autofac.Benchmarks
+{
+    /// <summary>
+    /// Tests the performance of retrieving a (reasonably) deeply-nested object graph.
+    /// </summary>
+    public class DeepGraphResolveBenchmark
+    {
+        private IContainer _container;
+
+        [Setup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<A>();
+            builder.RegisterType<B1>();
+            builder.RegisterType<B2>();
+            builder.RegisterType<C1>();
+            builder.RegisterType<C2>();
+            builder.RegisterType<D1>();
+            builder.RegisterType<D2>();
+            _container = builder.Build();
+        }
+
+        [Benchmark]
+        public void Resolve()
+        {
+            var instance = _container.Resolve<A>();
+            GC.KeepAlive(instance);
+        }
+    }
+
+#pragma warning disable SA1402, SA1502
+
+    internal class A
+    {
+        public A(B1 b1, B2 b2) { }
+    }
+
+    internal class B1
+    {
+        public B1(B2 b2, C1 c1, C2 c2) { }
+    }
+
+    internal class B2
+    {
+        public B2(C1 c1, C2 c2) { }
+    }
+
+    internal class C1
+    {
+        public C1(C2 c2, D1 d1, D2 d2) { }
+    }
+
+    internal class C2
+    {
+        public C2(D1 d1, D2 d2) { }
+    }
+
+    internal class D1 { }
+
+    internal class D2 { }
+
+#pragma warning restore SA1402, SA1502
+}

--- a/bench/Autofac.Benchmarks/Harness.cs
+++ b/bench/Autofac.Benchmarks/Harness.cs
@@ -35,5 +35,11 @@ namespace Autofac.Benchmarks
         {
             BenchmarkRunner.Run<RootContainerResolveBenchmark>();
         }
+
+        [Fact]
+        public void DeepGraphResolve()
+        {
+            BenchmarkRunner.Run<DeepGraphResolveBenchmark>();
+        }
     }
 }


### PR DESCRIPTION
This partially addresses #769 by removing allocations  and unnecessary work from the hot path of reflection-based component activation.

```ini
Host Process Environment Information:
BenchmarkDotNet.Core=v0.9.9.0
OS=Windows
Processor=?, ProcessorCount=8
Frequency=2533308 ticks, Resolution=394.7408 ns, Timer=TSC
CLR=CORE, Arch=64-bit ? [RyuJIT]
GC=Concurrent Workstation
dotnet cli version: 1.0.0-preview2-003121
Type=DeepGraphResolveBenchmark  Mode=Throughput
```

### Before

|  Method |     Median |    StdDev |
|-------- |----------- |---------- |
| Resolve | 38.4004 us | 0.8659 us |


### After

|  Method |     Median |    StdDev |
|-------- |----------- |---------- |
| Resolve | 17.9659 us | 0.1156 us |
