### PR TITLE
Adding IAsyncDisposable Support to Autofac

### DIFF
--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.0;netstandard2.0;netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.1;net45</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591;IDE0008</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -35,6 +35,10 @@
     <Product>Autofac</Product>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or  '$(TargetFramework)' == 'netstandard2.1'  ">
+    <DefineConstants>ASYNC_DISPOSE_AVAILABLE;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
       <PrivateAssets>All</PrivateAssets>
@@ -52,6 +56,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="System.ComponentModel" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0-preview1.19504.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591;IDE0008</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -50,8 +50,12 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0-preview1.19504.10" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0;netstandard1.1;net45</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591;IDE0008</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -150,10 +150,15 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>ResolveOperationResources.resx</DependentUpon>
     </Compile>
-    <Compile Update="Core\ServiceResources.Designer.cs">
+    <Compile Update="Core\DisposerResources.Designer.cs">
+      <DependentUpon>DisposerResources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
+    </Compile>
+    <Compile Update="Core\ServiceResources.Designer.cs">
       <DependentUpon>ServiceResources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
     </Compile>
     <Compile Update="Features\Collections\CollectionRegistrationSourceResources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -333,6 +338,10 @@
     <EmbeddedResource Update="Core\Resolving\ResolveOperationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>ResolveOperationResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Core\DisposerResources.resx">
+      <LastGenOutput>DisposerResources.Designer.cs</LastGenOutput>
+      <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
     <EmbeddedResource Update="Core\ServiceResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Autofac is an IoC container for Microsoft .NET. It manages the dependencies between classes so that applications stay easy to change as they grow in size and complexity.</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;netstandard1.1;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS1591;IDE0008</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -35,10 +35,6 @@
     <Product>Autofac</Product>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or  '$(TargetFramework)' == 'netstandard2.1'  ">
-    <DefineConstants>ASYNC_DISPOSE_AVAILABLE;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.4">
       <PrivateAssets>All</PrivateAssets>
@@ -52,10 +48,6 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
-    <PackageReference Include="System.ComponentModel" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Autofac/Core/Container.cs
+++ b/src/Autofac/Core/Container.cs
@@ -179,7 +179,6 @@ namespace Autofac.Core
             base.Dispose(disposing);
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)
@@ -193,7 +192,6 @@ namespace Autofac.Core
 
             // Do not call the base, otherwise the standard Dispose will fire.
         }
-#endif
 
         /// <summary>
         /// Gets the service object of the specified type.

--- a/src/Autofac/Core/Container.cs
+++ b/src/Autofac/Core/Container.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Autofac.Core.Activators.Delegate;
 using Autofac.Core.Lifetime;
 using Autofac.Core.Registration;
@@ -177,6 +178,22 @@ namespace Autofac.Core
 
             base.Dispose(disposing);
         }
+
+#if NETCOREAPP3_0
+        protected override async ValueTask DisposeAsync(bool disposing)
+        {
+            if (disposing)
+            {
+                await _rootLifetimeScope.DisposeAsync();
+
+                // Registries are not likely to have async tasks to dispose of,
+                // so we will leave it as a straight dispose.
+                ComponentRegistry.Dispose();
+            }
+
+            // Do not call the base, otherwise the standard Dispose will fire.
+        }
+#endif
 
         /// <summary>
         /// Gets the service object of the specified type.

--- a/src/Autofac/Core/Container.cs
+++ b/src/Autofac/Core/Container.cs
@@ -179,7 +179,7 @@ namespace Autofac.Core
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)

--- a/src/Autofac/Core/DependencyResolutionException.cs
+++ b/src/Autofac/Core/DependencyResolutionException.cs
@@ -24,9 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
-#if !NETSTANDARD1_1
 using System.Runtime.Serialization;
