### PR TITLE
Exceptions in CurrentScopeEnding handler stops disposal

### DIFF
--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -308,9 +308,15 @@ namespace Autofac.Core.Lifetime
             if (disposing)
             {
                 var handler = CurrentScopeEnding;
-                handler?.Invoke(this, new LifetimeScopeEndingEventArgs(this));
 
-                Disposer.Dispose();
+                try
+                {
+                    handler?.Invoke(this, new LifetimeScopeEndingEventArgs(this));
+                }
+                finally
+                {
+                    Disposer.Dispose();
+                }
 
                 // ReSharper disable once InconsistentlySynchronizedField
                 _sharedInstances.Clear();

--- a/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
+++ b/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
@@ -515,5 +515,32 @@ namespace Autofac.Test.Core.Lifetime
                 }
             }
         }
+
+        class HandlerException : Exception
+        {
+        }
+
+        [Fact]
+        public void ContainerIsDisposedEvenIfHandlerThrowsException()
+        {
+            var rootScope = new ContainerBuilder().Build();
+
+            var nestedScope = rootScope.BeginLifetimeScope(cb =>
+                cb.RegisterType<DisposeTracker>().SingleInstance());
+
+            nestedScope.CurrentScopeEnding += (sender, args) => throw new HandlerException();
+
+            var dt = nestedScope.Resolve<DisposeTracker>();
+
+            try
+            {
+                nestedScope.Dispose();
+            }
+            catch (HandlerException)
+            {
+            }
+
+            Assert.True(dt.IsDisposed);
+        }
     }
 }


### PR DESCRIPTION
As container lifetime scopes end, always dispose objects