### PR TITLE
PERF: Improved runtime performance

### DIFF
--- a/src/Autofac/Core/Resolving/CircularDependencyDetector.cs
+++ b/src/Autofac/Core/Resolving/CircularDependencyDetector.cs
@@ -37,7 +37,7 @@ namespace Autofac.Core.Resolving
         /// </summary>
         private const int MaxResolveDepth = 50;
 
-        private static string CreateDependencyGraphTo(IComponentRegistration registration, IEnumerable<InstanceLookup> activationStack)
+        private static string CreateDependencyGraphTo(IComponentRegistration registration, Stack<InstanceLookup> activationStack)
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
             if (activationStack == null) throw new ArgumentNullException(nameof(activationStack));
@@ -56,18 +56,13 @@ namespace Autofac.Core.Resolving
         public static void CheckForCircularDependency(IComponentRegistration registration, Stack<InstanceLookup> activationStack, int callDepth)
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
-            if (activationStack == null) throw new ArgumentNullException(nameof(activationStack));
 
             if (callDepth > MaxResolveDepth)
                 throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.MaxDepthExceeded, registration));
 
-            if (IsCircularDependency(registration, activationStack))
+            // Checks for circular dependency
+            if (activationStack.Any(a => a.ComponentRegistration == registration))
                 throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.CircularDependency, CreateDependencyGraphTo(registration, activationStack)));
-        }
-
-        private static bool IsCircularDependency(IComponentRegistration registration, IEnumerable<InstanceLookup> activationStack)
-        {
-            return activationStack.Any(a => a.ComponentRegistration == registration);
         }
     }
 }


### PR DESCRIPTION
Improved runtime performance by 
- inlining isCircularDependency check
- removed "activationStack" parameter guard from circular depdendency check because it was never possible being null 
- converted foreach loop to for loop for more ops/sec

I used this benchmark:
https://github.com/danielpalme/IocPerformance
http://www.palmmedia.de/Blog/2011/8/30/ioc-container-benchmark-performance-comparison

Release mode. ( times are milliseconds, lower is better )

Before
```
Autofac                                      Single      Multi
 Singleton                                      786        677
 Transient                                      815        632
 Combined                                      2200       1715
 Complex                                       7229       5245
 Property                                      7072       4886
 Generics                                      1986       1505
 IEnumerable                                   8172       4121
 Conditional                                   1350        783
 Child Container                              59504      33258
 Asp Net Core                                 13567      10291
 Interception With Proxy                      20642      10757
 Prepare And Register                           266
 Prepare And Register And Simple Resolve        287
```


After
```
Autofac                                      Single      Multi
 Singleton                                      489        343
 Transient                                      509        320
 Combined                                      1649       1114
 Complex                                       5596       3562
 Property                                      5761       3579
 Generics                                      1778       1368
 IEnumerable                                   7091       3927
 Conditional                                   1150        677
 Child Container                              59575      33461
 Asp Net Core                                 13039      10238
 Interception With Proxy                      19863      10403
 Prepare And Register                           262
 Prepare And Register And Simple Resolve        280
```


Benchmark computer:
AMD Ryzen Threadripper 1900X 8-Core (16CPU) 3.8Ghz
32GB DDR4 3200Mhz
Windows 10 ( 1709 )