-#endif
 
 namespace Autofac.Core
 {
@@ -36,17 +34,13 @@ namespace Autofac.Core
     /// been made during the operation. For example, 'on activated' handlers may have already been
     /// fired, or 'single instance' components partially constructed.
     /// </summary>
-#if !NETSTANDARD1_1
     [Serializable]
-#endif
     public class DependencyResolutionException : Exception
     {
-#if !NETSTANDARD1_1
         protected DependencyResolutionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyResolutionException" /> class.

--- a/src/Autofac/Core/Disposer.cs
+++ b/src/Autofac/Core/Disposer.cs
@@ -43,7 +43,7 @@ namespace Autofac.Core
         private Stack<object> _items = new Stack<object>();
 
         // Need to use a semaphore instead of a simple object to lock on, because
-        // we need to synchronoise an awaitable block.
+        // we need to synchronise an awaitable block.
         private SemaphoreSlim _synchRoot = new SemaphoreSlim(1, 1);
 
         /// <summary>
@@ -61,14 +61,16 @@ namespace Autofac.Core
                     {
                         var item = _items.Pop();
 
-                        // If we are in synchronous dispose, and an object doesn't implement
+                        // If we are in synchronous dispose, and an object implements IDisposable,
+                        // then use it.
                         if (item is IDisposable disposable)
                         {
                             disposable.Dispose();
                         }
                         else
                         {
-                            // Type only implements IAsyncDisposable, which is not valid if there is a synchronous dispose being done.
+                            // Type only implements IAsyncDisposable, which is not valid if there
+                            // is a synchronous dispose being done.
                             throw new InvalidOperationException(string.Format(
                                 DisposerResources.Culture,
                                 DisposerResources.TypeOnlyImplementsIAsyncDisposable,

--- a/src/Autofac/Core/Disposer.cs
+++ b/src/Autofac/Core/Disposer.cs
@@ -92,7 +92,6 @@ namespace Autofac.Core
             base.Dispose(disposing);
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)
@@ -148,7 +147,6 @@ namespace Autofac.Core
         {
             AddInternal(instance);
         }
-#endif
 
         /// <summary>
         /// Adds an object to the disposer. When the disposer is

--- a/src/Autofac/Core/Disposer.cs
+++ b/src/Autofac/Core/Disposer.cs
@@ -90,7 +90,7 @@ namespace Autofac.Core
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)

--- a/src/Autofac/Core/Disposer.cs
+++ b/src/Autofac/Core/Disposer.cs
@@ -25,6 +25,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Autofac.Util;
 
 namespace Autofac.Core
@@ -36,11 +38,13 @@ namespace Autofac.Core
     internal class Disposer : Disposable, IDisposer
     {
         /// <summary>
-        /// Contents all implement IDisposable.
+        /// Contents all implement IDisposable or IAsyncDisposable.
         /// </summary>
-        private Stack<IDisposable> _items = new Stack<IDisposable>();
+        private Stack<object> _items = new Stack<object>();
 
-        private readonly object _synchRoot = new object();
+        // Need to use a semaphore instead of a simple object to lock on, because
+        // we need to synchronoise an awaitable block.
+        private SemaphoreSlim _synchRoot = new SemaphoreSlim(1, 1);
 
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
@@ -50,20 +54,99 @@ namespace Autofac.Core
         {
             if (disposing)
             {
-                lock (_synchRoot)
+                _synchRoot.Wait();
+                try
                 {
                     while (_items.Count > 0)
                     {
                         var item = _items.Pop();
-                        item.Dispose();
+
+                        // If we are in synchronous dispose, and an object doesn't implement
+                        if (item is IDisposable disposable)
+                        {
+                            disposable.Dispose();
+                        }
+                        else
+                        {
+                            // Type only implements IAsyncDisposable, which is not valid if there is a synchronous dispose being done.
+                            throw new InvalidOperationException(string.Format(
+                                DisposerResources.Culture,
+                                DisposerResources.TypeOnlyImplementsIAsyncDisposable,
+                                item.GetType().FullName));
+                        }
                     }
 
                     _items = null;
+                }
+                finally
+                {
+                    _synchRoot.Release();
+
+                    // We don't need the semaphore any more.
+                    _synchRoot.Dispose();
                 }
             }
 
             base.Dispose(disposing);
         }
+
+#if NETCOREAPP3_0
+        protected override async ValueTask DisposeAsync(bool disposing)
+        {
+            if (disposing)
+            {
+                // Acquire our semaphore.
+                await _synchRoot.WaitAsync().ConfigureAwait(false);
+                try
+                {
+                    while (_items.Count > 0)
+                    {
+                        var item = _items.Pop();
+
+                        // If the item implements IAsyncDisposable we will call its DisposeAsync Method.
+                        if (item is IAsyncDisposable asyncDisposable)
+                        {
+                            var vt = asyncDisposable.DisposeAsync();
+
+                            // Don't await if it's already completed (this is a slight gain in performance of using ValueTask).
+                            if (!vt.IsCompletedSuccessfully)
+                            {
+                                await vt.ConfigureAwait(false);
+                            }
+                        }
+                        else if (item is IDisposable disposable)
+                        {
+                            // Call the standard Dispose.
+                            disposable.Dispose();
+                        }
+                    }
+
+                    _items = null;
+                }
+                finally
+                {
+                    _synchRoot.Release();
+
+                    // We don't need the semaphore any more.
+                    _synchRoot.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds an object to the disposer, where that object only implements IAsyncDisposable. When the disposer is
+        /// disposed, so will the object be.
+        /// This is not typically recommended, and you should implement IDisposable as well.
+        /// </summary>
+        /// <param name="instance">The instance.</param>
+        /// <remarks>
+        /// If this Disposer is disposed of using a synchronous Dispose call, that call will throw an exception.
+        /// </remarks>
+        public void AddInstanceForAsyncDisposal(IAsyncDisposable instance)
+        {
+            AddInternal(instance);
+        }
+#endif
 
         /// <summary>
         /// Adds an object to the disposer. When the disposer is
@@ -72,10 +155,27 @@ namespace Autofac.Core
         /// <param name="instance">The instance.</param>
         public void AddInstanceForDisposal(IDisposable instance)
         {
+            AddInternal(instance);
+        }
+
+        private void AddInternal(object instance)
+        {
             if (instance == null) throw new ArgumentNullException(nameof(instance));
 
-            lock (_synchRoot)
+            if (IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(Disposer), DisposerResources.CannotAddToDisposedDisposer);
+            }
+
+            _synchRoot.Wait();
+            try
+            {
                 _items.Push(instance);
+            }
+            finally
+            {
+                _synchRoot.Release();
+            }
         }
     }
 }

--- a/src/Autofac/Core/DisposerResources.Designer.cs
+++ b/src/Autofac/Core/DisposerResources.Designer.cs
@@ -11,6 +11,8 @@
 namespace Autofac.Core {
     using System;
     using System.Reflection;
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -18,17 +20,17 @@ namespace Autofac.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class ServiceResources {
+    internal class DisposerResources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal ServiceResources() {
+        internal DisposerResources() {
         }
         
         /// <summary>
@@ -38,7 +40,7 @@ namespace Autofac.Core {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Autofac.Core.ServiceResources", typeof(ServiceResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Autofac.Core.DisposerResources", typeof(DisposerResources).GetTypeInfo().Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -60,20 +62,20 @@ namespace Autofac.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Subclasses of Autofac.Service must override Object.Equals().
+        ///   Looks up a localized string similar to The Disposer object has already been Disposed, so no items can be added to it..
         /// </summary>
-        internal static string MustOverrideEquals {
+        internal static string CannotAddToDisposedDisposer {
             get {
-                return ResourceManager.GetString("MustOverrideEquals", resourceCulture);
+                return ResourceManager.GetString("CannotAddToDisposedDisposer", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Subclasses of Autofac.Service must override Object.GetHashCode().
+        ///   Looks up a localized string similar to A synchronous Dispose has been attempted, but the tracked object of type &apos;{0}&apos; only implements IAsyncDisposable..
         /// </summary>
-        internal static string MustOverrideGetHashCode {
+        internal static string TypeOnlyImplementsIAsyncDisposable {
             get {
-                return ResourceManager.GetString("MustOverrideGetHashCode", resourceCulture);
+                return ResourceManager.GetString("TypeOnlyImplementsIAsyncDisposable", resourceCulture);
             }
         }
     }

--- a/src/Autofac/Core/DisposerResources.resx
+++ b/src/Autofac/Core/DisposerResources.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CannotAddToDisposedDisposer" xml:space="preserve">
+    <value>The Disposer object has already been Disposed, so no items can be added to it.</value>
+  </data>
+  <data name="TypeOnlyImplementsIAsyncDisposable" xml:space="preserve">
+    <value>A synchronous Dispose has been attempted, but the tracked object of type '{0}' only implements IAsyncDisposable.</value>
+  </data>
+</root>

--- a/src/Autofac/Core/IDisposer.cs
+++ b/src/Autofac/Core/IDisposer.cs
@@ -31,7 +31,7 @@ namespace Autofac.Core
     /// Provided on an object that will dispose of other objects when it is
     /// itself disposed.
     /// </summary>
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
     public interface IDisposer : IDisposable, IAsyncDisposable
 #else
     public interface IDisposer : IDisposable
@@ -43,7 +43,7 @@ namespace Autofac.Core
         /// </summary>
         /// <param name="instance">The instance.</param>
         void AddInstanceForDisposal(IDisposable instance);
-#if  NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         /// <summary>
         /// Adds an object to the disposer, where that object implements IAsyncDisposable. When the disposer is
         /// disposed, so will the object be.

--- a/src/Autofac/Core/IDisposer.cs
+++ b/src/Autofac/Core/IDisposer.cs
@@ -31,11 +31,7 @@ namespace Autofac.Core
     /// Provided on an object that will dispose of other objects when it is
     /// itself disposed.
     /// </summary>
-#if ASYNC_DISPOSE_AVAILABLE
     public interface IDisposer : IDisposable, IAsyncDisposable
-#else
-    public interface IDisposer : IDisposable
-#endif
     {
         /// <summary>
         /// Adds an object to the disposer. When the disposer is
@@ -43,7 +39,7 @@ namespace Autofac.Core
         /// </summary>
         /// <param name="instance">The instance.</param>
         void AddInstanceForDisposal(IDisposable instance);
-#if ASYNC_DISPOSE_AVAILABLE
+
         /// <summary>
         /// Adds an object to the disposer, where that object implements IAsyncDisposable. When the disposer is
         /// disposed, so will the object be.
@@ -55,6 +51,5 @@ namespace Autofac.Core
         /// that call will throw an exception when it attempts to dispose of the provided instance.
         /// </remarks>
         void AddInstanceForAsyncDisposal(IAsyncDisposable instance);
-#endif
     }
 }

--- a/src/Autofac/Core/IDisposer.cs
+++ b/src/Autofac/Core/IDisposer.cs
@@ -31,7 +31,11 @@ namespace Autofac.Core
     /// Provided on an object that will dispose of other objects when it is
     /// itself disposed.
     /// </summary>
+#if NETCOREAPP3_0
+    public interface IDisposer : IDisposable, IAsyncDisposable
+#else
     public interface IDisposer : IDisposable
+#endif
     {
         /// <summary>
         /// Adds an object to the disposer. When the disposer is
@@ -39,5 +43,18 @@ namespace Autofac.Core
         /// </summary>
         /// <param name="instance">The instance.</param>
         void AddInstanceForDisposal(IDisposable instance);
+#if  NETCOREAPP3_0
+        /// <summary>
+        /// Adds an object to the disposer, where that object implements IAsyncDisposable. When the disposer is
+        /// disposed, so will the object be.
+        /// You should most likely implement IDisposable as well, and call <see cref="AddInstanceForDisposal(IDisposable)"/> instead of this method.
+        /// </summary>
+        /// <param name="instance">The instance.</param>
+        /// <remarks>
+        /// If the provided object only implements IAsyncDisposable, and the <see cref="IDisposer"/> is disposed of using a synchronous Dispose call,
+        /// that call will throw an exception when it attempts to dispose of the provided instance.
+        /// </remarks>
+        void AddInstanceForAsyncDisposal(IAsyncDisposable instance);
+#endif
     }
 }

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -358,7 +358,6 @@ namespace Autofac.Core.Lifetime
             base.Dispose(disposing);
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)
@@ -380,7 +379,6 @@ namespace Autofac.Core.Lifetime
 
             // Don't call the base (which would just call the normal Dispose).
         }
-#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckNotDisposed()

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -358,7 +358,7 @@ namespace Autofac.Core.Lifetime
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -147,7 +147,7 @@ namespace Autofac.Core.Resolving
                 {
                     _activationScope.Disposer.AddInstanceForDisposal(instanceAsDisposable);
                 }
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
                 else if (decoratorTarget is IAsyncDisposable asyncDisposableInstance)
                 {
                     _activationScope.Disposer.AddInstanceForAsyncDisposal(asyncDisposableInstance);

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -144,7 +144,15 @@ namespace Autofac.Core.Resolving
                 // instance once the instance has been activated - assuming that it will be
                 // done during the lifetime scope's Disposer executing.
                 if (decoratorTarget is IDisposable instanceAsDisposable)
+                {
                     _activationScope.Disposer.AddInstanceForDisposal(instanceAsDisposable);
+                }
+#if NETCOREAPP3_0
+                else if (decoratorTarget is IAsyncDisposable asyncDisposableInstance)
+                {
+                    _activationScope.Disposer.AddInstanceForAsyncDisposal(asyncDisposableInstance);
+                }
+#endif
             }
 
             ComponentRegistration.RaiseActivating(this, resolveParameters, ref _newInstance);

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -147,12 +147,10 @@ namespace Autofac.Core.Resolving
                 {
                     _activationScope.Disposer.AddInstanceForDisposal(instanceAsDisposable);
                 }
-#if ASYNC_DISPOSE_AVAILABLE
                 else if (decoratorTarget is IAsyncDisposable asyncDisposableInstance)
                 {
                     _activationScope.Disposer.AddInstanceForAsyncDisposal(asyncDisposableInstance);
                 }
-#endif
             }
 
             ComponentRegistration.RaiseActivating(this, resolveParameters, ref _newInstance);

--- a/src/Autofac/Core/ServiceResources.Designer.cs
+++ b/src/Autofac/Core/ServiceResources.Designer.cs
@@ -11,6 +11,8 @@
 namespace Autofac.Core {
     using System;
     using System.Reflection;
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>

--- a/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
@@ -53,15 +53,10 @@ namespace Autofac.Features.LazyDependencies
                 throw new ArgumentNullException(nameof(registrationAccessor));
 
             var swt = service as IServiceWithType;
-#if NET45
-            var lazyType = GetLazyType(swt);
-            if (swt == null || lazyType == null || !swt.ServiceType.IsGenericTypeDefinedBy(lazyType))
-                return Enumerable.Empty<IComponentRegistration>();
-#else
+
             var lazyType = typeof(Lazy<,>);
             if (swt == null || !swt.ServiceType.IsGenericTypeDefinedBy(lazyType))
                 return Enumerable.Empty<IComponentRegistration>();
-#endif
 
             var genericTypeArguments = swt.ServiceType.GetTypeInfo().GenericTypeArguments.ToArray();
             var valueType = genericTypeArguments[0];
@@ -104,16 +99,5 @@ namespace Autofac.Features.LazyDependencies
 
             return rb.CreateRegistration();
         }
-
-#if NET45
-        private static Type GetLazyType(IServiceWithType serviceWithType)
-        {
-            return serviceWithType != null
-                   && serviceWithType.ServiceType.GetTypeInfo().IsGenericType
-                   && serviceWithType.ServiceType.GetGenericTypeDefinition().FullName == "System.Lazy`2"
-                       ? serviceWithType.ServiceType.GetGenericTypeDefinition()
-                       : null;
-        }
-#endif
     }
 }

--- a/src/Autofac/ILifetimeScope.cs
+++ b/src/Autofac/ILifetimeScope.cs
@@ -69,7 +69,11 @@ namespace Autofac
     /// <seealso cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope"/>
     /// <seealso cref="InstanceSharing"/>
     /// <seealso cref="IComponentLifetime"/>
+#if NETCOREAPP3_0
+    public interface ILifetimeScope : IComponentContext, IDisposable, IAsyncDisposable
+#else
     public interface ILifetimeScope : IComponentContext, IDisposable
+#endif
     {
         /// <summary>
         /// Begin a new nested scope. Component instances created via the new scope

--- a/src/Autofac/ILifetimeScope.cs
+++ b/src/Autofac/ILifetimeScope.cs
@@ -69,7 +69,7 @@ namespace Autofac
     /// <seealso cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope"/>
     /// <seealso cref="InstanceSharing"/>
     /// <seealso cref="IComponentLifetime"/>
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
     public interface ILifetimeScope : IComponentContext, IDisposable, IAsyncDisposable
 #else
     public interface ILifetimeScope : IComponentContext, IDisposable

--- a/src/Autofac/ILifetimeScope.cs
+++ b/src/Autofac/ILifetimeScope.cs
@@ -69,11 +69,7 @@ namespace Autofac
     /// <seealso cref="IRegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.InstancePerLifetimeScope"/>
     /// <seealso cref="InstanceSharing"/>
     /// <seealso cref="IComponentLifetime"/>
-#if ASYNC_DISPOSE_AVAILABLE
     public interface ILifetimeScope : IComponentContext, IDisposable, IAsyncDisposable
-#else
-    public interface ILifetimeScope : IComponentContext, IDisposable
-#endif
     {
         /// <summary>
         /// Begin a new nested scope. Component instances created via the new scope

--- a/src/Autofac/Util/Disposable.cs
+++ b/src/Autofac/Util/Disposable.cs
@@ -33,7 +33,7 @@ namespace Autofac.Util
     /// <summary>
     /// Base class for disposable objects.
     /// </summary>
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
     public class Disposable : IDisposable, IAsyncDisposable
 #else
     public class Disposable : IDisposable
@@ -76,7 +76,7 @@ namespace Autofac.Util
             }
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
 
         [SuppressMessage(
             "Usage",

--- a/src/Autofac/Util/Disposable.cs
+++ b/src/Autofac/Util/Disposable.cs
@@ -33,11 +33,7 @@ namespace Autofac.Util
     /// <summary>
     /// Base class for disposable objects.
     /// </summary>
-#if ASYNC_DISPOSE_AVAILABLE
     public class Disposable : IDisposable, IAsyncDisposable
-#else
-    public class Disposable : IDisposable
-#endif
     {
         private const int DisposedFlag = 1;
         private int _isDisposed;
@@ -76,8 +72,6 @@ namespace Autofac.Util
             }
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
-
         [SuppressMessage(
             "Usage",
             "CA1816:Dispose methods should call SuppressFinalize",
@@ -105,7 +99,5 @@ namespace Autofac.Util
 
             return default;
         }
-
-#endif
     }
 }

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
@@ -14,6 +14,10 @@
     <ProjectReference Include="..\Autofac.Test.Scenarios.ScannedAssembly\Autofac.Test.Scenarios.ScannedAssembly.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <Reference Include="System.ComponentModel.Composition" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Compile Remove="TestResults\**" />
     <EmbeddedResource Remove="TestResults\**" />

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +19,6 @@
     <EmbeddedResource Remove="TestResults\**" />
     <None Remove="TestResults\**" />
   </ItemGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'  ">
-    <DefineConstants>ASYNC_DISPOSE_AVAILABLE;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -19,6 +19,10 @@
     <None Remove="TestResults\**" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'  ">
+    <DefineConstants>ASYNC_DISPOSE_AVAILABLE;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -152,7 +152,6 @@ namespace Autofac.Specification.Test.Features
             Assert.IsType<ImplementorA>(decoratedService.Decorated);
         }
 
-#if NETCOREAPP2_1
         [Fact]
         public void CanResolveDecoratorWithLazyWithMetadata()
         {
@@ -168,7 +167,6 @@ namespace Autofac.Specification.Test.Features
             Assert.IsType<ImplementorA>(decoratedService.Decorated);
             Assert.Equal(123, meta.Metadata.A);
         }
-#endif
 
         [Fact]
         public void CanResolveDecoratorWithOwned()

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac.Test.Scenarios.ScannedAssembly</AssemblyName>
@@ -9,7 +9,6 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Autofac.Test.Scenarios.ScannedAssembly</PackageId>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.1' ">1.6.0</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -39,6 +39,10 @@
     <DefineConstants>$(DefineConstants);PARTIAL_TRUST</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'  ">
+    <DefineConstants>ASYNC_DISPOSE_AVAILABLE;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -10,6 +10,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,15 +36,11 @@
     </PackageReference>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <DefineConstants>$(DefineConstants);PARTIAL_TRUST</DefineConstants>
   </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0'  ">
-    <DefineConstants>ASYNC_DISPOSE_AVAILABLE;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591;SA1602;SA1611</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
@@ -36,11 +36,11 @@
     </PackageReference>
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);PARTIAL_TRUST</DefineConstants>
   </PropertyGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
 

--- a/test/Autofac.Test/Core/ContainerTests.cs
+++ b/test/Autofac.Test/Core/ContainerTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Autofac.Core;
 using Autofac.Test.Scenarios.Parameterisation;
+using Autofac.Test.Util;
 using Xunit;
 
 namespace Autofac.Test.Core
@@ -176,6 +178,28 @@ namespace Autofac.Test.Core
                 container.Resolve<ReplaceableComponent>();
             }
         }
+
+#if NETCOREAPP3_0
+        [Fact]
+        public async ValueTask AsyncContainerDisposeTriggersAsyncServiceDispose()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register(c => new AsyncDisposeTracker()).SingleInstance();
+
+            AsyncDisposeTracker tracker;
+
+            await using (var container = builder.Build())
+            {
+                tracker = container.Resolve<AsyncDisposeTracker>();
+
+                Assert.False(tracker.IsSyncDisposed);
+                Assert.False(tracker.IsAsyncDisposed);
+            }
+
+            Assert.False(tracker.IsSyncDisposed);
+            Assert.True(tracker.IsAsyncDisposed);
+        }
+#endif
 
         private class ReplaceInstanceModule : Module
         {

--- a/test/Autofac.Test/Core/ContainerTests.cs
+++ b/test/Autofac.Test/Core/ContainerTests.cs
@@ -179,7 +179,6 @@ namespace Autofac.Test.Core
             }
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
         [Fact]
         public async ValueTask AsyncContainerDisposeTriggersAsyncServiceDispose()
         {
@@ -199,7 +198,6 @@ namespace Autofac.Test.Core
             Assert.False(tracker.IsSyncDisposed);
             Assert.True(tracker.IsAsyncDisposed);
         }
-#endif
 
         private class ReplaceInstanceModule : Module
         {

--- a/test/Autofac.Test/Core/ContainerTests.cs
+++ b/test/Autofac.Test/Core/ContainerTests.cs
@@ -179,7 +179,7 @@ namespace Autofac.Test.Core
             }
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         [Fact]
         public async ValueTask AsyncContainerDisposeTriggersAsyncServiceDispose()
         {

--- a/test/Autofac.Test/Core/DisposerTests.cs
+++ b/test/Autofac.Test/Core/DisposerTests.cs
@@ -58,7 +58,7 @@ namespace Autofac.Test.Core
             });
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         [Fact]
         public void DisposerDisposesOfObjectsAsyncIfIAsyncDisposableDeclared()
         {

--- a/test/Autofac.Test/Core/DisposerTests.cs
+++ b/test/Autofac.Test/Core/DisposerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Autofac.Core;
 using Autofac.Test.Util;
@@ -38,5 +39,137 @@ namespace Autofac.Test.Core
             disposer.Dispose();
             Assert.True(instance.IsDisposed);
         }
+
+        [Fact]
+        public void CannotAddObjectsToDisposerAfterSyncDispose()
+        {
+            var instance = new DisposeTracker();
+
+            var disposer = new Disposer();
+            disposer.AddInstanceForDisposal(instance);
+            Assert.False(instance.IsDisposed);
+            Assert.False(instance.IsDisposed);
+            disposer.Dispose();
+            Assert.True(instance.IsDisposed);
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                disposer.AddInstanceForDisposal(instance);
+            });
+        }
+
+#if NETCOREAPP3_0
+        [Fact]
+        public void DisposerDisposesOfObjectsAsyncIfIAsyncDisposableDeclared()
+        {
+            var instance = new AsyncDisposeTracker();
+
+            var disposer = new Disposer();
+            disposer.AddInstanceForDisposal(instance);
+            Assert.False(instance.IsSyncDisposed);
+            Assert.False(instance.IsAsyncDisposed);
+            var result = disposer.DisposeAsync();
+            Assert.False(instance.IsSyncDisposed);
+
+            // Dispose is happening async, so this won't be true yet.
+            Assert.False(instance.IsAsyncDisposed);
+
+            // Now we wait.
+            result.GetAwaiter().GetResult();
+
+            Assert.False(instance.IsSyncDisposed);
+            Assert.True(instance.IsAsyncDisposed);
+        }
+
+        [Fact]
+        public void DisposerDisposesOfObjectsSyncIfIDisposableOnly()
+        {
+            var instance = new DisposeTracker();
+
+            var disposer = new Disposer();
+            disposer.AddInstanceForDisposal(instance);
+            Assert.False(instance.IsDisposed);
+            disposer.DisposeAsync().GetAwaiter().GetResult();
+            Assert.True(instance.IsDisposed);
+        }
+
+        [Fact]
+        public void DisposerDisposesOfObjectsSyncIfIAsyncDisposableDeclaredButSyncDisposeCalled()
+        {
+            var instance = new AsyncDisposeTracker();
+
+            var disposer = new Disposer();
+            disposer.AddInstanceForDisposal(instance);
+            Assert.False(instance.IsSyncDisposed);
+            Assert.False(instance.IsAsyncDisposed);
+            disposer.Dispose();
+            Assert.True(instance.IsSyncDisposed);
+            Assert.False(instance.IsAsyncDisposed);
+        }
+
+        [Fact]
+        public void CannotAddObjectsToDisposerAfterAsyncDispose()
+        {
+            var instance = new AsyncDisposeTracker();
+
+            var disposer = new Disposer();
+            disposer.AddInstanceForDisposal(instance);
+            Assert.False(instance.IsSyncDisposed);
+            Assert.False(instance.IsAsyncDisposed);
+            disposer.DisposeAsync().GetAwaiter().GetResult();
+            Assert.False(instance.IsSyncDisposed);
+            Assert.True(instance.IsAsyncDisposed);
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                disposer.AddInstanceForDisposal(instance);
+            });
+        }
+
+        [Fact]
+        public void SyncDisposalOnObjectWithNoIDisposableThrows()
+        {
+            var instance = new AsyncOnlyDisposeTracker();
+
+            var disposer = new Disposer();
+            disposer.AddInstanceForAsyncDisposal(instance);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                disposer.Dispose();
+            });
+        }
+
+        [Fact]
+        public void DisposerAsyncDisposesContainedInstances_InReverseOfOrderAdded()
+        {
+            var disposeOrder = new List<object>();
+
+            var asyncInstance1 = new AsyncDisposeTracker();
+            asyncInstance1.Disposing += (s, e) => disposeOrder.Add(asyncInstance1);
+            var asyncOnlyInstance2 = new AsyncOnlyDisposeTracker();
+            asyncOnlyInstance2.Disposing += (s, e) => disposeOrder.Add(asyncOnlyInstance2);
+            var syncInstance3 = new DisposeTracker();
+            syncInstance3.Disposing += (s, e) => disposeOrder.Add(syncInstance3);
+            var syncInstance4 = new DisposeTracker();
+            syncInstance4.Disposing += (s, e) => disposeOrder.Add(syncInstance4);
+
+            var disposer = new Disposer();
+
+            disposer.AddInstanceForDisposal(asyncInstance1);
+            disposer.AddInstanceForDisposal(syncInstance3);
+            disposer.AddInstanceForDisposal(syncInstance4);
+            disposer.AddInstanceForAsyncDisposal(asyncOnlyInstance2);
+
+            disposer.DisposeAsync().GetAwaiter().GetResult();
+
+            Assert.Collection(
+                disposeOrder,
+                o1 => Assert.Same(asyncOnlyInstance2, o1),
+                o2 => Assert.Same(syncInstance4, o2),
+                o3 => Assert.Same(syncInstance3, o3),
+                o4 => Assert.Same(asyncInstance1, o4));
+        }
+#endif
     }
 }

