### PR TITLE
Inherit Registered callback in child scopes (closes #218)

### DIFF
--- a/src/Autofac/Builder/MetadataKeys.cs
+++ b/src/Autofac/Builder/MetadataKeys.cs
@@ -34,5 +34,7 @@ namespace Autofac.Builder
         internal const string StartOnActivatePropertyKey = "__StartOnActivate";
 
         internal const string ContainerBuildOptions = "__ContainerBuildOptions";
+
+        internal const string RegisteredPropertyKey = "__RegisteredKey";
     }
 }


### PR DESCRIPTION
Makes module behavior more consistent in lifetime scopes and my log4net module PR obsolete.