### PR TITLE
Allow configuration of circular dependency max resolve depth in the container builder.

### DIFF
--- a/src/Autofac/ContainerBuilder.cs
+++ b/src/Autofac/ContainerBuilder.cs
@@ -30,6 +30,7 @@ using System.Globalization;
 using System.Linq;
 using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Core.Resolving;
 using Autofac.Features.Collections;
 using Autofac.Features.GeneratedFactories;
 using Autofac.Features.Indexed;
@@ -97,6 +98,17 @@ namespace Autofac
         /// context across registrations.
         /// </value>
         public IDictionary<string, object> Properties { get; }
+
+        /// <summary>
+        /// Sets the maximum size of the stack used when resolving a single component (and all of its transitive dependencies) from the container.
+        /// If this limit is exceeded the component will be treated as a circular dependency.
+        /// </summary>
+        /// <param name="maximumStackDepth">Maximum size of the stack used for resolve operations.</param>
+        public ContainerBuilder WithMaxResolveStackDepth(int maximumStackDepth)
+        {
+            Properties[CircularDependencyDetector.MaxResolveStackDepthPropertyName] = maximumStackDepth;
+            return this;
+        }
 
         /// <summary>
         /// Register a callback that will be invoked when the container is configured.

--- a/src/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperation.cs
@@ -112,7 +112,7 @@ namespace Autofac.Core.Resolving
 
             ++_callDepth;
 
-            if (_activationStack.Count > 0) CircularDependencyDetector.CheckForCircularDependency(registration, _activationStack, _callDepth);
+            if (_activationStack.Count > 0) CircularDependencyDetector.CheckForCircularDependency(currentOperationScope, registration, _activationStack, _callDepth);
 
             var activation = new InstanceLookup(registration, this, currentOperationScope, parameters);
 


### PR DESCRIPTION
This comes from my comments in #798 regarding problems I have with the current circular dependency implementation. Hopefully the unit test demonstrates the problem clearly.

The current circular dependency stack limit is set to 50, however in practice depending on how your scopes are configured this limit is lower due to how inner scopes are implemented. The web application I work with creates a separate scope for each request, with the majority of component registrations coming from the root container. I noticed that resolving a component from an inner scope that has dependencies registered in an outer scope creates an internal DelegateActivator for each dependency as an intermediate between the two scopes. This is in addition to the normal ReflectionActivator, so in effect the stack limit can be reduced to 25 in this situation. If your application has a very deep dependency graph, it is quite easy to exceed this 25 limit.

What I propose is a low-friction workaround by making this limit configurable in the container builder so I can at least increase the limit for my application without having to resort to adding Lazy<> registrations to arbitrary places in the dependency tree to "reset" the stack.