--- a/test/Autofac.Test/Core/DisposerTests.cs
+++ b/test/Autofac.Test/Core/DisposerTests.cs
@@ -58,7 +58,6 @@ namespace Autofac.Test.Core
             });
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
         [Fact]
         public void DisposerDisposesOfObjectsAsyncIfIAsyncDisposableDeclared()
         {
@@ -170,6 +169,5 @@ namespace Autofac.Test.Core
                 o3 => Assert.Same(syncInstance3, o3),
                 o4 => Assert.Same(asyncInstance1, o4));
         }
-#endif
     }
 }

--- a/test/Autofac.Test/Core/DisposerTests.cs
+++ b/test/Autofac.Test/Core/DisposerTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 using Autofac.Core;
 using Autofac.Test.Util;
 using Xunit;
@@ -59,7 +59,7 @@ namespace Autofac.Test.Core
         }
 
         [Fact]
-        public void DisposerDisposesOfObjectsAsyncIfIAsyncDisposableDeclared()
+        public async ValueTask DisposerDisposesOfObjectsAsyncIfIAsyncDisposableDeclared()
         {
             var instance = new AsyncDisposeTracker();
 
@@ -74,21 +74,21 @@ namespace Autofac.Test.Core
             Assert.False(instance.IsAsyncDisposed);
 
             // Now we wait.
-            result.GetAwaiter().GetResult();
+            await result;
 
             Assert.False(instance.IsSyncDisposed);
             Assert.True(instance.IsAsyncDisposed);
         }
 
         [Fact]
