### PR TITLE
Issue 879 - Add default InstanceOwnership to ContainerBuilder

### DIFF
--- a/src/Autofac/Builder/RegistrationBuilder.cs
+++ b/src/Autofac/Builder/RegistrationBuilder.cs
@@ -54,13 +54,17 @@ namespace Autofac.Builder
         /// </summary>
         /// <typeparam name="T">Instance type returned by delegate.</typeparam>
         /// <param name="delegate">Delegate to register.</param>
+        /// <param name="ownership">Initial <see cref="InstanceOwnership"/> for the registration,
+        /// determining whether components implementing IDisposable are disposed by Autofac at the end of a unit of work.
+        /// Defaults to OwnedByLifetimeScope.</param>
         /// <returns>A registration builder.</returns>
-        public static IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> ForDelegate<T>(Func<IComponentContext, IEnumerable<Parameter>, T> @delegate)
+        public static IRegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle> ForDelegate<T>(Func<IComponentContext, IEnumerable<Parameter>, T> @delegate, InstanceOwnership ownership = InstanceOwnership.OwnedByLifetimeScope)
         {
             return new RegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle>(
                 new TypedService(typeof(T)),
                 new SimpleActivatorData(new DelegateActivator(typeof(T), (c, p) => @delegate(c, p))),
-                new SingleRegistrationStyle());
+                new SingleRegistrationStyle(),
+                ownership);
         }
 
         /// <summary>
@@ -68,13 +72,16 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="delegate">Delegate to register.</param>
         /// <param name="limitType">Most specific type return value of delegate can be cast to.</param>
-        /// <returns>A registration builder.</returns>
-        public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> ForDelegate(Type limitType, Func<IComponentContext, IEnumerable<Parameter>, object> @delegate)
+        /// <param name="ownership">Initial <see cref="InstanceOwnership"/> for the registration,
+        /// determining whether components implementing IDisposable are disposed by Autofac at the end of a unit of work.
+        /// Defaults to OwnedByLifetimeScope.</param>
+        public static IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> ForDelegate(Type limitType, Func<IComponentContext, IEnumerable<Parameter>, object> @delegate, InstanceOwnership ownership = InstanceOwnership.OwnedByLifetimeScope)
         {
             return new RegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle>(
                 new TypedService(limitType),
                 new SimpleActivatorData(new DelegateActivator(limitType, @delegate)),
-                new SingleRegistrationStyle());
+                new SingleRegistrationStyle(),
+                ownership);
         }
 
         /// <summary>
@@ -82,12 +89,16 @@ namespace Autofac.Builder
         /// </summary>
         /// <typeparam name="TImplementer">Implementation type to register.</typeparam>
         /// <returns>A registration builder.</returns>
-        public static IRegistrationBuilder<TImplementer, ConcreteReflectionActivatorData, SingleRegistrationStyle> ForType<TImplementer>()
+        /// <param name="ownership">Initial <see cref="InstanceOwnership"/> for the registration,
+        /// determining whether components implementing IDisposable are disposed by Autofac at the end of a unit of work.
+        /// Defaults to OwnedByLifetimeScope.</param>
+        public static IRegistrationBuilder<TImplementer, ConcreteReflectionActivatorData, SingleRegistrationStyle> ForType<TImplementer>(InstanceOwnership ownership = InstanceOwnership.OwnedByLifetimeScope)
         {
             return new RegistrationBuilder<TImplementer, ConcreteReflectionActivatorData, SingleRegistrationStyle>(
                 new TypedService(typeof(TImplementer)),
                 new ConcreteReflectionActivatorData(typeof(TImplementer)),
-                new SingleRegistrationStyle());
+                new SingleRegistrationStyle(),
+                ownership);
         }
 
         /// <summary>
@@ -95,12 +106,16 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="implementationType">Implementation type to register.</param>
         /// <returns>A registration builder.</returns>
