### PR TITLE
Memory traffic optimization

### DIFF
--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -4,7 +4,7 @@
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>4.8.1</VersionPrefix>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;CA1819</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac</AssemblyName>

--- a/src/Autofac/Builder/ContainerBuildOptions.cs
+++ b/src/Autofac/Builder/ContainerBuildOptions.cs
@@ -40,12 +40,6 @@ namespace Autofac.Builder
         None = 0,
 
         /// <summary>
-        /// Prevents inclusion of standard modules like support for
-        /// relationship types including <see cref="IEnumerable{T}"/> etc.
-        /// </summary>
-        ExcludeDefaultModules = 2,
-
-        /// <summary>
         /// Does not call <see cref="IStartable.Start"/> on components implementing
         /// this interface (useful for module testing.)
         /// </summary>

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -278,5 +278,19 @@ namespace Autofac.Builder
         /// </param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> WithMetadata<TMetadata>(Action<MetadataConfiguration<TMetadata>> configurationAction);
+
+        /// <summary>
+        /// Configure the services that the component will provide.
+        /// </summary>
+        /// <param name="service">Service types to expose.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> As(Type service);
+
+        /// <summary>
+        /// Configure the services that the component will provide.
+        /// </summary>
+        /// <param name="service">Services to expose.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> As(Service service);
     }
 }

--- a/src/Autofac/Builder/ReflectionActivatorData.cs
+++ b/src/Autofac/Builder/ReflectionActivatorData.cs
@@ -108,11 +108,11 @@ namespace Autofac.Builder
         /// <summary>
         /// Gets the explicitly bound constructor parameters.
         /// </summary>
-        public IList<Parameter> ConfiguredParameters { get; } = new List<Parameter>();
+        public List<Parameter> ConfiguredParameters { get; } = new List<Parameter>();
 
         /// <summary>
         /// Gets the explicitly bound properties.
         /// </summary>
-        public IList<Parameter> ConfiguredProperties { get; } = new List<Parameter>();
+        public List<Parameter> ConfiguredProperties { get; } = new List<Parameter>();
     }
 }

--- a/src/Autofac/Builder/RegistrationBuilder.cs
+++ b/src/Autofac/Builder/RegistrationBuilder.cs
@@ -133,7 +133,7 @@ namespace Autofac.Builder
                 builder.RegistrationStyle.Id,
                 builder.RegistrationData,
                 builder.ActivatorData.Activator,
-                builder.RegistrationData.Services,
+                builder.RegistrationData.Services.ToArray(),
                 builder.RegistrationStyle.Target);
         }
 
@@ -149,7 +149,7 @@ namespace Autofac.Builder
             Guid id,
             RegistrationData data,
             IInstanceActivator activator,
-            IEnumerable<Service> services)
+            Service[] services)
         {
             return CreateRegistration(id, data, activator, services, null);
         }
@@ -170,7 +170,7 @@ namespace Autofac.Builder
             Guid id,
             RegistrationData data,
             IInstanceActivator activator,
-            IEnumerable<Service> services,
+            Service[] services,
             IComponentRegistration target)
         {
             if (activator == null) throw new ArgumentNullException(nameof(activator));
@@ -179,11 +179,15 @@ namespace Autofac.Builder
             var limitType = activator.LimitType;
             if (limitType != typeof(object))
             {
-                foreach (var ts in services.OfType<IServiceWithType>())
+                foreach (var ts in services)
                 {
-                    if (!ts.ServiceType.GetTypeInfo().IsAssignableFrom(limitType.GetTypeInfo()))
+                    var asServiceWithType = ts as IServiceWithType;
+                    if (asServiceWithType != null)
                     {
-                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationBuilderResources.ComponentDoesNotSupportService, limitType, ts));
+                        if (!asServiceWithType.ServiceType.GetTypeInfo().IsAssignableFrom(limitType.GetTypeInfo()))
+                        {
+                            throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationBuilderResources.ComponentDoesNotSupportService, limitType, ts));
+                        }
                     }
                 }
             }

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -241,11 +241,24 @@ namespace Autofac.Builder
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> As(params Type[] services)
         {
-            return As(services.Select(t =>
-                t.FullName != null
-                ? new TypedService(t)
-                : new TypedService(t.GetGenericTypeDefinition()))
-                .Cast<Service>().ToArray());
+            Service[] argArray = new Service[services.Length];
+
+            for (int i = 0; i < services.Length; i++)
+            {
+                argArray[i] = new TypedService(services[i]);
+            }
+
+            return As(argArray);
+        }
+
+        /// <summary>
+        /// Configure the services that the component will provide.
+        /// </summary>
+        /// <param name="service">Service types to expose.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> As(Type service)
+        {
+            return As(new TypedService(service));
         }
 
         /// <summary>
