### PR TITLE
Faster RegisterAssemblyTypes

### DIFF
--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -88,8 +88,8 @@ namespace Autofac.Features.Scanning
                     !t.GetTypeInfo().IsAbstract &&
                     !t.GetTypeInfo().IsGenericTypeDefinition &&
                     !t.IsDelegate() &&
-                    !t.IsCompilerGenerated() &&
-                    rb.ActivatorData.Filters.All(p => p(t))))
+                    rb.ActivatorData.Filters.All(p => p(t)) &&
+                    !t.IsCompilerGenerated()))
             {
                 var scanned = RegistrationBuilder.ForType(t)
                     .FindConstructorsWith(rb.ActivatorData.ConstructorFinder)

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>

--- a/test/Autofac.Specification.Test/Registration/AssemblyScanningPerformanceTests.cs
+++ b/test/Autofac.Specification.Test/Registration/AssemblyScanningPerformanceTests.cs
@@ -1,0 +1,33 @@
+namespace Autofac.Specification.Test.Registration
+{
+    using System.Diagnostics;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class AssemblyScanningPerformanceTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public AssemblyScanningPerformanceTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void MeasurePerformance()
+        {
+            var builder = new ContainerBuilder();
+            for (var i = 0; i < 1000; i++)
+            {
+                //just to simulate a lot of "scanning" with few (in this case zero) "hits"
+                builder.RegisterAssemblyTypes(GetType().Assembly).Where(x => false);
+            }
+
+            var stopwatch = Stopwatch.StartNew();
+            builder.Build().Dispose();
+
+            //after fix drops from ~500ms to ~100ms
+            output.WriteLine(stopwatch.Elapsed.TotalMilliseconds.ToString());
+        }
+    }
+}


### PR DESCRIPTION
We use autofac in lots of our tests where a new container is created for each test, so fast container creation is important for us. When looking at what takes time for us, it's the "IsCompilerGenerated" call which internally looks for custom attributes.

Perf dump from our env when we run some of our tests...
![image](https://user-images.githubusercontent.com/1101237/59288486-31234200-8c74-11e9-804d-9bd2934046ea.png)

This fix simply moves this check to after "the filters". In most cases this should be more optimal (not that often there's _lots_ of types marked with [CompilerGenerated] anyhow).

The "test"/example in this PR is about 80% faster after this fix.
