### PR TITLE
Fix crash on IOS when the linker is enabled

### DIFF
--- a/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
@@ -62,9 +62,9 @@ namespace Autofac.Core.Activators.Reflection
         {
             // On IOS, when the mono linker is enabled (and it's enabled by default) it strips out all parts of
             // the framework which are not in use. The linker does not support reflection, however, therefore it
-            // does not recognize the call to 'GetRuntimeMethod(nameof(Convert.ChangeType)' (which is called from 
-            // a method in this class) as using the 'Convert.ChangeType' method and strips it away unless it's  
-            // explicitly used somewhere else, crashing Autofac if that method is called. 
+            // does not recognize the call to 'GetRuntimeMethod(nameof(Convert.ChangeType)' (which is called from
+            // a method in this class) as using the 'Convert.ChangeType' method and strips it away unless it's
+            // explicitly used somewhere else, crashing Autofac if that method is called.
             // Therefore, by explicitly calling it here, we're playing nicely with the linker and making sure
             // Autofac works on IOS.
             Convert.ChangeType((object)1234f, typeof(float));

--- a/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
@@ -58,6 +58,18 @@ namespace Autofac.Core.Activators.Reflection
         /// </summary>
         public bool CanInstantiate { get; }
 
+        static ConstructorParameterBinding()
+        {
+            // On IOS, when the mono linker is enabled (and it's enabled by default) it strips out all parts of
+            // the framework which are not in use. The linker does not support reflection, however, therefore it
+            // does not recognize the call to 'GetRuntimeMethod(nameof(Convert.ChangeType)' (which is called from 
+            // a method in this class) as using the 'Convert.ChangeType' method and strips it away unless it's  
+            // explicitly used somewhere else, crashing Autofac if that method is called. 
+            // Therefore, by explicitly calling it here, we're playing nicely with the linker and making sure
+            // Autofac works on IOS.
+            Convert.ChangeType((object)1234f, typeof(float));
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstructorParameterBinding"/> class.
         /// </summary>


### PR DESCRIPTION
On IOS, when the mono linker is enabled (and it’s enabled by default and recommended by Xamarin) it strips out all parts of the framework which are not in use. The linker does not support reflection, however, therefore it does not recognize the call to 'GetRuntimeMethod(nameof(Convert.ChangeType)' (which is called in ConstructorParameterBinding -> ConvertPrimitiveType) as using the 'Convert.ChangeType' method and strips it away unless it's explicitly used somewhere else, crashing Autofac if that method is called (null reference exception as ‘GetRuntimeMethod’ returns null).
Added an explicit call to Convert.ChangeType to let the linker know that we need this method and with that making sure Autofac works on IOS.