-        public static IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> ForType(Type implementationType)
+        /// <param name="ownership">Initial <see cref="InstanceOwnership"/> for the registration,
+        /// determining whether components implementing IDisposable are disposed by Autofac at the end of a unit of work.
+        /// Defaults to OwnedByLifetimeScope.</param>
+        public static IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> ForType(Type implementationType, InstanceOwnership ownership = InstanceOwnership.OwnedByLifetimeScope)
         {
             return new RegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>(
                 new TypedService(implementationType),
                 new ConcreteReflectionActivatorData(implementationType),
-                new SingleRegistrationStyle());
+                new SingleRegistrationStyle(),
+                ownership);
         }
 
         /// <summary>

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -35,7 +35,7 @@ namespace Autofac.Builder
 {
     internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> : IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>, IHideObjectMembers
     {
-        public RegistrationBuilder(Service defaultService, TActivatorData activatorData, TRegistrationStyle style)
+        public RegistrationBuilder(Service defaultService, TActivatorData activatorData, TRegistrationStyle style, InstanceOwnership defaultInstanceOwnership)
         {
             if (defaultService == null) throw new ArgumentNullException(nameof(defaultService));
             if (activatorData == null) throw new ArgumentNullException(nameof(activatorData));
@@ -43,7 +43,7 @@ namespace Autofac.Builder
 
             ActivatorData = activatorData;
             RegistrationStyle = style;
-            RegistrationData = new RegistrationData(defaultService);
+            RegistrationData = new RegistrationData(defaultService, defaultInstanceOwnership);
         }
 
         /// <summary>

--- a/src/Autofac/Builder/RegistrationData.cs
+++ b/src/Autofac/Builder/RegistrationData.cs
@@ -50,7 +50,10 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="defaultService">The default service that will be used if no others
         /// are added.</param>
-        public RegistrationData(Service defaultService)
+        /// <param name="instanceOwnership">Initial <see cref="InstanceOwnership"/> for the registration,
+        /// determining whether components implementing IDisposable are disposed by Autofac at the end of a unit of work.
+        /// Defaults to OwnedByLifetimeScope.</param>
+        public RegistrationData(Service defaultService, InstanceOwnership instanceOwnership = InstanceOwnership.OwnedByLifetimeScope)
         {
             if (defaultService == null) throw new ArgumentNullException(nameof(defaultService));
 
@@ -60,6 +63,8 @@ namespace Autofac.Builder
             {
                 { MetadataKeys.RegistrationOrderMetadataKey, SequenceGenerator.GetNextUniqueSequence() },
             };
+
+            Ownership = instanceOwnership;
         }
 
         /// <summary>
@@ -106,7 +111,7 @@ namespace Autofac.Builder
         /// <summary>
         /// Gets or sets the instance ownership assigned to the component.
         /// </summary>
-        public InstanceOwnership Ownership { get; set; } = InstanceOwnership.OwnedByLifetimeScope;
+        public InstanceOwnership Ownership { get; set; }
 
         /// <summary>
         /// Gets or sets the lifetime assigned to the component.

--- a/src/Autofac/ContainerBuilder.cs
+++ b/src/Autofac/ContainerBuilder.cs
@@ -81,16 +81,6 @@ namespace Autofac
         /// <summary>
         /// Initializes a new instance of the <see cref="ContainerBuilder"/> class.
         /// </summary>
-        /// <param name="defaultInstanceOwnership">The default <see cref="InstanceOwnership"/> for any registrations created
-        /// by the <see cref="ContainerBuilder"/>. Defaults to OwnedByLifetimeScope.</param>
-        public ContainerBuilder(InstanceOwnership defaultInstanceOwnership)
-            : this(new Dictionary<string, object>(), defaultInstanceOwnership)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ContainerBuilder"/> class.
-        /// </summary>
         /// <param name="properties">The properties used during component registration.</param>
         /// <param name="defaultInstanceOwnership">The default <see cref="InstanceOwnership"/> for any registrations created
         /// by the <see cref="ContainerBuilder"/>. Defaults to OwnedByLifetimeScope.</param>

--- a/src/Autofac/ContainerBuilder.cs
+++ b/src/Autofac/ContainerBuilder.cs
@@ -63,6 +63,9 @@ namespace Autofac
     public class ContainerBuilder
     {
         private readonly IList<DeferredCallback> _configurationCallbacks = new List<DeferredCallback>();
+
+        internal InstanceOwnership DefaultInstanceOwnership { get; }
+
         private bool _wasBuilt;
 
         private const string BuildCallbackPropertyKey = "__BuildCallbackKey";
@@ -78,10 +81,23 @@ namespace Autofac
         /// <summary>
         /// Initializes a new instance of the <see cref="ContainerBuilder"/> class.
         /// </summary>
+        /// <param name="defaultInstanceOwnership">The default <see cref="InstanceOwnership"/> for any registrations created
+        /// by the <see cref="ContainerBuilder"/>. Defaults to OwnedByLifetimeScope.</param>
+        public ContainerBuilder(InstanceOwnership defaultInstanceOwnership)
+            : this(new Dictionary<string, object>(), defaultInstanceOwnership)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ContainerBuilder"/> class.
+        /// </summary>
         /// <param name="properties">The properties used during component registration.</param>
-        internal ContainerBuilder(IDictionary<string, object> properties)
+        /// <param name="defaultInstanceOwnership">The default <see cref="InstanceOwnership"/> for any registrations created
+        /// by the <see cref="ContainerBuilder"/>. Defaults to OwnedByLifetimeScope.</param>
+        internal ContainerBuilder(IDictionary<string, object> properties, InstanceOwnership defaultInstanceOwnership = InstanceOwnership.OwnedByLifetimeScope)
         {
             Properties = properties;
+            DefaultInstanceOwnership = defaultInstanceOwnership;
 
             if (!Properties.ContainsKey(BuildCallbackPropertyKey))
             {

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationExtensions.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationExtensions.cs
@@ -39,7 +39,8 @@ namespace Autofac.Features.GeneratedFactories
             var rb = new RegistrationBuilder<TLimit, GeneratedFactoryActivatorData, SingleRegistrationStyle>(
                 new TypedService(delegateType),
                 activatorData,
-                new SingleRegistrationStyle());
+                new SingleRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => RegistrationBuilder.RegisterSingleComponent(cr, rb));
 

--- a/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationExtensions.cs
+++ b/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationExtensions.cs
@@ -67,7 +67,8 @@ namespace Autofac.Features.LightweightAdapters
             var rb = new RegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle>(
                 toService,
                 new LightweightAdapterActivatorData(fromService, (c, p, f) => adapter(c, p, (TFrom)f)),
-                new DynamicRegistrationStyle());
+                new DynamicRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => cr.AddRegistrationSource(
                 new LightweightAdapterRegistrationSource(rb.RegistrationData, rb.ActivatorData)));

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
@@ -45,7 +45,8 @@ namespace Autofac.Features.OpenGenerics
             var rb = new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
                 new TypedService(implementor),
                 new ReflectionActivatorData(implementor),
-                new DynamicRegistrationStyle());
+                new DynamicRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => cr.AddRegistrationSource(
                 new OpenGenericRegistrationSource(rb.RegistrationData, rb.ActivatorData)));
@@ -63,7 +64,8 @@ namespace Autofac.Features.OpenGenerics
             var rb = new RegistrationBuilder<object, OpenGenericDecoratorActivatorData, DynamicRegistrationStyle>(
                 (Service)GetServiceWithKey(decoratedServiceType, toKey),
                 new OpenGenericDecoratorActivatorData(decoratorType, GetServiceWithKey(decoratedServiceType, fromKey)),
-                new DynamicRegistrationStyle());
+                new DynamicRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => cr.AddRegistrationSource(
                 new OpenGenericDecoratorRegistrationSource(rb.RegistrationData, rb.ActivatorData)));

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -44,7 +44,8 @@ namespace Autofac.Features.Scanning
             var rb = new RegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>(
                 new TypedService(typeof(object)),
                 new ScanningActivatorData(),
-                new DynamicRegistrationStyle());
+                new DynamicRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => ScanAssemblies(assemblies, cr, rb));
 
