### PR TITLE
Provide the Service being resolved to ResolveComponent method

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.9.3.{build}
+version: 5.0.0.{build}
 
 configuration: Release
 

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
-    <VersionPrefix>4.9.3</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard1.1;net45</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -4,6 +4,7 @@
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>4.9.3</VersionPrefix>
     <TargetFrameworks>netstandard2.0;netstandard1.1;net45</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Autofac/Builder/StartableManager.cs
+++ b/src/Autofac/Builder/StartableManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
 using Autofac.Core;
 
@@ -28,7 +27,8 @@ namespace Autofac.Builder
                 {
                     try
                     {
-                        componentContext.ResolveComponent(startableService, registration, Enumerable.Empty<Parameter>());
+                        var request = new ResolveRequest(startableService, registration, Enumerable.Empty<Parameter>());
+                        componentContext.ResolveComponent(request);
                     }
                     finally
                     {
@@ -41,7 +41,8 @@ namespace Autofac.Builder
                 {
                     try
                     {
-                        componentContext.ResolveComponent(autoActivateService, registration, Enumerable.Empty<Parameter>());
+                        var request = new ResolveRequest(autoActivateService, registration, Enumerable.Empty<Parameter>());
+                        componentContext.ResolveComponent(request);
                     }
                     catch (DependencyResolutionException ex)
                     {

--- a/src/Autofac/Builder/StartableManager.cs
+++ b/src/Autofac/Builder/StartableManager.cs
@@ -23,23 +23,25 @@ namespace Autofac.Builder
                 // We track which registrations have already been auto-activated by adding
                 // a metadata value. If the value is present, we won't re-activate. This helps
                 // in the container update situation.
-                foreach (var startable in componentRegistry.RegistrationsFor(new TypedService(typeof(IStartable))).Where(r => !r.Metadata.ContainsKey(MetadataKeys.AutoActivated)))
+                var startableService = new TypedService(typeof(IStartable));
+                foreach (var registration in componentRegistry.RegistrationsFor(startableService).Where(r => !r.Metadata.ContainsKey(MetadataKeys.AutoActivated)))
                 {
                     try
                     {
-                        componentContext.ResolveComponent(startable, Enumerable.Empty<Parameter>());
+                        componentContext.ResolveComponent(startableService, registration, Enumerable.Empty<Parameter>());
                     }
                     finally
                     {
-                        startable.Metadata[MetadataKeys.AutoActivated] = true;
+                        registration.Metadata[MetadataKeys.AutoActivated] = true;
                     }
                 }
 
-                foreach (var registration in componentRegistry.RegistrationsFor(new AutoActivateService()).Where(r => !r.Metadata.ContainsKey(MetadataKeys.AutoActivated)))
+                var autoActivateService = new AutoActivateService();
+                foreach (var registration in componentRegistry.RegistrationsFor(autoActivateService).Where(r => !r.Metadata.ContainsKey(MetadataKeys.AutoActivated)))
                 {
                     try
                     {
-                        componentContext.ResolveComponent(registration, Enumerable.Empty<Parameter>());
+                        componentContext.ResolveComponent(autoActivateService, registration, Enumerable.Empty<Parameter>());
                     }
                     catch (DependencyResolutionException ex)
                     {

--- a/src/Autofac/Core/Activators/Reflection/AutowiringParameter.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringParameter.cs
@@ -54,7 +54,7 @@ namespace Autofac.Core.Activators.Reflection
             var service = new TypedService(pi.ParameterType);
             if (context.ComponentRegistry.TryGetRegistration(service, out var registration))
             {
-                valueProvider = () => context.ResolveComponent(service, registration, Enumerable.Empty<Parameter>());
+                valueProvider = () => context.ResolveComponent(new ResolveRequest(service, registration, Enumerable.Empty<Parameter>()));
                 return true;
             }
 

--- a/src/Autofac/Core/Activators/Reflection/AutowiringParameter.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringParameter.cs
@@ -51,10 +51,10 @@ namespace Autofac.Core.Activators.Reflection
             if (pi == null) throw new ArgumentNullException(nameof(pi));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            IComponentRegistration registration;
-            if (context.ComponentRegistry.TryGetRegistration(new TypedService(pi.ParameterType), out registration))
+            var service = new TypedService(pi.ParameterType);
+            if (context.ComponentRegistry.TryGetRegistration(service, out var registration))
             {
-                valueProvider = () => context.ResolveComponent(registration, Enumerable.Empty<Parameter>());
+                valueProvider = () => context.ResolveComponent(service, registration, Enumerable.Empty<Parameter>());
                 return true;
             }
 

--- a/src/Autofac/Core/Container.cs
+++ b/src/Autofac/Core/Container.cs
@@ -155,19 +155,10 @@ namespace Autofac.Core
         /// </summary>
         public IComponentRegistry ComponentRegistry { get; }
 
-        /// <summary>
-        /// Resolve an instance of the provided registration within the context.
-        /// </summary>
-        /// <param name="registration">The registration.</param>
-        /// <param name="parameters">Parameters for the instance.</param>
-        /// <returns>
-        /// The component instance.
-        /// </returns>
-        /// <exception cref="ComponentNotRegisteredException"/>
-        /// <exception cref="DependencyResolutionException"/>
-        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        /// <inheritdoc />
+        public object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
         {
-            return _rootLifetimeScope.ResolveComponent(registration, parameters);
+            return _rootLifetimeScope.ResolveComponent(service, registration, parameters);
         }
 
         /// <summary>

--- a/src/Autofac/Core/Container.cs
+++ b/src/Autofac/Core/Container.cs
@@ -156,9 +156,9 @@ namespace Autofac.Core
         public IComponentRegistry ComponentRegistry { get; }
 
         /// <inheritdoc />
-        public object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object ResolveComponent(ResolveRequest request)
         {
-            return _rootLifetimeScope.ResolveComponent(service, registration, parameters);
+            return _rootLifetimeScope.ResolveComponent(request);
         }
 
         /// <summary>

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -25,7 +25,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -260,17 +259,16 @@ namespace Autofac.Core.Lifetime
         }
 
         /// <inheritdoc />
-        public object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object ResolveComponent(ResolveRequest request)
         {
-            if (registration == null) throw new ArgumentNullException(nameof(registration));
-            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
+            if (request == null) throw new ArgumentNullException(nameof(request));
 
             CheckNotDisposed();
 
             var operation = new ResolveOperation(this);
             var handler = ResolveOperationBeginning;
             handler?.Invoke(this, new ResolveOperationBeginningEventArgs(operation));
-            return operation.Execute(service, registration, parameters);
+            return operation.Execute(request);
         }
 
         /// <summary>

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -259,17 +259,8 @@ namespace Autofac.Core.Lifetime
             return locals;
         }
 
-        /// <summary>
-        /// Resolve an instance of the provided registration within the context.
-        /// </summary>
-        /// <param name="registration">The registration.</param>
-        /// <param name="parameters">Parameters for the instance.</param>
-        /// <returns>
-        /// The component instance.
-        /// </returns>
-        /// <exception cref="Autofac.Core.Registration.ComponentNotRegisteredException"/>
-        /// <exception cref="DependencyResolutionException"/>
-        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        /// <inheritdoc />
+        public object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
             if (parameters == null) throw new ArgumentNullException(nameof(parameters));
@@ -279,7 +270,7 @@ namespace Autofac.Core.Lifetime
             var operation = new ResolveOperation(this);
             var handler = ResolveOperationBeginning;
             handler?.Invoke(this, new ResolveOperationBeginningEventArgs(operation));
-            return operation.Execute(registration, parameters);
+            return operation.Execute(service, registration, parameters);
         }
 
         /// <summary>

--- a/src/Autofac/Core/Registration/ExternalRegistrySource.cs
+++ b/src/Autofac/Core/Registration/ExternalRegistrySource.cs
@@ -80,7 +80,7 @@ namespace Autofac.Core.Registration
                     //        .CreateRegistration()
                     new ExternalComponentRegistration(
                         Guid.NewGuid(),
-                        new DelegateActivator(r.Activator.LimitType, (c, p) => c.ResolveComponent(r, p)),
+                        new DelegateActivator(r.Activator.LimitType, (c, p) => c.ResolveComponent(service, r, p)),
                         new CurrentScopeLifetime(),
                         InstanceSharing.None,
                         InstanceOwnership.ExternallyOwned,

--- a/src/Autofac/Core/Registration/ExternalRegistrySource.cs
+++ b/src/Autofac/Core/Registration/ExternalRegistrySource.cs
@@ -80,7 +80,7 @@ namespace Autofac.Core.Registration
                     //        .CreateRegistration()
                     new ExternalComponentRegistration(
                         Guid.NewGuid(),
-                        new DelegateActivator(r.Activator.LimitType, (c, p) => c.ResolveComponent(service, r, p)),
+                        new DelegateActivator(r.Activator.LimitType, (c, p) => c.ResolveComponent(new ResolveRequest(service, r, p))),
                         new CurrentScopeLifetime(),
                         InstanceSharing.None,
                         InstanceOwnership.ExternallyOwned,

--- a/src/Autofac/Core/Resolving/IResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/IResolveOperation.cs
@@ -38,10 +38,11 @@ namespace Autofac.Core.Resolving
         /// Get or create and share an instance of <paramref name="registration"/> in the <paramref name="currentOperationScope"/>.
         /// </summary>
         /// <param name="currentOperationScope">The scope in the hierarchy in which the operation will begin.</param>
+        /// <param name="service">The service to activate.</param>
         /// <param name="registration">The component to resolve.</param>
         /// <param name="parameters">Parameters for the component.</param>
         /// <returns>The component instance.</returns>
-        object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, IComponentRegistration registration, IEnumerable<Parameter> parameters);
+        object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters);
 
         /// <summary>
         /// Raised when the entire operation is complete.

--- a/src/Autofac/Core/Resolving/IResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/IResolveOperation.cs
@@ -24,7 +24,6 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-using System.Collections.Generic;
 
 namespace Autofac.Core.Resolving
 {
@@ -35,14 +34,12 @@ namespace Autofac.Core.Resolving
     public interface IResolveOperation
     {
         /// <summary>
-        /// Get or create and share an instance of <paramref name="registration"/> in the <paramref name="currentOperationScope"/>.
+        /// Get or create and share an instance of the requested service in the <paramref name="currentOperationScope"/>.
         /// </summary>
         /// <param name="currentOperationScope">The scope in the hierarchy in which the operation will begin.</param>
-        /// <param name="service">The service to activate.</param>
-        /// <param name="registration">The component to resolve.</param>
-        /// <param name="parameters">Parameters for the component.</param>
+        /// <param name="request">The resolve request.</param>
         /// <returns>The component instance.</returns>
-        object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters);
+        object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request);
 
         /// <summary>
         /// Raised when the entire operation is complete.

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -38,6 +38,7 @@ namespace Autofac.Core.Resolving
     [SuppressMessage("Microsoft.ApiDesignGuidelines", "CA2213", Justification = "The instance lookup activation scope gets disposed of by the creator of the scope.")]
     internal class InstanceLookup : IComponentContext, IInstanceLookup
     {
+        private readonly Service _service;
         private readonly IResolveOperation _context;
         private readonly ISharingLifetimeScope _activationScope;
         private object _newInstance;
@@ -45,6 +46,7 @@ namespace Autofac.Core.Resolving
         private const string ActivatorChainExceptionData = "ActivatorChain";
 
         public InstanceLookup(
+            Service service,
             IComponentRegistration registration,
             IResolveOperation context,
             ISharingLifetimeScope mostNestedVisibleScope,
@@ -52,6 +54,7 @@ namespace Autofac.Core.Resolving
         {
             Parameters = parameters;
             ComponentRegistration = registration;
+            _service = service;
             _context = context;
 
             try
@@ -182,9 +185,9 @@ namespace Autofac.Core.Resolving
 
         public IComponentRegistry ComponentRegistry => _activationScope.ComponentRegistry;
 
-        public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
         {
-            return _context.GetOrCreateInstance(_activationScope, registration, parameters);
+            return _context.GetOrCreateInstance(_activationScope, service, registration, parameters);
         }
 
         public IComponentRegistration ComponentRegistration { get; }

--- a/src/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperation.cs
@@ -54,25 +54,23 @@ namespace Autofac.Core.Resolving
         }
 
         /// <inheritdoc />
-        public object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object ResolveComponent(ResolveRequest request)
         {
-            return GetOrCreateInstance(_mostNestedLifetimeScope, service, registration, parameters);
+            return GetOrCreateInstance(_mostNestedLifetimeScope, request);
         }
 
         /// <summary>
         /// Execute the complete resolve operation.
         /// </summary>
-        /// <param name="service">The service to resolve.</param>
-        /// <param name="registration">The registration.</param>
-        /// <param name="parameters">Parameters for the instance.</param>
+        /// <param name="request">The resolution context.</param>
         [SuppressMessage("CA1031", "CA1031", Justification = "General exception gets rethrown in a DependencyResolutionException.")]
-        public object Execute(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object Execute(ResolveRequest request)
         {
             object result;
 
             try
             {
-                result = ResolveComponent(service, registration, parameters);
+                result = ResolveComponent(request);
             }
             catch (ObjectDisposedException)
             {
@@ -94,24 +92,23 @@ namespace Autofac.Core.Resolving
         }
 
         /// <summary>
-        /// Continue building the object graph by instantiating <paramref name="registration"/> in the
+        /// Continue building the object graph by instantiating <paramref name="request"/> in the
         /// current <paramref name="currentOperationScope"/>.
         /// </summary>
-        /// <param name="service">The service to activate.</param>
         /// <param name="currentOperationScope">The current scope of the operation.</param>
-        /// <param name="registration">The component to activate.</param>
-        /// <param name="parameters">The parameters for the component.</param>
+        /// <param name="request">The resolve request.</param>
         /// <returns>The resolved instance.</returns>
         /// <exception cref="ArgumentNullException"/>
-        public object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        public object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request)
         {
             if (_ended) throw new ObjectDisposedException(ResolveOperationResources.TemporaryContextDisposed, innerException: null);
 
             ++_callDepth;
 
-            if (_activationStack.Count > 0) CircularDependencyDetector.CheckForCircularDependency(registration, _activationStack, _callDepth);
+            if (_activationStack.Count > 0)
+                CircularDependencyDetector.CheckForCircularDependency(request.Registration, _activationStack, _callDepth);
 
-            var activation = new InstanceLookup(service, registration, this, currentOperationScope, parameters);
+            var activation = new InstanceLookup(this, currentOperationScope, request);
 
             _activationStack.Push(activation);
 

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -116,7 +116,7 @@ namespace Autofac.Features.Collections
                 (c, p) =>
                 {
                     var elements = c.ComponentRegistry.RegistrationsFor(elementTypeService).OrderBy(cr => cr.GetRegistrationOrder());
-                    var items = elements.Select(cr => c.ResolveComponent(cr, p));
+                    var items = elements.Select(cr => c.ResolveComponent(elementTypeService, cr, p));
 
                     return generator(items);
                 });

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -116,7 +116,7 @@ namespace Autofac.Features.Collections
                 (c, p) =>
                 {
                     var elements = c.ComponentRegistry.RegistrationsFor(elementTypeService).OrderBy(cr => cr.GetRegistrationOrder());
-                    var items = elements.Select(cr => c.ResolveComponent(elementTypeService, cr, p));
+                    var items = elements.Select(cr => c.ResolveComponent(new ResolveRequest(elementTypeService, cr, p)));
 
                     return generator(items);
                 });

--- a/src/Autofac/Features/Decorators/InstanceDecorator.cs
+++ b/src/Autofac/Features/Decorators/InstanceDecorator.cs
@@ -71,7 +71,7 @@ namespace Autofac.Features.Decorators
                 var serviceParameter = new TypedParameter(serviceType, instance);
                 var contextParameter = new TypedParameter(typeof(IDecoratorContext), decoratorContext);
                 var invokeParameters = resolveParameters.Concat(new Parameter[] { serviceParameter, contextParameter });
-                instance = context.ResolveComponent(decorator.Registration, invokeParameters);
+                instance = context.ResolveComponent(decorator.Service, decorator.Registration, invokeParameters);
 
                 decoratorContext = decoratorContext.UpdateContext(instance);
             }

--- a/src/Autofac/Features/Decorators/InstanceDecorator.cs
+++ b/src/Autofac/Features/Decorators/InstanceDecorator.cs
@@ -71,7 +71,7 @@ namespace Autofac.Features.Decorators
                 var serviceParameter = new TypedParameter(serviceType, instance);
                 var contextParameter = new TypedParameter(typeof(IDecoratorContext), decoratorContext);
                 var invokeParameters = resolveParameters.Concat(new Parameter[] { serviceParameter, contextParameter });
-                instance = context.ResolveComponent(decorator.Service, decorator.Registration, invokeParameters);
+                instance = context.ResolveComponent(new ResolveRequest(decorator.Service, decorator.Registration, invokeParameters));
 
                 decoratorContext = decoratorContext.UpdateContext(instance);
             }

--- a/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
+++ b/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
@@ -77,11 +77,13 @@ namespace Autofac.Features.GeneratedFactories
         /// <summary>
         /// Initializes a new instance of the <see cref="FactoryGenerator"/> class.
         /// </summary>
+        /// <param name="service">The service that will be activated in
+        /// order to create the products of the factory.</param>
         /// <param name="productRegistration">The component that will be activated in
         /// order to create the products of the factory.</param>
         /// <param name="delegateType">The delegate to provide as a factory.</param>
         /// <param name="parameterMapping">The parameter mapping mode to use.</param>
-        public FactoryGenerator(Type delegateType, IComponentRegistration productRegistration, ParameterMapping parameterMapping)
+        public FactoryGenerator(Type delegateType, Service service, IComponentRegistration productRegistration, ParameterMapping parameterMapping)
         {
             if (productRegistration == null) throw new ArgumentNullException(nameof(productRegistration));
             Enforce.ArgumentTypeIsFunction(delegateType);
@@ -89,9 +91,10 @@ namespace Autofac.Features.GeneratedFactories
             _generator = CreateGenerator(
                 (activatorContextParam, resolveParameterArray) =>
                 {
-                    // productRegistration, [new Parameter(name, (object)dps)]*
+                    // service, productRegistration, [new Parameter(name, (object)dps)]*
                     var resolveParams = new Expression[]
                     {
+                        Expression.Constant(service, typeof(Service)),
                         Expression.Constant(productRegistration, typeof(IComponentRegistration)),
                         Expression.NewArrayInit(typeof(Parameter), resolveParameterArray),
                     };
@@ -99,7 +102,8 @@ namespace Autofac.Features.GeneratedFactories
                     // c.Resolve(...)
                     return Expression.Call(
                         activatorContextParam,
-                        ReflectionExtensions.GetMethod<IComponentContext>(cc => cc.ResolveComponent(default(IComponentRegistration), default(Parameter[]))),
+                        ReflectionExtensions.GetMethod<IComponentContext>(cc => cc.ResolveComponent(
+                            default(Service), default(IComponentRegistration), default(Parameter[]))),
                         resolveParams);
                 },
                 delegateType,

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
@@ -56,7 +56,7 @@ namespace Autofac.Features.GeneratedFactories
             return registrationAccessor(resultTypeService)
                 .Select(r =>
                 {
-                    var factory = new FactoryGenerator(ts.ServiceType, r, ParameterMapping.Adaptive);
+                    var factory = new FactoryGenerator(ts.ServiceType, service, r, ParameterMapping.Adaptive);
                     var rb = RegistrationBuilder.ForDelegate(ts.ServiceType, factory.GenerateFactory)
                         .InstancePerLifetimeScope()
                         .ExternallyOwned()

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
@@ -56,7 +56,7 @@ namespace Autofac.Features.GeneratedFactories
             return registrationAccessor(resultTypeService)
                 .Select(r =>
                 {
-                    var factory = new FactoryGenerator(ts.ServiceType, service, r, ParameterMapping.Adaptive);
+                    var factory = new FactoryGenerator(ts.ServiceType, resultTypeService, r, ParameterMapping.Adaptive);
                     var rb = RegistrationBuilder.ForDelegate(ts.ServiceType, factory.GenerateFactory)
                         .InstancePerLifetimeScope()
                         .ExternallyOwned()

--- a/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
@@ -74,7 +74,8 @@ namespace Autofac.Features.LazyDependencies
                 (c, p) =>
                 {
                     var context = c.Resolve<IComponentContext>();
-                    return new Lazy<T>(() => (T)context.ResolveComponent(valueService, valueRegistration, p));
+                    var request = new ResolveRequest(valueService, valueRegistration, p);
+                    return new Lazy<T>(() => (T)context.ResolveComponent(request));
                 })
                 .As(providedService)
                 .Targeting(valueRegistration)

--- a/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
@@ -57,7 +57,7 @@ namespace Autofac.Features.LazyDependencies
             var registrationCreator = CreateLazyRegistrationMethod.MakeGenericMethod(valueType);
 
             return registrationAccessor(valueService)
-                .Select(v => registrationCreator.Invoke(null, new object[] { service, v }))
+                .Select(v => registrationCreator.Invoke(null, new object[] { service, valueService, v }))
                 .Cast<IComponentRegistration>();
         }
 
@@ -68,13 +68,13 @@ namespace Autofac.Features.LazyDependencies
             return LazyRegistrationSourceResources.LazyRegistrationSourceDescription;
         }
 
-        private static IComponentRegistration CreateLazyRegistration<T>(Service providedService, IComponentRegistration valueRegistration)
+        private static IComponentRegistration CreateLazyRegistration<T>(Service providedService, Service valueService, IComponentRegistration valueRegistration)
         {
             var rb = RegistrationBuilder.ForDelegate(
                 (c, p) =>
                 {
                     var context = c.Resolve<IComponentContext>();
-                    return new Lazy<T>(() => (T)context.ResolveComponent(providedService, valueRegistration, p));
+                    return new Lazy<T>(() => (T)context.ResolveComponent(valueService, valueRegistration, p));
                 })
                 .As(providedService)
                 .Targeting(valueRegistration)

--- a/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
@@ -74,7 +74,7 @@ namespace Autofac.Features.LazyDependencies
                 (c, p) =>
                 {
                     var context = c.Resolve<IComponentContext>();
-                    return new Lazy<T>(() => (T)context.ResolveComponent(valueRegistration, p));
+                    return new Lazy<T>(() => (T)context.ResolveComponent(providedService, valueRegistration, p));
                 })
                 .As(providedService)
                 .Targeting(valueRegistration)

--- a/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
@@ -95,7 +95,7 @@ namespace Autofac.Features.LazyDependencies
                 {
                     var context = c.Resolve<IComponentContext>();
                     var lazyType = ((IServiceWithType)providedService).ServiceType;
-                    var valueFactory = new Func<T>(() => (T)context.ResolveComponent(valueRegistration, p));
+                    var valueFactory = new Func<T>(() => (T)context.ResolveComponent(providedService, valueRegistration, p));
                     return Activator.CreateInstance(lazyType, valueFactory, metadata);
                 })
                 .As(providedService)

--- a/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
@@ -95,7 +95,8 @@ namespace Autofac.Features.LazyDependencies
                 {
                     var context = c.Resolve<IComponentContext>();
                     var lazyType = ((IServiceWithType)providedService).ServiceType;
-                    var valueFactory = new Func<T>(() => (T)context.ResolveComponent(valueService, valueRegistration, p));
+                    var request = new ResolveRequest(valueService, valueRegistration, p);
+                    var valueFactory = new Func<T>(() => (T)context.ResolveComponent(request));
                     return Activator.CreateInstance(lazyType, valueFactory, metadata);
                 })
                 .As(providedService)

--- a/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
+++ b/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
@@ -63,7 +63,7 @@ namespace Autofac.Features.LightweightAdapters
                     {
                         var rb = RegistrationBuilder
                             .ForDelegate((c, p) => _activatorData.Adapter(
-                                c, Enumerable.Empty<Parameter>(), c.ResolveComponent(_activatorData.FromService, r, p)))
+                                c, Enumerable.Empty<Parameter>(), c.ResolveComponent(new ResolveRequest(_activatorData.FromService, r, p))))
                             .Targeting(r)
                             .InheritRegistrationOrderFrom(r);
 
@@ -92,7 +92,7 @@ namespace Autofac.Features.LightweightAdapters
                     {
                         var rb = RegistrationBuilder
                             .ForDelegate((c, p) => _activatorData.Adapter(
-                                c, p, c.ResolveComponent(serviceToFind, r, Enumerable.Empty<Parameter>())))
+                                c, p, c.ResolveComponent(new ResolveRequest(serviceToFind, r, Enumerable.Empty<Parameter>()))))
                             .Targeting(r);
 
                         rb.RegistrationData.CopyFrom(_registrationData, true);

--- a/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
+++ b/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
@@ -62,7 +62,8 @@ namespace Autofac.Features.LightweightAdapters
                     .Select(r =>
                     {
                         var rb = RegistrationBuilder
-                            .ForDelegate((c, p) => _activatorData.Adapter(c, Enumerable.Empty<Parameter>(), c.ResolveComponent(r, p)))
+                            .ForDelegate((c, p) => _activatorData.Adapter(
+                                c, Enumerable.Empty<Parameter>(), c.ResolveComponent(_activatorData.FromService, r, p)))
                             .Targeting(r)
                             .InheritRegistrationOrderFrom(r);
 
@@ -90,7 +91,8 @@ namespace Autofac.Features.LightweightAdapters
                     .Select(r =>
                     {
                         var rb = RegistrationBuilder
-                            .ForDelegate((c, p) => _activatorData.Adapter(c, p, c.ResolveComponent(r, Enumerable.Empty<Parameter>())))
+                            .ForDelegate((c, p) => _activatorData.Adapter(
+                                c, p, c.ResolveComponent(serviceToFind, r, Enumerable.Empty<Parameter>())))
                             .Targeting(r);
 
                         rb.RegistrationData.CopyFrom(_registrationData, true);

--- a/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
@@ -72,7 +72,7 @@ namespace Autofac.Features.Metadata
         {
             var rb = RegistrationBuilder
                 .ForDelegate((c, p) => new Meta<T>(
-                    (T)c.ResolveComponent(valueRegistration, p),
+                    (T)c.ResolveComponent(providedService, valueRegistration, p),
                     valueRegistration.Target.Metadata))
                 .As(providedService)
                 .Targeting(valueRegistration)

--- a/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
@@ -72,7 +72,7 @@ namespace Autofac.Features.Metadata
         {
             var rb = RegistrationBuilder
                 .ForDelegate((c, p) => new Meta<T>(
-                    (T)c.ResolveComponent(valueService, valueRegistration, p),
+                    (T)c.ResolveComponent(new ResolveRequest(valueService, valueRegistration, p)),
                     valueRegistration.Target.Metadata))
                 .As(providedService)
                 .Targeting(valueRegistration)

--- a/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
@@ -57,7 +57,7 @@ namespace Autofac.Features.Metadata
             var registrationCreator = CreateMetaRegistrationMethod.MakeGenericMethod(valueType);
 
             return registrationAccessor(valueService)
-                .Select(v => registrationCreator.Invoke(null, new object[] { service, v }))
+                .Select(v => registrationCreator.Invoke(null, new object[] { service, valueService, v }))
                 .Cast<IComponentRegistration>();
         }
 
@@ -68,11 +68,11 @@ namespace Autofac.Features.Metadata
             return MetaRegistrationSourceResources.MetaRegistrationSourceDescription;
         }
 
-        private static IComponentRegistration CreateMetaRegistration<T>(Service providedService, IComponentRegistration valueRegistration)
+        private static IComponentRegistration CreateMetaRegistration<T>(Service providedService, Service valueService, IComponentRegistration valueRegistration)
         {
             var rb = RegistrationBuilder
                 .ForDelegate((c, p) => new Meta<T>(
-                    (T)c.ResolveComponent(providedService, valueRegistration, p),
+                    (T)c.ResolveComponent(valueService, valueRegistration, p),
                     valueRegistration.Target.Metadata))
                 .As(providedService)
                 .Targeting(valueRegistration)

--- a/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
@@ -80,7 +80,7 @@ namespace Autofac.Features.Metadata
             var metadata = MetadataViewProvider.GetMetadataViewProvider<TMetadata>()(valueRegistration.Target.Metadata);
 
             var rb = RegistrationBuilder
-                .ForDelegate((c, p) => new Meta<T, TMetadata>((T)c.ResolveComponent(valueService, valueRegistration, p), metadata))
+                .ForDelegate((c, p) => new Meta<T, TMetadata>((T)c.ResolveComponent(new ResolveRequest(valueService, valueRegistration, p)), metadata))
                 .As(providedService)
                 .Targeting(valueRegistration);
 

--- a/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
@@ -40,9 +40,9 @@ namespace Autofac.Features.Metadata
     /// </summary>
     internal class StronglyTypedMetaRegistrationSource : IRegistrationSource
     {
-        private static readonly MethodInfo CreateMetaRegistrationMethod = typeof(StronglyTypedMetaRegistrationSource).GetTypeInfo().GetDeclaredMethod("CreateMetaRegistration");
+        private static readonly MethodInfo CreateMetaRegistrationMethod = typeof(StronglyTypedMetaRegistrationSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateMetaRegistration));
 
-        private delegate IComponentRegistration RegistrationCreator(Service service, IComponentRegistration valueRegistration);
+        private delegate IComponentRegistration RegistrationCreator(Service providedService, Service valueService, IComponentRegistration valueRegistration);
 
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
@@ -65,7 +65,7 @@ namespace Autofac.Features.Metadata
                 typeof(RegistrationCreator), null);
 
             return registrationAccessor(valueService)
-                .Select(v => registrationCreator.Invoke(service, v));
+                .Select(v => registrationCreator.Invoke(service, valueService, v));
         }
 
         public bool IsAdapterForIndividualComponents => true;
@@ -75,12 +75,12 @@ namespace Autofac.Features.Metadata
             return MetaRegistrationSourceResources.StronglyTypedMetaRegistrationSourceDescription;
         }
 
-        private static IComponentRegistration CreateMetaRegistration<T, TMetadata>(Service providedService, IComponentRegistration valueRegistration)
+        private static IComponentRegistration CreateMetaRegistration<T, TMetadata>(Service providedService, Service valueService, IComponentRegistration valueRegistration)
         {
             var metadata = MetadataViewProvider.GetMetadataViewProvider<TMetadata>()(valueRegistration.Target.Metadata);
 
             var rb = RegistrationBuilder
-                .ForDelegate((c, p) => new Meta<T, TMetadata>((T)c.ResolveComponent(providedService, valueRegistration, p), metadata))
+                .ForDelegate((c, p) => new Meta<T, TMetadata>((T)c.ResolveComponent(valueService, valueRegistration, p), metadata))
                 .As(providedService)
                 .Targeting(valueRegistration);
 

--- a/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
@@ -80,7 +80,7 @@ namespace Autofac.Features.Metadata
             var metadata = MetadataViewProvider.GetMetadataViewProvider<TMetadata>()(valueRegistration.Target.Metadata);
 
             var rb = RegistrationBuilder
-                .ForDelegate((c, p) => new Meta<T, TMetadata>((T)c.ResolveComponent(valueRegistration, p), metadata))
+                .ForDelegate((c, p) => new Meta<T, TMetadata>((T)c.ResolveComponent(providedService, valueRegistration, p), metadata))
                 .As(providedService)
                 .Targeting(valueRegistration);
 

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -70,18 +70,18 @@ namespace Autofac.Features.OpenGenerics
                     .Select(cr => RegistrationBuilder.CreateRegistration(
                             Guid.NewGuid(),
                             _registrationData,
-                            new ReflectionActivator(constructedImplementationType, _activatorData.ConstructorFinder, _activatorData.ConstructorSelector, AddDecoratedComponentParameter(swt.ServiceType, cr, _activatorData.ConfiguredParameters), _activatorData.ConfiguredProperties),
+                            new ReflectionActivator(constructedImplementationType, _activatorData.ConstructorFinder, _activatorData.ConstructorSelector, AddDecoratedComponentParameter(fromService, swt.ServiceType, cr, _activatorData.ConfiguredParameters), _activatorData.ConfiguredProperties),
                             services));
             }
 
             return Enumerable.Empty<IComponentRegistration>();
         }
 
-        private static Parameter[] AddDecoratedComponentParameter(Type decoratedParameterType, IComponentRegistration decoratedComponent, IList<Parameter> configuredParameters)
+        private static Parameter[] AddDecoratedComponentParameter(Service service, Type decoratedParameterType, IComponentRegistration decoratedComponent, IList<Parameter> configuredParameters)
         {
             var parameter = new ResolvedParameter(
                 (pi, c) => pi.ParameterType == decoratedParameterType,
-                (pi, c) => c.ResolveComponent(decoratedComponent, Enumerable.Empty<Parameter>()));
+                (pi, c) => c.ResolveComponent(service, decoratedComponent, Enumerable.Empty<Parameter>()));
 
             var resultArray = new Parameter[configuredParameters.Count + 1];
             resultArray[0] = parameter;

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -81,7 +81,7 @@ namespace Autofac.Features.OpenGenerics
         {
             var parameter = new ResolvedParameter(
                 (pi, c) => pi.ParameterType == decoratedParameterType,
-                (pi, c) => c.ResolveComponent(service, decoratedComponent, Enumerable.Empty<Parameter>()));
+                (pi, c) => c.ResolveComponent(new ResolveRequest(service, decoratedComponent, Enumerable.Empty<Parameter>())));
 
             var resultArray = new Parameter[configuredParameters.Count + 1];
             resultArray[0] = parameter;

--- a/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
+++ b/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
@@ -66,7 +66,8 @@ namespace Autofac.Features.OwnedInstances
                             var lifetime = c.Resolve<ILifetimeScope>().BeginLifetimeScope(ownedInstanceService);
                             try
                             {
-                                var value = lifetime.ResolveComponent(ownedInstanceService, r, p);
+                                var context = new ResolveRequest(ownedInstanceService, r, p);
+                                var value = lifetime.ResolveComponent(context);
                                 return Activator.CreateInstance(ts.ServiceType, new[] { value, lifetime });
                             }
                             catch

--- a/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
+++ b/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
@@ -66,7 +66,7 @@ namespace Autofac.Features.OwnedInstances
                             var lifetime = c.Resolve<ILifetimeScope>().BeginLifetimeScope(ownedInstanceService);
                             try
                             {
-                                var value = lifetime.ResolveComponent(r, p);
+                                var value = lifetime.ResolveComponent(service, r, p);
                                 return Activator.CreateInstance(ts.ServiceType, new[] { value, lifetime });
                             }
                             catch

--- a/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
+++ b/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
@@ -66,7 +66,7 @@ namespace Autofac.Features.OwnedInstances
                             var lifetime = c.Resolve<ILifetimeScope>().BeginLifetimeScope(ownedInstanceService);
                             try
                             {
-                                var value = lifetime.ResolveComponent(service, r, p);
+                                var value = lifetime.ResolveComponent(ownedInstanceService, r, p);
                                 return Activator.CreateInstance(ts.ServiceType, new[] { value, lifetime });
                             }
                             catch

--- a/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
+++ b/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
@@ -107,7 +107,7 @@ namespace Autofac.Features.Variance
 
             return variantRegistrations
                 .Select(vr => RegistrationBuilder
-                    .ForDelegate((c, p) => c.ResolveComponent(service, vr, p))
+                    .ForDelegate((c, p) => c.ResolveComponent(new ResolveRequest(service, vr, p)))
                     .Targeting(vr)
                     .As(service)
                     .WithMetadata(IsContravariantAdapter, true)

--- a/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
+++ b/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
@@ -107,7 +107,7 @@ namespace Autofac.Features.Variance
 
             return variantRegistrations
                 .Select(vr => RegistrationBuilder
-                    .ForDelegate((c, p) => c.ResolveComponent(vr, p))
+                    .ForDelegate((c, p) => c.ResolveComponent(service, vr, p))
                     .Targeting(vr)
                     .As(service)
                     .WithMetadata(IsContravariantAdapter, true)

--- a/src/Autofac/IComponentContext.cs
+++ b/src/Autofac/IComponentContext.cs
@@ -44,6 +44,7 @@ namespace Autofac
         /// <summary>
         /// Resolve an instance of the provided registration within the context.
         /// </summary>
+        /// <param name="service">The service to resolve.</param>
         /// <param name="registration">The registration.</param>
         /// <param name="parameters">Parameters for the instance.</param>
         /// <returns>
@@ -51,6 +52,6 @@ namespace Autofac
         /// </returns>
         /// <exception cref="ComponentNotRegisteredException"/>
         /// <exception cref="Autofac.Core.DependencyResolutionException"/>
-        object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters);
+        object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters);
     }
 }

--- a/src/Autofac/IComponentContext.cs
+++ b/src/Autofac/IComponentContext.cs
@@ -23,7 +23,6 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
 using Autofac.Core;
 using Autofac.Core.Registration;
 
@@ -44,14 +43,12 @@ namespace Autofac
         /// <summary>
         /// Resolve an instance of the provided registration within the context.
         /// </summary>
-        /// <param name="service">The service to resolve.</param>
-        /// <param name="registration">The registration.</param>
-        /// <param name="parameters">Parameters for the instance.</param>
+        /// <param name="request">The resolve request.</param>
         /// <returns>
         /// The component instance.
         /// </returns>
         /// <exception cref="ComponentNotRegisteredException"/>
-        /// <exception cref="Autofac.Core.DependencyResolutionException"/>
-        object ResolveComponent(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters);
+        /// <exception cref="DependencyResolutionException"/>
+        object ResolveComponent(ResolveRequest request);
     }
 }

