### PR TITLE
Only get generic type definition if possible, when validating parameter

### DIFF
--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -191,8 +191,9 @@ namespace Autofac.Util
                 {
                     var paramArg = baseType.GenericTypeArguments[i];
                     var constraintArg = constraint.GenericTypeArguments[i];
+                    var constraintArgIsGeneric = constraintArg.GetTypeInfo().IsGenericType;
 
-                    allGenericParametersMatch &= paramArg.IsClosedTypeOf(constraintArg.GetGenericTypeDefinition());
+                    allGenericParametersMatch &= paramArg.IsClosedTypeOf(constraintArgIsGeneric ? constraintArg.GetGenericTypeDefinition() : constraintArg);
                 }
             }
 

--- a/test/Autofac.Test/Features/OpenGenerics/ComplexGenericsTests.cs
+++ b/test/Autofac.Test/Features/OpenGenerics/ComplexGenericsTests.cs
@@ -320,6 +320,16 @@ namespace Autofac.Test.Features.OpenGenerics
                 container.Resolve<IDouble<decimal, INested<IDouble<string, int>>>>());
         }
 
+        [Fact]
+        public void TestSelfReferentialGeneric()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterGeneric(typeof(SelfReferenceConsumer<>)).As(typeof(IBaseGeneric<>));
+            var container = cb.Build();
+
+            var instance = container.Resolve<IBaseGeneric<DerivedSelfReferencing>>();
+        }
+
         public class C<T> : I1<T>, I2<T>
         {
         }
@@ -410,5 +420,24 @@ namespace Autofac.Test.Features.OpenGenerics
         public class Wrapper<T>
         {
         }
+
+        public interface IBaseGeneric<TDerived>
+            where TDerived : BaseGenericImplementation<TDerived>, new()
+        {
+        }
+
+        public class SelfReferenceConsumer<TSource> : IBaseGeneric<TSource>
+            where TSource : BaseGenericImplementation<TSource>, new()
+        {
+        }
+
+        public abstract class BaseGenericImplementation<TDerived>
+        {
+        }
+
+        public class DerivedSelfReferencing : BaseGenericImplementation<DerivedSelfReferencing>
+        {
+        }
+
     }
 }


### PR DESCRIPTION
When checking for IsClosedTypeOf for generic type arguments, determine whether the constraint argument is generic; if it is then get the type definition, otherwise use it directly.

Added test for self-referential generics.

Fixes #1006 