@@ -60,7 +61,8 @@ namespace Autofac.Features.Scanning
             var rb = new RegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>(
                 new TypedService(typeof(object)),
                 new ScanningActivatorData(),
-                new DynamicRegistrationStyle());
+                new DynamicRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => ScanTypes(types, cr, rb));
 
@@ -91,7 +93,7 @@ namespace Autofac.Features.Scanning
                     rb.ActivatorData.Filters.All(p => p(t)) &&
                     !t.IsCompilerGenerated()))
             {
-                var scanned = RegistrationBuilder.ForType(t)
+                var scanned = RegistrationBuilder.ForType(t, rb.RegistrationData.Ownership)
                     .FindConstructorsWith(rb.ActivatorData.ConstructorFinder)
                     .UsingConstructor(rb.ActivatorData.ConstructorSelector)
                     .WithParameters(rb.ActivatorData.ConfiguredParameters)

--- a/src/Autofac/Module.cs
+++ b/src/Autofac/Module.cs
@@ -69,6 +69,11 @@ namespace Autofac
     public abstract class Module : IModule
     {
         /// <summary>
+        /// Gets the <see cref="InstanceOwnership"></see> which is used as the default for all registrations loaded by the <see cref="Module"/>.
+        /// </summary>
+        protected virtual InstanceOwnership DefaultInstanceOwnership => InstanceOwnership.OwnedByLifetimeScope;
+
+        /// <summary>
         /// Apply the module to the component registry.
         /// </summary>
         /// <param name="componentRegistry">Component registry to apply configuration to.</param>
@@ -76,7 +81,7 @@ namespace Autofac
         {
             if (componentRegistry == null) throw new ArgumentNullException(nameof(componentRegistry));
 
-            var moduleBuilder = new ContainerBuilder(componentRegistry.Properties);
+            var moduleBuilder = new ContainerBuilder(componentRegistry.Properties, DefaultInstanceOwnership);
 
             Load(moduleBuilder);
             moduleBuilder.UpdateRegistry(componentRegistry);

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -96,7 +96,8 @@ namespace Autofac
             var rb = new RegistrationBuilder<T, SimpleActivatorData, SingleRegistrationStyle>(
                 new TypedService(typeof(T)),
                 new SimpleActivatorData(activator),
-                new SingleRegistrationStyle());
+                new SingleRegistrationStyle(),
+                builder.DefaultInstanceOwnership);
 
             rb.SingleInstance();
 
@@ -127,7 +128,7 @@ namespace Autofac
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
 
-            var rb = RegistrationBuilder.ForType<TImplementer>();
+            var rb = RegistrationBuilder.ForType<TImplementer>(builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => RegistrationBuilder.RegisterSingleComponent(cr, rb));
 
@@ -146,7 +147,7 @@ namespace Autofac
             if (builder == null) throw new ArgumentNullException(nameof(builder));
             if (implementationType == null) throw new ArgumentNullException(nameof(implementationType));
 
-            var rb = RegistrationBuilder.ForType(implementationType);
+            var rb = RegistrationBuilder.ForType(implementationType, builder.DefaultInstanceOwnership);
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => RegistrationBuilder.RegisterSingleComponent(cr, rb));
 

--- a/test/Autofac.Test/ContainerBuilderTests.cs
+++ b/test/Autofac.Test/ContainerBuilderTests.cs
@@ -41,18 +41,5 @@ namespace Autofac.Test
 
             Assert.Equal(2, container.ComponentRegistry.Properties["count"]);
         }
