### PR TITLE
Performance Improvement - IsGenericTypeDefinedBy

### DIFF
--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -39,7 +39,7 @@ namespace Autofac.Util
 
         private static readonly ConcurrentDictionary<Type, bool> IsGenericListOrCollectionInterfaceTypeCache = new ConcurrentDictionary<Type, bool>();
 
-        private static readonly ConcurrentDictionary<Tuple<Type, Type>, bool> IsGenericTypeDefinedByCache = new ConcurrentDictionary<Tuple<Type, Type>, bool>();
+        private static readonly ConcurrentDictionary<(Type, Type), bool> IsGenericTypeDefinedByCache = new ConcurrentDictionary<(Type, Type), bool>();
 
         public static Type FunctionReturnType(this Type type)
         {
@@ -148,7 +148,7 @@ namespace Autofac.Util
         public static bool IsGenericTypeDefinedBy(this Type @this, Type openGeneric)
         {
             return IsGenericTypeDefinedByCache.GetOrAdd(
-                Tuple.Create(@this, openGeneric),
+                (@this, openGeneric),
                 key => !key.Item1.GetTypeInfo().ContainsGenericParameters
                     && key.Item1.GetTypeInfo().IsGenericType
                     && key.Item1.GetGenericTypeDefinition() == key.Item2);


### PR DESCRIPTION
I've changed the ``IsGenericTypeDefinedByCache`` dictionary used by TypeExtensions.IsGenericTypeDefinedBy to use ValueTuple as the key, rather than Tuple.

It's used quite a lot, and this change reduces allocations to zero and generally improves performance of the method. It's called quite a lot, so hopefully this will help a little with a few of the generic IoC paths.

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
AMD Ryzen 5 2500U with Radeon Vega Mobile Gfx, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), 64bit RyuJIT


|                    Method | DictSize |       Mean |    Error |    StdDev |     Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |--------- |-----------:|---------:|----------:|-----------:|-------:|------:|------:|----------:|
|    IsGenericTypeDefinedBy |      100 | 1,583.9 ns | 24.77 ns |  23.17 ns | 1,582.2 ns | 0.2441 |     - |     - |     512 B |
| IsGenericTypeDefinedByNew |      100 | 1,049.9 ns | 32.82 ns |  96.26 ns |   991.5 ns |      - |     - |     - |         - |
|    IsGenericTypeDefinedBy |      500 | 1,844.4 ns | 63.29 ns | 186.61 ns | 1,951.4 ns | 0.2441 |     - |     - |     512 B |
| IsGenericTypeDefinedByNew |      500 | 1,072.7 ns | 31.63 ns |  93.26 ns | 1,021.2 ns |      - |     - |     - |         - |
|    IsGenericTypeDefinedBy |     1000 | 1,803.0 ns | 66.45 ns | 195.94 ns | 1,682.7 ns | 0.2441 |     - |     - |     512 B |
| IsGenericTypeDefinedByNew |     1000 | 1,039.4 ns | 30.58 ns |  90.16 ns |   992.4 ns |      - |     - |     - |         - |
|    IsGenericTypeDefinedBy |     2000 | 1,722.9 ns | 35.98 ns | 106.10 ns | 1,660.6 ns | 0.2441 |     - |     - |     512 B |
| IsGenericTypeDefinedByNew |     2000 |   997.5 ns | 19.91 ns |  52.10 ns |   965.5 ns |      - |     - |     - |         - |
|    IsGenericTypeDefinedBy |     5000 | 1,734.9 ns | 34.75 ns | 102.45 ns | 1,666.5 ns | 0.2441 |     - |     - |     512 B |
| IsGenericTypeDefinedByNew |     5000 |   932.6 ns | 16.49 ns |  12.88 ns |   930.7 ns |      - |     - |     - |         - |
|    IsGenericTypeDefinedBy |    10000 | 1,724.1 ns | 39.21 ns | 113.75 ns | 1,671.5 ns | 0.2441 |     - |     - |     512 B |
| IsGenericTypeDefinedByNew |    10000 | 1,034.5 ns | 36.10 ns | 106.43 ns |   961.6 ns |      - |     - |     - |         - |
```

I've not added it to the formal benchmark project because it's a bit niche, but I've put the benchmark in a gist if you want to check it:
https://gist.github.com/alistairjevans/ab67db8be96cedc2d294118e09ed1714