@@ -258,6 +271,20 @@ namespace Autofac.Builder
             if (services == null) throw new ArgumentNullException(nameof(services));
 
             RegistrationData.AddServices(services);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Configure the services that the component will provide.
+        /// </summary>
+        /// <param name="service">Services to expose.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> As(Service service)
+        {
+            if (service == null) throw new ArgumentNullException(nameof(service));
+
+            RegistrationData.AddService(service);
 
             return this;
         }

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -245,7 +245,10 @@ namespace Autofac.Builder
 
             for (int i = 0; i < services.Length; i++)
             {
-                argArray[i] = new TypedService(services[i]);
+                if (services[i].FullName != null)
+                    argArray[i] = new TypedService(services[i]);
+                else
+                    argArray[i] = new TypedService(services[i].GetGenericTypeDefinition());
             }
 
             return As(argArray);

--- a/src/Autofac/Builder/RegistrationData.cs
+++ b/src/Autofac/Builder/RegistrationData.cs
@@ -41,7 +41,7 @@ namespace Autofac.Builder
         private bool _defaultServiceOverridden;
         private Service _defaultService;
 
-        private readonly ICollection<Service> _services = new HashSet<Service>();
+        private readonly HashSet<Service> _services = new HashSet<Service>();
 
         private IComponentLifetime _lifetime = new CurrentScopeLifetime();
 
@@ -147,17 +147,17 @@ namespace Autofac.Builder
         /// <summary>
         /// Gets the handlers for the Preparing event.
         /// </summary>
-        public ICollection<EventHandler<PreparingEventArgs>> PreparingHandlers { get; } = new List<EventHandler<PreparingEventArgs>>();
+        public List<EventHandler<PreparingEventArgs>> PreparingHandlers { get; } = new List<EventHandler<PreparingEventArgs>>();
 
         /// <summary>
         /// Gets the handlers for the Activating event.
         /// </summary>
-        public ICollection<EventHandler<ActivatingEventArgs<object>>> ActivatingHandlers { get; } = new List<EventHandler<ActivatingEventArgs<object>>>();
+        public List<EventHandler<ActivatingEventArgs<object>>> ActivatingHandlers { get; } = new List<EventHandler<ActivatingEventArgs<object>>>();
 
         /// <summary>
         /// Gets the handlers for the Activated event.
         /// </summary>
-        public ICollection<EventHandler<ActivatedEventArgs<object>>> ActivatedHandlers { get; } = new List<EventHandler<ActivatedEventArgs<object>>>();
+        public List<EventHandler<ActivatedEventArgs<object>>> ActivatedHandlers { get; } = new List<EventHandler<ActivatedEventArgs<object>>>();
 
         /// <summary>
         /// Copies the contents of another RegistrationData object into this one.

--- a/src/Autofac/Builder/RegistrationData.cs
+++ b/src/Autofac/Builder/RegistrationData.cs
@@ -56,7 +56,7 @@ namespace Autofac.Builder
 
             _defaultService = defaultService;
 
-            Metadata = new Dictionary<string, object>
+            Metadata = new Dictionary<string, object>(1)
             {
                 { MetadataKeys.RegistrationOrderMetadataKey, SequenceGenerator.GetNextUniqueSequence() },
             };

--- a/src/Autofac/Builder/SingleRegistrationStyle.cs
+++ b/src/Autofac/Builder/SingleRegistrationStyle.cs
@@ -42,7 +42,7 @@ namespace Autofac.Builder
         /// <summary>
         /// Gets the handlers to notify of the component registration event.
         /// </summary>
