### PR TITLE
Updated Autofac to include netcore / netstandard 2.0 build

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,7 @@ Import-Module $PSScriptRoot\Build\Autofac.Build.psd1 -Force
 
 $artifactsPath = "$PSScriptRoot\artifacts"
 $packagesPath = "$artifactsPath\packages"
-$sdkVersion = "1.1.0"
+$sdkVersion = "2.0.0"
 
 # Clean up artifacts folder
 if (Test-Path $artifactsPath) {

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>4.6.1</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -52,6 +52,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+    <PackageReference Include="System.ComponentModel" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ComponentModel" Version="4.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
+++ b/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
@@ -101,8 +101,11 @@ namespace Autofac.Features.LightweightAdapters
                         return rb.CreateRegistration();
                     });
             }
-
+#if NETSTANDARD2_0
+            return Array.Empty<IComponentRegistration>();
+#else
             return new IComponentRegistration[0];
+#endif
         }
 
         public bool IsAdapterForIndividualComponents => true;

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -612,7 +612,7 @@ namespace Autofac
         private static Type[] GetImplementedInterfaces(Type type)
         {
             var interfaces = type.GetTypeInfo().ImplementedInterfaces.Where(i => i != typeof(IDisposable));
-            return type.GetTypeInfo().IsInterface ? interfaces.Append(type).ToArray() : interfaces.ToArray();
+            return type.GetTypeInfo().IsInterface ? interfaces.AppendItem(type).ToArray() : interfaces.ToArray();
         }
 
         /// <summary>

--- a/src/Autofac/Util/SequenceExtensions.cs
+++ b/src/Autofac/Util/SequenceExtensions.cs
@@ -53,7 +53,7 @@ namespace Autofac.Util
         /// <param name="sequence">The sequence.</param>
         /// <param name="trailingItem">The trailing item.</param>
         /// <returns>The sequence with an item appended to the end.</returns>
-        public static IEnumerable<T> Append<T>(this IEnumerable<T> sequence, T trailingItem)
+        public static IEnumerable<T> AppendItem<T>(this IEnumerable<T> sequence, T trailingItem)
         {
             if (sequence == null) throw new ArgumentNullException(nameof(sequence));
 

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Test.Scenarios.ScannedAssembly</AssemblyName>
@@ -9,7 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Autofac.Test.Scenarios.ScannedAssembly</PackageId>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.0;net46</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Test</AssemblyName>


### PR DESCRIPTION
- Changed name of SequenceExtensions.Append to AppendItem due to
collision with netstandard2 linq extension Append.
- Added conditional compilation flag for Array.Empty on netstandard2