### PR TITLE
#624 Start startable components in dependency order

### DIFF
--- a/src/Autofac/Builder/MetadataKeys.cs
+++ b/src/Autofac/Builder/MetadataKeys.cs
@@ -30,5 +30,7 @@ namespace Autofac.Builder
         internal const string RegistrationOrderMetadataKey = "__RegistrationOrder";
 
         internal const string AutoActivated = "__AutoActivated";
+
+        internal const string StartOnActivatePropertyKey = "__StartOnActivate";
     }
 }

--- a/src/Autofac/ContainerBuilder.cs
+++ b/src/Autofac/ContainerBuilder.cs
@@ -167,9 +167,7 @@ namespace Autofac
                 // We track which registrations have already been auto-activated by adding
                 // a metadata value. If the value is present, we won't re-activate. This helps
                 // in the container update situation.
-                object meta;
-
-                foreach (var startable in componentRegistry.RegistrationsFor(new TypedService(typeof(IStartable))).Where(r => !r.Metadata.TryGetValue(started, out meta)))
+                foreach (var startable in componentRegistry.RegistrationsFor(new TypedService(typeof(IStartable))).Where(r => !r.Metadata.ContainsKey(started)))
                 {
                     try
                     {
@@ -181,7 +179,7 @@ namespace Autofac
                     }
                 }
 
-                foreach (var registration in componentRegistry.RegistrationsFor(new AutoActivateService()).Where(r => !r.Metadata.TryGetValue(started, out meta)))
+                foreach (var registration in componentRegistry.RegistrationsFor(new AutoActivateService()).Where(r => !r.Metadata.ContainsKey(started)))
                 {
                     try
                     {

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -91,11 +91,10 @@ namespace Autofac.Core.Resolving
 
         private void StartStartableComponent(object instance)
         {
-            object meta;
             if (instance is IStartable startable
                 && ComponentRegistration.Services.Any(s => (s is TypedService typed) && typed.ServiceType == typeof(IStartable))
-                && !this.ComponentRegistration.Metadata.TryGetValue(MetadataKeys.AutoActivated, out meta)
-                && this.ComponentRegistry.Properties.TryGetValue(MetadataKeys.StartOnActivatePropertyKey, out meta))
+                && !ComponentRegistration.Metadata.ContainsKey(MetadataKeys.AutoActivated)
+                && ComponentRegistry.Properties.ContainsKey(MetadataKeys.StartOnActivatePropertyKey))
             {
                 try
                 {

--- a/test/Autofac.Test/ContainerBuilderTests.cs
+++ b/test/Autofac.Test/ContainerBuilderTests.cs
@@ -450,6 +450,24 @@ namespace Autofac.Test
             container.Resolve<ComponentTakesStartableDependency>();
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WhenTheContainerIsBuilt_StartableComponentsThatDependOnAutoActivateComponents_AreNotStartedTwice(bool isSingleton)
+        {
+            var builder = new ContainerBuilder();
+            var expectedStartCount = isSingleton ? 1 : 2;
+            var dependencyRegistration = builder.RegisterType<StartableDependency>().As<IStartableDependency>().AutoActivate();
+            if (isSingleton)
+                dependencyRegistration.SingleInstance();
+
+            builder.RegisterType<StartableTakesDependency>().AsSelf().As<IStartable>();
+
+            StartableDependency.Count = 0;
+            builder.Build();
+            Assert.Equal(expectedStartCount, StartableDependency.Count);
+        }
+
         [Fact]
         public void WhenTheContainerIsUpdated_ExistingStartableComponentsAreNotReStarted()
         {


### PR DESCRIPTION
Hi guys,

I wanted to take a stab at issue #624 to address a practical need in some large systems where `IStartable` is heavily utilized.
To give some context on our usage of `IStartable` without going into specifics -- distributed systems often have recurring tasks, metadata retrieval operations, things that need to happen when booting up a service or application. These operations usually connect to external systems.
We have unit tests that build containers using the `IgnoreStartableComponents` option. This allows us to ensure that the container is correctly defined at compile time, while eliminating the need for mocking or overriding components just to verify that the container builds.

I added some basic unit tests to verify that this works. The unit test fails without the corresponding code changes in the Autofac code. I'll also verify this in a larger scale (1000+ class container, with 100+ `IStartable` components).

Please let me know if you see any issues, my main concerns are:

- Adding code to the `InstanceLookup` class, which is a hot code path
- If Start() throws, should it be wrapped in a DependencyResolutionException? 

Thanks,

Bas