-        public ICollection<EventHandler<ComponentRegisteredEventArgs>> RegisteredHandlers { get; } = new List<EventHandler<ComponentRegisteredEventArgs>>();
+        public List<EventHandler<ComponentRegisteredEventArgs>> RegisteredHandlers { get; } = new List<EventHandler<ComponentRegisteredEventArgs>>();
 
         /// <summary>
         /// Gets or sets a value indicating whether default registrations should be preserved.

--- a/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
@@ -66,7 +66,7 @@ namespace Autofac.Core.Activators.Reflection
         /// <param name="context">Context in which to construct instance.</param>
         public ConstructorParameterBinding(
             ConstructorInfo ci,
-            IEnumerable<Parameter> availableParameters,
+            Parameter[] availableParameters,
             IComponentContext context)
         {
             if (ci == null) throw new ArgumentNullException(nameof(ci));

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -57,8 +57,8 @@ namespace Autofac.Core.Activators.Reflection
             Type implementationType,
             IConstructorFinder constructorFinder,
             IConstructorSelector constructorSelector,
-            IEnumerable<Parameter> configuredParameters,
-            IEnumerable<Parameter> configuredProperties)
+            IList<Parameter> configuredParameters,
+            IList<Parameter> configuredProperties)
             : base(implementationType)
         {
             if (constructorFinder == null) throw new ArgumentNullException(nameof(constructorFinder));
@@ -70,7 +70,14 @@ namespace Autofac.Core.Activators.Reflection
             ConstructorFinder = constructorFinder;
             ConstructorSelector = constructorSelector;
             _configuredProperties = configuredProperties.ToArray();
-            _defaultParameters = configuredParameters.Concat(new Parameter[] { new AutowiringParameter(), new DefaultValueParameter() }).ToArray();
+
+            _defaultParameters = new Parameter[configuredParameters.Count + 2];
+
+            for (int i = 0; i < configuredParameters.Count; i++)
+                _defaultParameters[i] = configuredParameters[i];
+
+            _defaultParameters[_defaultParameters.Length - 2] = new AutowiringParameter();
+            _defaultParameters[_defaultParameters.Length - 1] = new DefaultValueParameter();
         }
 
         /// <summary>

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -135,10 +135,25 @@ namespace Autofac.Core.Activators.Reflection
 
         private ConstructorParameterBinding[] GetValidConstructorBindings(IComponentContext context, IEnumerable<Parameter> parameters)
         {
-            // Most often, there will be no `parameters` and/or no `_defaultParameters`; in both of those cases we can avoid allocating.
-            var prioritisedParameters = parameters.Any() ?
-                (_defaultParameters.Length == 0 ? parameters : parameters.Concat(_defaultParameters)) :
-                _defaultParameters;
+            // Most often, there will be no `parameters`we can avoid allocating.
+            Parameter[] prioritisedParameters;
+            if (parameters is Parameter[] parametersArray)
+            {
+                if (parametersArray.Length == 0)
+                {
+                    prioritisedParameters = _defaultParameters;
+                }
+                else
+                {
+                    prioritisedParameters = new Parameter[_defaultParameters.Length + parametersArray.Length];
+                    Array.Copy(parametersArray, 0, prioritisedParameters, 0, parametersArray.Length);
+                    Array.Copy(_defaultParameters, 0, prioritisedParameters, parametersArray.Length, _defaultParameters.Length);
+                }
+            }
+            else
+            {
+                prioritisedParameters = parameters.Concat(_defaultParameters).ToArray();
+            }
 
             var constructorBindings = new ConstructorParameterBinding[_availableConstructors.Length];
             for (var i = 0; i < _availableConstructors.Length; ++i)

--- a/src/Autofac/Core/IComponentRegistration.cs
+++ b/src/Autofac/Core/IComponentRegistration.cs
@@ -63,7 +63,7 @@ namespace Autofac.Core
         /// <summary>
         /// Gets the services provided by the component.
         /// </summary>
-        IEnumerable<Service> Services { get; }
+        Service[] Services { get; }
 
         /// <summary>
         /// Gets additional data associated with the component.

--- a/src/Autofac/Core/Registration/ComponentRegistration.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistration.cs
@@ -56,20 +56,21 @@ namespace Autofac.Core.Registration
             IComponentLifetime lifetime,
             InstanceSharing sharing,
             InstanceOwnership ownership,
-            IEnumerable<Service> services,
+            Service[] services,
             IDictionary<string, object> metadata)
         {
             if (activator == null) throw new ArgumentNullException(nameof(activator));
             if (lifetime == null) throw new ArgumentNullException(nameof(lifetime));
             if (services == null) throw new ArgumentNullException(nameof(services));
             if (metadata == null) throw new ArgumentNullException(nameof(metadata));
+            Enforce.ArgumentElementNotNull(services, nameof(services));
 
             Id = id;
             Activator = activator;
             Lifetime = lifetime;
             Sharing = sharing;
             Ownership = ownership;
-            Services = Enforce.ArgumentElementNotNull(services, nameof(services));
+            Services = services;
             Metadata = metadata;
         }
 