-        public void DisposerDisposesOfObjectsSyncIfIDisposableOnly()
+        public async ValueTask DisposerDisposesOfObjectsSyncIfIDisposableOnly()
         {
             var instance = new DisposeTracker();
 
             var disposer = new Disposer();
             disposer.AddInstanceForDisposal(instance);
             Assert.False(instance.IsDisposed);
-            disposer.DisposeAsync().GetAwaiter().GetResult();
+            await disposer.DisposeAsync();
             Assert.True(instance.IsDisposed);
         }
 
@@ -107,7 +107,7 @@ namespace Autofac.Test.Core
         }
 
         [Fact]
-        public void CannotAddObjectsToDisposerAfterAsyncDispose()
+        public async ValueTask CannotAddObjectsToDisposerAfterAsyncDispose()
         {
             var instance = new AsyncDisposeTracker();
 
@@ -115,7 +115,7 @@ namespace Autofac.Test.Core
             disposer.AddInstanceForDisposal(instance);
             Assert.False(instance.IsSyncDisposed);
             Assert.False(instance.IsAsyncDisposed);
-            disposer.DisposeAsync().GetAwaiter().GetResult();
+            await disposer.DisposeAsync();
             Assert.False(instance.IsSyncDisposed);
             Assert.True(instance.IsAsyncDisposed);
 
@@ -140,7 +140,7 @@ namespace Autofac.Test.Core
         }
 
         [Fact]
