### PR TITLE
Null-check the parameter base type in ParameterCompatibleWithTypeConstraint

### DIFF
--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -180,7 +180,7 @@ namespace Autofac.Util
             }
 
             var allGenericParametersMatch = false;
-            var baseType = parameter.GetTypeInfo().BaseType;
+            var baseType = parameter.GetTypeInfo().BaseType ?? parameter;
             if (!constraint.GetTypeInfo().IsInterface &&
                 baseType.GetTypeInfo().IsGenericType &&
                 baseType.GenericTypeArguments.Length > 0 &&

--- a/test/Autofac.Test/Features/OpenGenerics/ComplexGenericsTests.cs
+++ b/test/Autofac.Test/Features/OpenGenerics/ComplexGenericsTests.cs
@@ -330,6 +330,31 @@ namespace Autofac.Test.Features.OpenGenerics
             var instance = container.Resolve<IBaseGeneric<DerivedSelfReferencing>>();
         }
 
+        [Fact]
+        public void ResolveTypeFromOpenGenericInterfaceTypeParameterIsInterfaceWithConstraint()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterGeneric(typeof(CGenericNestedProvider<>)).AsImplementedInterfaces();
+            cb.RegisterType<CNestedSimpleInterface>().AsImplementedInterfaces();
+            var container = cb.Build();
+
+            var instance = container.Resolve<INested<ISimpleInterface>>();
+        }
+
+
+        private class CNestedSimpleInterface : INested<ISimpleInterface>
+        {
+        }
+
+        private class CGenericNestedProvider<T> : INested<T>
+            where T : CSimpleNoInterface
+        {
+        }
+
+        private class CSimpleNoInterface
+        {
+        }
+
         public class C<T> : I1<T>, I2<T>
         {
         }
@@ -438,6 +463,5 @@ namespace Autofac.Test.Features.OpenGenerics
         public class DerivedSelfReferencing : BaseGenericImplementation<DerivedSelfReferencing>
         {
         }
-
     }
 }


### PR DESCRIPTION
Also added test for specific interface constraint scenario, ``ResolveTypeFromOpenGenericInterfaceTypeParameterIsInterfaceWithConstraint``.

Fixes #1009 