@@ -90,7 +91,7 @@ namespace Autofac.Core.Registration
             IComponentLifetime lifetime,
             InstanceSharing sharing,
             InstanceOwnership ownership,
-            IEnumerable<Service> services,
+            Service[] services,
             IDictionary<string, object> metadata,
             IComponentRegistration target)
             : this(id, activator, lifetime, sharing, ownership, services, metadata)
@@ -135,7 +136,7 @@ namespace Autofac.Core.Registration
         /// <summary>
         /// Gets the services provided by the component.
         /// </summary>
-        public IEnumerable<Service> Services { get; }
+        public Service[] Services { get; }
 
         /// <summary>
         /// Gets additional data associated with the component.

--- a/src/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
@@ -54,7 +54,7 @@ namespace Autofac.Core.Registration
 
         public InstanceOwnership Ownership => _inner.Ownership;
 
-        public IEnumerable<Service> Services => _inner.Services;
+        public Service[] Services => _inner.Services;
 
         public IDictionary<string, object> Metadata => _inner.Metadata;
 

--- a/src/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistry.cs
@@ -52,17 +52,17 @@ namespace Autofac.Core.Registration
         /// <summary>
         /// External registration sources.
         /// </summary>
-        private readonly IList<IRegistrationSource> _dynamicRegistrationSources = new List<IRegistrationSource>();
+        private readonly List<IRegistrationSource> _dynamicRegistrationSources = new List<IRegistrationSource>();
 
         /// <summary>
         /// All registrations.
         /// </summary>
-        private readonly ICollection<IComponentRegistration> _registrations = new List<IComponentRegistration>();
+        private readonly List<IComponentRegistration> _registrations = new List<IComponentRegistration>();
 
         /// <summary>
         /// Keeps track of the status of registered services.
         /// </summary>
-        private readonly IDictionary<Service, ServiceRegistrationInfo> _serviceInfo = new Dictionary<Service, ServiceRegistrationInfo>();
+        private readonly Dictionary<Service, ServiceRegistrationInfo> _serviceInfo = new Dictionary<Service, ServiceRegistrationInfo>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ComponentRegistry"/> class.
@@ -162,12 +162,17 @@ namespace Autofac.Core.Registration
 
         private void UpdateInitialisedAdapters(IComponentRegistration registration)
         {
-            var adapterServices = _serviceInfo
-                .Where(si => si.Value.ShouldRecalculateAdaptersOn(registration))
-                .Select(si => si.Key)
-                .ToArray();
+            List<Service> adapterServices = new List<Service>();
 
-            if (adapterServices.Length == 0)
+            foreach (var serviceInfo in _serviceInfo)
+            {
+                if (serviceInfo.Value.ShouldRecalculateAdaptersOn(registration))
+                {
+                    adapterServices.Add(serviceInfo.Key);
+                }
+            }
+
+            if (adapterServices.Count == 0)
                 return;
 
             Debug.WriteLine(

--- a/src/Autofac/Core/Registration/ExternalRegistrySource.cs
+++ b/src/Autofac/Core/Registration/ExternalRegistrySource.cs
@@ -105,7 +105,7 @@ namespace Autofac.Core.Registration
         /// </summary>
         private class ExternalComponentRegistration : ComponentRegistration
         {
-            public ExternalComponentRegistration(Guid id, IInstanceActivator activator, IComponentLifetime lifetime, InstanceSharing sharing, InstanceOwnership ownership, IEnumerable<Service> services, IDictionary<string, object> metadata, IComponentRegistration target)
+            public ExternalComponentRegistration(Guid id, IInstanceActivator activator, IComponentLifetime lifetime, InstanceSharing sharing, InstanceOwnership ownership, Service[] services, IDictionary<string, object> metadata, IComponentRegistration target)
                 : base(id, activator, lifetime, sharing, ownership, services, metadata, target)
             {
             }

--- a/src/Autofac/Core/Resolving/CircularDependencyDetector.cs
+++ b/src/Autofac/Core/Resolving/CircularDependencyDetector.cs
@@ -61,8 +61,11 @@ namespace Autofac.Core.Resolving
                 throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.MaxDepthExceeded, registration));
 
             // Checks for circular dependency
-            if (activationStack.Any(a => a.ComponentRegistration == registration))
-                throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.CircularDependency, CreateDependencyGraphTo(registration, activationStack)));
+            foreach (var a in activationStack)
+            {
+                if (a.ComponentRegistration == registration)
+                    throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.CircularDependency, CreateDependencyGraphTo(registration, activationStack)));
+            }
         }
     }
 }

