### PR TITLE
Fix lock contention #941 #906

### DIFF
--- a/src/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistry.cs
@@ -118,6 +118,7 @@ namespace Autofac.Core.Registration
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
 
+            // get without lock if already registered
             var info = GetInitializedServiceInfoOrDefault(service);
             if (info != null && info.TryGetRegistration(out registration))
             {
@@ -131,18 +132,6 @@ namespace Autofac.Core.Registration
             }
         }
 
-        private IComponentRegistration GetIfRegisteredAndInitializedOrDefault(Service service)
-        {
-            var info = GetInitializedServiceInfoOrDefault(service);
-            if (info != null && info.IsInitialized)
-            {
-                if (info.TryGetRegistration(out var registration))
-                    return registration;
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Determines whether the specified service is registered.
         /// </summary>
@@ -152,9 +141,12 @@ namespace Autofac.Core.Registration
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
 
+            // get without lock if already registered
             var info = GetInitializedServiceInfoOrDefault(service);
             if (info != null && info.IsRegistered)
+            {
                 return true;
+            }
 
             lock (_synchRoot)
             {
@@ -255,6 +247,7 @@ namespace Autofac.Core.Registration
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
 
+            // get without lock if already registered
             var info = GetInitializedServiceInfoOrDefault(service);
             if (info != null)
             {

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -173,10 +173,10 @@ namespace Autofac.Core.Registration
                         Volatile.Write(ref _preserveDefaultImplementations, new List<IComponentRegistration>());
                     }
 
-                    var newpreserveDefaultImplementations = new List<IComponentRegistration>(Volatile.Read(ref _preserveDefaultImplementations));
-                    newpreserveDefaultImplementations.Add(registration);
+                    var newPreserveDefaultImplementations = new List<IComponentRegistration>(Volatile.Read(ref _preserveDefaultImplementations));
+                    newPreserveDefaultImplementations.Add(registration);
 
-                    Volatile.Write(ref _preserveDefaultImplementations, newpreserveDefaultImplementations);
+                    Volatile.Write(ref _preserveDefaultImplementations, newPreserveDefaultImplementations);
                 }
             }
             else


### PR DESCRIPTION
Nolock solution for `TryGetRegistration`, `IsRegistered`, `RegistrationsFor`. Issues: #941, #906

For case when `ServiceRegistrationInfo` is already exists and `IsInitialized`, i.e. after service was Resolved once.

There can be little memory overhead during initialization, but that is a small price for allowing it to work in multi-core high load environment.