-        public void DisposerAsyncDisposesContainedInstances_InReverseOfOrderAdded()
+        public async ValueTask DisposerAsyncDisposesContainedInstances_InReverseOfOrderAdded()
         {
             var disposeOrder = new List<object>();
 
@@ -160,7 +160,7 @@ namespace Autofac.Test.Core
             disposer.AddInstanceForDisposal(syncInstance4);
             disposer.AddInstanceForAsyncDisposal(asyncOnlyInstance2);
 
-            disposer.DisposeAsync().GetAwaiter().GetResult();
+            await disposer.DisposeAsync();
 
             Assert.Collection(
                 disposeOrder,

--- a/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
+++ b/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
@@ -102,7 +102,7 @@ namespace Autofac.Test.Core.Lifetime
             }
         }
 
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
         [Fact]
         public async ValueTask AsyncDisposeLifetimeScopeDisposesRegistrationsAsync()
         {

--- a/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
+++ b/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
@@ -102,7 +102,6 @@ namespace Autofac.Test.Core.Lifetime
             }
         }
 
-#if ASYNC_DISPOSE_AVAILABLE
         [Fact]
         public async ValueTask AsyncDisposeLifetimeScopeDisposesRegistrationsAsync()
         {
@@ -163,7 +162,6 @@ namespace Autofac.Test.Core.Lifetime
             Assert.False(asyncTracker.IsAsyncDisposed);
             Assert.True(asyncTracker.IsSyncDisposed);
         }