--- a/src/Autofac/Directory.Build.props
+++ b/src/Autofac/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Workaround for https://github.com/dotnet/sdk/pull/908 -->
+  <Target Name="GetPackagingOutputs" />
+</Project>

--- a/src/Autofac/Directory.Build.props
+++ b/src/Autofac/Directory.Build.props
@@ -1,4 +1,0 @@
-<Project>
-  <!-- Workaround for https://github.com/dotnet/sdk/pull/908 -->
-  <Target Name="GetPackagingOutputs" />
-</Project>

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -84,7 +84,7 @@ namespace Autofac.Features.OpenGenerics
                 (pi, c) => c.ResolveComponent(decoratedComponent, Enumerable.Empty<Parameter>()));
 
             var resultArray = new Parameter[configuredParameters.Count + 1];
-            resultArray[1] = parameter;
+            resultArray[0] = parameter;
 
             for (int i = 0; i < configuredParameters.Count; i++)
                 resultArray[i + 1] = configuredParameters[i];

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -60,7 +60,7 @@ namespace Autofac.Features.OpenGenerics
             if (registrationAccessor == null) throw new ArgumentNullException(nameof(registrationAccessor));
 
             Type constructedImplementationType;
-            IEnumerable<Service> services;
+            Service[] services;
             if (OpenGenericServiceBinder.TryBindServiceType(service, _registrationData.Services, _activatorData.ImplementationType, out constructedImplementationType, out services))
             {
                 var swt = (IServiceWithType)service;
@@ -77,13 +77,19 @@ namespace Autofac.Features.OpenGenerics
             return Enumerable.Empty<IComponentRegistration>();
         }
 
-        private static IEnumerable<Parameter> AddDecoratedComponentParameter(Type decoratedParameterType, IComponentRegistration decoratedComponent, IEnumerable<Parameter> configuredParameters)
+        private static IList<Parameter> AddDecoratedComponentParameter(Type decoratedParameterType, IComponentRegistration decoratedComponent, IList<Parameter> configuredParameters)
         {
             var parameter = new ResolvedParameter(
                 (pi, c) => pi.ParameterType == decoratedParameterType,
                 (pi, c) => c.ResolveComponent(decoratedComponent, Enumerable.Empty<Parameter>()));
 
-            return new[] { parameter }.Concat(configuredParameters);
+            var resultArray = new Parameter[configuredParameters.Count + 1];
+            resultArray[1] = parameter;
+
+            for (int i = 0; i < configuredParameters.Count; i++)
+                resultArray[i + 1] = configuredParameters[i];
+
+            return resultArray;
         }
 
         public bool IsAdapterForIndividualComponents => true;

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
@@ -60,7 +60,7 @@ namespace Autofac.Features.OpenGenerics
             if (registrationAccessor == null) throw new ArgumentNullException(nameof(registrationAccessor));
 
             Type constructedImplementationType;
