### PR TITLE
Match non-interface constraints using IsClosedTypeOf

### DIFF
--- a/test/Autofac.Test/Features/OpenGenerics/ComplexGenericsTests.cs
+++ b/test/Autofac.Test/Features/OpenGenerics/ComplexGenericsTests.cs
@@ -187,7 +187,7 @@ namespace Autofac.Test.Features.OpenGenerics
             Assert.True(container.IsRegistered<Constrained<int, IConstraint<int>>>());
         }
 
-        [Fact(Skip = "Issue #972")]
+        [Fact]
         public void CanResolveComponentWithNestedEnumerableConstraint()
         {
             // Issue #972


### PR DESCRIPTION
This addresses #972 by looking for non-interface generic type constraints and verifying all of the parameter's base type's generic type arguments are closed types of the constraint. Note: there may be additional cases of nesting that need to be tested and verified. I fixed the one that had a test case.