### PR TITLE
Deadlock timeout (remove simple lock which produce the threat of dead…

### DIFF
--- a/src/Autofac/Util/Locks/AsyncExtensions.cs
+++ b/src/Autofac/Util/Locks/AsyncExtensions.cs
@@ -1,0 +1,27 @@
+﻿using Autofac;
+using Autofac.Core.Registration;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Represent Semaphore scoping extensions.
+    /// </summary>
+    public static class AsyncExtensions
+    {
+        public static ContainerBuilder WithTimeout(
+            this ContainerBuilder container,
+            TimeSpan timeout)
+        {
+            if (container.Properties.ContainsKey(AsyncLock.LockTimeoutKey))
+            {
+                container.Properties[AsyncLock.LockTimeoutKey] = timeout;
+            }
+            else
+            {
+                container.Properties.Add(AsyncLock.LockTimeoutKey, timeout);
+            }
+
+            return container;
+        }
+    }
+}

--- a/src/Autofac/Util/Locks/AsyncLock.cs
+++ b/src/Autofac/Util/Locks/AsyncLock.cs
@@ -1,0 +1,87 @@
+﻿namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Represent Semaphore scoping.
+    /// The semaphore scope will enable the usage of semaphore easy like lock.
+    /// </summary>
+    public sealed class AsyncLock : IDisposable
+    {
+        public const string LockTimeoutKey = "__LockTimeout";
+
+        private readonly SemaphoreSlim _gate;
+        private readonly TimeSpan _defaultTimeout;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncLock" /> class.
+        /// </summary>
+        /// <param name="gateLimit">The number of max concurrent requests (beyond this count request will delay until the completion of other request).
+        /// </param>
+        /// <param name="defaultTimeout">
+        /// The default timeout will cause the waiting call to throw exception,
+        /// Maximum waiting in order to acquires the lock-scope, beyond this waiting it will throw TimeoutException.
+        /// </param>
+        public AsyncLock(TimeSpan defaultTimeout, byte gateLimit = 1)
+        {
+            _gate = new SemaphoreSlim(gateLimit);
+            _defaultTimeout = defaultTimeout;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncLock" /> class.
+        /// </summary>
+        /// <param name="gate">The gate.</param>
+        /// <param name="defaultTimeout">The default timeout will cause the waiting call to throw exception,
+        /// Maximum waiting in order to acquires the lock-scope, beyond this waiting it will throw TimeoutException.</param>
+        public AsyncLock(SemaphoreSlim gate, TimeSpan defaultTimeout)
+        {
+            _gate = gate;
+            _defaultTimeout = defaultTimeout;
+        }
+
+        /// <summary>
+        /// Try to acquire async lock,
+        /// when failed the LockScope.Acquired will equals false
+        /// </summary>
+        /// <param name="overrideTimeout">The override timeout.</param>
+        /// <returns>lock disposal and acquired indication</returns>
+        public async Task<LockScope> TryAcquireAsync(TimeSpan overrideTimeout = default(TimeSpan))
+        {
+            var timeout = overrideTimeout == default(TimeSpan) ? _defaultTimeout : overrideTimeout;
+            bool acquired = await _gate.WaitAsync(timeout).ConfigureAwait(false);
+            return new LockScope(_gate, acquired);
+        }
+
+        /// <summary>
+        /// Try to acquire async lock,
+        /// when it will throw TimeoutException
+        /// </summary>
+        /// <param name="overrideTimeout">The override timeout.</param>
+        /// <returns>lock disposal</returns>
+        /// <exception cref="TimeoutException">when acquire lock fail</exception>
+        public async Task<IDisposable> AcquireAsync(TimeSpan overrideTimeout = default(TimeSpan))
+        {
+            var scope = await TryAcquireAsync(overrideTimeout).ConfigureAwait(false);
+            if (!scope.Acquired)
+            {
+                scope.Dispose();
+                throw new TimeoutException();
+            }
+
+            return scope;
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            _gate?.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="AsyncLock"/> class.
+        /// </summary>
+        ~AsyncLock() => Dispose();
+    }
+}

--- a/src/Autofac/Util/Locks/LockScope.cs
+++ b/src/Autofac/Util/Locks/LockScope.cs
@@ -1,0 +1,65 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2011 Autofac Contributors
+// http://autofac.org
+//
+// this code is contribution from https://www.nuget.org/packages/Bnaya.CSharp.AsyncExtensions/
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace System.Threading.Tasks
+{
+    /// <summary>
+    /// Locking scope which can free the lock using Dispose and indicate whether lock is acquired
+    /// </summary>
+    public sealed class LockScope : IDisposable
+    {
+        private SemaphoreSlim _gate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LockScope"/> class.
+        /// </summary>
+        /// <param name="gate">The gate.</param>
+        /// <param name="acquired">if set to <c>true</c> [acquired].</param>
+        internal LockScope(SemaphoreSlim gate, bool acquired)
+        {
+            _gate = gate;
+            Acquired = acquired;
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the lock is acquired.
+        /// </summary>
+        public bool Acquired { get; }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <exception cref="ObjectDisposedException">Dispose can be invoked once</exception>
+        public void Dispose()
+        {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+            if (_gate == null)
+                throw new ObjectDisposedException("Dispose can be invoked once");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+
+            if (Acquired)
+            {
+                _gate?.Release();
+            }
+
+            _gate = null;
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="LockScope"/> class.
+        /// </summary>
+        ~LockScope()
+        {
+            Dispose();
+        }
+    }
+}

--- a/test/Autofac.Test/Core/Resolving/ResolveOperationAsyncTests.cs
+++ b/test/Autofac.Test/Core/Resolving/ResolveOperationAsyncTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Test.Scenarios.Dependencies;
+using Xunit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Autofac.Test.Core.Resolving
+{
+    public class ResolveOperationAsyncTests
+    {
+        private static ManualResetEventSlim _gate = new ManualResetEventSlim(false);
+
+        [Fact]
+        public void CtorPropDependencyDetectDeadlock()
+        {
+            var cb = new ContainerBuilder().WithTimeout(TimeSpan.FromMilliseconds(100));
+            cb.RegisterType<A>().SingleInstance();
+            cb.RegisterType<B>().SingleInstance();
+
+            var c = cb.Build();
+            try
+            {
+                var dbp = c.Resolve<A>();
+                throw new Exception("Unexpected");
+            }
+            catch (DependencyResolutionException ex)
+            {
+                var inner1 = ex.InnerException as AggregateException;
+                if (!(inner1?.InnerException is TimeoutException))
+                    throw new Exception("Unexpected");
+            }
+            finally
+            {
+                _gate.Set();
+            }
+        }
+
+        public class A
+        {
+            public A(ILifetimeScope container)
+            {
+                Task.Run(() => container.Resolve<B>()).Wait(); // classic locking will cause deadlock
+            }
+        }
+
+        public class B
+        {
+            public B()
+            {
+                if (!_gate.Wait(TimeSpan.FromSeconds(5)))
+                    throw new Exception("Deadlock");
+            }
+        }
+    }
+}


### PR DESCRIPTION
When resolving on multiple thread it can lead to a deadlock state when the resolved type's constructor is waiting on other resolve.
You can check the test in order to reproduce the scenario.
It may not being best practice to create this kind of code in the first place, but shit happen and sometime you do have constraint like legacy source code etc.
The fix enable to add timeout via new ContainerBuilder().WithTimeout(TimeSpan.FromMilliseconds(100)).

Internally the fix replace the simple lock with a convenient wrapper of semaphore which have timeout and support async operations. 