-            IEnumerable<Service> services;
+            Service[] services;
             if (OpenGenericServiceBinder.TryBindServiceType(service, _registrationData.Services, _activatorData.ImplementationType, out constructedImplementationType, out services))
             {
                 yield return RegistrationBuilder.CreateRegistration(

--- a/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -41,7 +41,7 @@ namespace Autofac.Features.OpenGenerics
             IEnumerable<Service> configuredOpenGenericServices,
             Type openGenericImplementationType,
             out Type constructedImplementationType,
-            out IEnumerable<Service> constructedServices)
+            out Service[] constructedServices)
         {
             var swt = service as IServiceWithType;
             if (swt != null && swt.ServiceType.GetTypeInfo().IsGenericType)

--- a/src/Autofac/ModuleRegistrationExtensions.cs
+++ b/src/Autofac/ModuleRegistrationExtensions.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Core.Registration;
 
@@ -164,7 +165,7 @@ namespace Autofac
                 .Where(t => moduleType.GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()))
                 .As<IModule>();
 
-            using (var moduleContainer = moduleFinder.Build())
+            using (var moduleContainer = moduleFinder.Build(ContainerBuildOptions.None))
             {
                 foreach (var module in moduleContainer.Resolve<IEnumerable<IModule>>())
                 {

--- a/test/Autofac.Test/ContainerBuilderTests.cs
+++ b/test/Autofac.Test/ContainerBuilderTests.cs
@@ -369,7 +369,7 @@ namespace Autofac.Test
         public void WhenBuildingWithDefaultsExcluded_DefaultModulesAreExcluded()
         {
             var builder = new ContainerBuilder();
-            var container = builder.Build(ContainerBuildOptions.ExcludeDefaultModules);
+            var container = builder.Build(ContainerBuildOptions.None, DefaultServiceFlags.None);
             Assert.False(container.IsRegistered<IEnumerable<object>>());
         }
 

--- a/test/Autofac.Test/Factory.cs
+++ b/test/Autofac.Test/Factory.cs
@@ -33,7 +33,7 @@ namespace Autofac.Test
                 lifetime,
                 sharing,
                 InstanceOwnership.OwnedByLifetimeScope,
-                services,
+                services.ToArray(),
                 GetDefaultMetadata());
         }
 
@@ -78,8 +78,8 @@ namespace Autofac.Test
                 implementation,
                 new DefaultConstructorFinder(),
                 new MostParametersConstructorSelector(),
-                parameters,
-                properties);
+                parameters.ToArray(),
+                properties.ToArray());
         }
 
         public static ProvidedInstanceActivator CreateProvidedInstanceActivator(object instance)
@@ -99,8 +99,8 @@ namespace Autofac.Test
 
         public static readonly IComponentContext EmptyContext = new Container();
 
-        public static readonly IEnumerable<Parameter> NoParameters = Enumerable.Empty<Parameter>();
+        public static readonly Parameter[] NoParameters = new Parameter[0];
 
-        public static readonly IEnumerable<Parameter> NoProperties = Enumerable.Empty<Parameter>();
+        public static readonly Parameter[] NoProperties = new Parameter[0];
     }
 }

--- a/test/Autofac.Test/Mocks.cs
+++ b/test/Autofac.Test/Mocks.cs
@@ -73,7 +73,7 @@ namespace Autofac.Test
 
             public InstanceOwnership Ownership { get; }
 
-            public IEnumerable<Service> Services { get; } = new Service[0];
+            public Service[] Services { get; } = new Service[0];
 
             public IDictionary<string, object> Metadata { get; }
 


### PR DESCRIPTION
Hi!

I work on mobile games written in C#/Xamarin, and start time is a bit critical there.
To improve it a bit, i slightly optimized Autofac memory allocations during registration phase to get rid of some simple ones:
1. foreach over interface (boxing of struct iterator)
2. allocation of iterators inside LINQ calls
3. allocation of delegates for LINQ calls 

Also i introduced a bit more fine-grained control of default services.

In my codebase with 1600 registrations results are following:
4.8.1: 122K allocations (3.45MB), 80K collected (2.2MB)
4.8.1+PR: 82K allocations (2.25MB), 46K collected (1.20MB)

Speedup was about ~10% on .NET 4.6 (No sample, made 10 runs with logging of Stopwatch and compared best timings). 

We use this fork for over a year, and i though someone else could find it useful.

TO BE UPDATED: I'll add some runtime optimizations (Resolve-time)