--- a/src/Autofac/ResolutionExtensions.cs
+++ b/src/Autofac/ResolutionExtensions.cs
@@ -1031,14 +1031,13 @@ namespace Autofac
                 throw new ArgumentNullException(nameof(context));
             }
 
-            IComponentRegistration registration;
-            if (!context.ComponentRegistry.TryGetRegistration(service, out registration))
+            if (!context.ComponentRegistry.TryGetRegistration(service, out var registration))
             {
                 instance = null;
                 return false;
             }
 
-            instance = context.ResolveComponent(registration, parameters);
+            instance = context.ResolveComponent(service, registration, parameters);
             return true;
         }
     }

--- a/src/Autofac/ResolutionExtensions.cs
+++ b/src/Autofac/ResolutionExtensions.cs
@@ -1037,7 +1037,7 @@ namespace Autofac
                 return false;
             }
 
-            instance = context.ResolveComponent(service, registration, parameters);
+            instance = context.ResolveComponent(new ResolveRequest(service, registration, parameters));
             return true;
         }
     }

--- a/src/Autofac/ResolveRequest.cs
+++ b/src/Autofac/ResolveRequest.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Autofac.Core;
+
+namespace Autofac
+{
+    /// <summary>
+    /// The details of an individual request to resolve a service.
+    /// </summary>
+    public class ResolveRequest
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ResolveRequest"/> class.
+        /// </summary>
+        /// <param name="service">The service being resolved.</param>
+        /// <param name="registration">The component registration for the service.</param>
+        /// <param name="parameters">The parameters used when resolving the service.</param>
+        public ResolveRequest(Service service, IComponentRegistration registration, IEnumerable<Parameter> parameters)
+        {
+            Service = service;
+            Registration = registration;
+            Parameters = parameters;
+        }
+
+        /// <summary>
+        /// Gets the service being resolved.
+        /// </summary>
+        public Service Service { get; }
+
+        /// <summary>
+        /// Gets the component registration for the service being resolved.
+        /// </summary>
+        public IComponentRegistration Registration { get; }
+
+        /// <summary>
+        /// Gets the parameters used when resolving the service.
+        /// </summary>
+        public IEnumerable<Parameter> Parameters { get; }
+    }
+}


### PR DESCRIPTION
A definite breaking changes here so will be targeted for `5.0`.

The main API change is in `IComponentContext.ResolveComponent` and by extension also `Container.ResolveComponent` and `LifetimeScope.ResolveComponent`. An additional `Service` parameter has been added to the method signature. We have a `Service` in almost all entry resolution entry points but lose it at the last moment inside `TryResolveService` after we find the appropriate `IComponentRegistration`.

I don't think the `ResolveComponent` method would be called directly very often, or in the odd case where it was being called, the appropriate `IComponentRegistration` was probably found by looking for a `Service`.

The most recent need for this is working in the new decorators. Knowing what `Service` is being resolved makes a few things a little easier and has allowed me to fix some of the recently raised issues.