-
-        [Theory]
-        [InlineData(InstanceOwnership.OwnedByLifetimeScope)]
-        [InlineData(InstanceOwnership.ExternallyOwned)]
-        public void ContainerBuilderPassesRegistrationsOwnership(InstanceOwnership ownership)
-        {
-            var builder = new ContainerBuilder(ownership);
-            builder.RegisterType<object>();
-            var container = builder.Build();
-            var regExists = container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(object)), out var reg);
-            Assert.True(regExists);
-            Assert.Equal(ownership, reg.Ownership);
-        }
     }
 }

--- a/test/Autofac.Test/ContainerBuilderTests.cs
+++ b/test/Autofac.Test/ContainerBuilderTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+using Autofac.Core;
 using Xunit;
 
 namespace Autofac.Test
@@ -40,6 +40,19 @@ namespace Autofac.Test
             container.Resolve<string>();
 
             Assert.Equal(2, container.ComponentRegistry.Properties["count"]);
+        }
+
+        [Theory]
+        [InlineData(InstanceOwnership.OwnedByLifetimeScope)]
+        [InlineData(InstanceOwnership.ExternallyOwned)]
+        public void ContainerBuilderPassesRegistrationsOwnership(InstanceOwnership ownership)
+        {
+            var builder = new ContainerBuilder(ownership);
+            builder.RegisterType<object>();
+            var container = builder.Build();
+            var regExists = container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(object)), out var reg);
+            Assert.True(regExists);
+            Assert.Equal(ownership, reg.Ownership);
         }
     }
 }


### PR DESCRIPTION
This is a draft PR for a somewhat crude way of setting the default ownership (owned by lifetime scope or externally owned) for registrations as per #879 . I'm still not 100% convinced this is a valuable addition but have put this up just to show what it might look like.

It expands out the constructors for `RegistrationData`, `RegistrationBuilder` and `ContainerBuilder` to accept an optional ownership parameter so generally would be backwards compatible. The `ContainerBuilder` then passes that default to any calls made on it to create new registrations.

An interesting related distinction I noticed is that `CollectionRegistrationSource` currently defaults to `ExternallyOwned` but all other registration sources default to `OwnedByLifetimeScope`. That's likely immaterial anyway and is unaffected by this change, but not sure if it's by design.