-#endif
 
         internal class DependsOnRegisteredInstance
         {

--- a/test/Autofac.Test/Util/AsyncDisposeTracker.cs
+++ b/test/Autofac.Test/Util/AsyncDisposeTracker.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 
 namespace Autofac.Test.Util
 {
-#if ASYNC_DISPOSE_AVAILABLE
     public class AsyncDisposeTracker : IDisposable, IAsyncDisposable
     {
         public event EventHandler<EventArgs> Disposing;
@@ -34,5 +33,4 @@ namespace Autofac.Test.Util
             }
         }
     }
-#endif
 }

--- a/test/Autofac.Test/Util/AsyncDisposeTracker.cs
+++ b/test/Autofac.Test/Util/AsyncDisposeTracker.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Autofac.Test.Util
 {
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
     public class AsyncDisposeTracker : IDisposable, IAsyncDisposable
     {
         public event EventHandler<EventArgs> Disposing;

--- a/test/Autofac.Test/Util/AsyncDisposeTracker.cs
+++ b/test/Autofac.Test/Util/AsyncDisposeTracker.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Autofac.Test.Util
+{
+#if NETCOREAPP3_0
+    public class AsyncDisposeTracker : IDisposable, IAsyncDisposable
+    {
+        public event EventHandler<EventArgs> Disposing;
+
+        public bool IsSyncDisposed { get; set; }
+
+        public bool IsAsyncDisposed { get; set; }
+
+        public void Dispose()
+        {
+            this.IsSyncDisposed = true;
+
+            if (this.Disposing != null)
+            {
+                this.Disposing(this, EventArgs.Empty);
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await Task.Delay(1);
+
+            IsAsyncDisposed = true;
+
+            if (this.Disposing != null)
+            {
+                this.Disposing(this, EventArgs.Empty);
+            }
+        }
+    }
+#endif
+}

--- a/test/Autofac.Test/Util/AsyncOnlyDisposeTracker.cs
+++ b/test/Autofac.Test/Util/AsyncOnlyDisposeTracker.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace Autofac.Test.Util
 {
-#if NETCOREAPP3_0
+#if ASYNC_DISPOSE_AVAILABLE
     public class AsyncOnlyDisposeTracker : IAsyncDisposable
     {
         public event EventHandler<EventArgs> Disposing;

--- a/test/Autofac.Test/Util/AsyncOnlyDisposeTracker.cs
+++ b/test/Autofac.Test/Util/AsyncOnlyDisposeTracker.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 
 namespace Autofac.Test.Util
 {
-#if ASYNC_DISPOSE_AVAILABLE
     public class AsyncOnlyDisposeTracker : IAsyncDisposable
     {
         public event EventHandler<EventArgs> Disposing;
@@ -22,5 +21,4 @@ namespace Autofac.Test.Util
             }
         }
     }
-#endif
 }

--- a/test/Autofac.Test/Util/AsyncOnlyDisposeTracker.cs
+++ b/test/Autofac.Test/Util/AsyncOnlyDisposeTracker.cs
@@ -3,15 +3,18 @@ using System.Threading.Tasks;
 
 namespace Autofac.Test.Util
 {
-    public class DisposeTracker : IDisposable
+#if NETCOREAPP3_0
+    public class AsyncOnlyDisposeTracker : IAsyncDisposable
     {
         public event EventHandler<EventArgs> Disposing;
 
-        public bool IsDisposed { get; set; }
+        public bool IsAsyncDisposed { get; set; }
 
-        public void Dispose()
+        public async ValueTask DisposeAsync()
         {
-            this.IsDisposed = true;
+            await Task.Delay(1);
+
+            IsAsyncDisposed = true;
 
             if (this.Disposing != null)
             {
@@ -19,4 +22,5 @@ namespace Autofac.Test.Util
             }
         }
     }
+#endif
 }

--- a/test/Autofac.Test/Util/DisposeTracker.cs
+++ b/test/Autofac.Test/Util/DisposeTracker.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 
 namespace Autofac.Test.Util
 {


### PR DESCRIPTION
I've made what I believe are the necessary changes to make asynchronous disposal of lifetime scopes work. See https://docs.microsoft.com/en-us/dotnet/api/system.iasyncdisposable?view=dotnet-plat-ext-3.0 for some background.

This now works:

```
await using (var scope = container.BeginLifetimeScope())
{
   var service = scope.Resolve<ServiceThatImplementsIAsyncDisposable>();
   // When the scope disposes, any services that implement IAsyncDisposable will be 
   // Disposed of using DisposeAsync rather than Dispose.
}
```

I've added framework targeting for netcoreapp3.0, and made all the ``IAsyncDisposable`` support conditional on that target.

The main changes for this are in the ``Disposer``, which has to now handle async dispose of all registered objects.  The locking mechanism to sync access to the set of tracked objects has changed from a lock statement to a ``SemaphoreSlim``, because the ``Monitor`` does not work in an async context.  Both ``IDisposable`` items and ``IAsyncDisposable`` items can be added to the same Disposer, and they will be disposed in the same order as they would have been with normal ``Dispose``.  Objects that only have an ``IAsyncDisposable`` implementation will cause an exception to be thrown if a ``LifetimeScope`` is then disposed of synchronously. This matches the behaviour of the main .NET DI system.

The ``Disposable`` base class has been updated to implement ``IAsyncDisposable``, and provide default functionality of calling synchronous  ``Dispose`` if an implementing class does not need to support ``DisposeAsync``.  Container and LifetimeScope do implement ``DisposeAsync``, so they can Dispose of the root lifetime scope and the scope's ``Disposer`` respectively.

There's an associated set of changes needed in the DependencyInjection integration, which I have locally, to allow the Autofac lifetime scope to get cleaned up async on scope end, by implementing IAsyncDisposable on the relevant framework types.

I've added a selection of tests to check that async behaviour works as expected, and plays nicely with normally-disposed and async-disposed objects.