### PR TITLE
Fix Issue#1030

### DIFF
--- a/src/Autofac/Features/AttributeFilters/KeyFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/KeyFilterAttribute.cs
@@ -121,20 +121,19 @@ namespace Autofac.Features.AttributeFilters
         /// </summary>
         /// <param name="parameter">The specific parameter being resolved that is marked with this attribute.</param>
         /// <param name="context">The component context under which the parameter is being resolved.</param>
+        /// <param name="value">The instance of the object that should be used for the parameter value.</param>
         /// <returns>
-        /// The instance of the object that should be used for the parameter value.
+        /// true if a value can be supplied; otherwise, false.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// Thrown if <paramref name="parameter" /> or <paramref name="context" /> is <see langword="null" />.
         /// </exception>
-        public override object ResolveParameter(ParameterInfo parameter, IComponentContext context)
+        public override bool TryResolveParameter(ParameterInfo parameter, IComponentContext context, out object value)
         {
             if (parameter == null) throw new ArgumentNullException(nameof(parameter));
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            object value;
-            context.TryResolveKeyed(Key, parameter.ParameterType, out value);
-            return value;
+            return context.TryResolveKeyed(Key, parameter.ParameterType, out value);
         }
     }
 }

--- a/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
@@ -142,13 +142,14 @@ namespace Autofac.Features.AttributeFilters
         /// </summary>
         /// <param name="parameter">The specific parameter being resolved that is marked with this attribute.</param>
         /// <param name="context">The component context under which the parameter is being resolved.</param>
+        /// <param name="value">The instance of the object that should be used for the parameter value.</param>
         /// <returns>
-        /// The instance of the object that should be used for the parameter value.
+        /// true if a value can be supplied; otherwise, false.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="parameter" /> or <paramref name="context" /> is <see langword="null" />.
         /// </exception>
-        public override object ResolveParameter(ParameterInfo parameter, IComponentContext context)
+        public override bool TryResolveParameter(ParameterInfo parameter, IComponentContext context, out object value)
         {
             if (parameter == null) throw new ArgumentNullException(nameof(parameter));
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -160,9 +161,11 @@ namespace Autofac.Features.AttributeFilters
             var elementType = GetElementType(parameter.ParameterType);
             var hasMany = elementType != parameter.ParameterType;
 
-            return hasMany
+            value = hasMany
                 ? FilterAllMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value })
                 : FilterOneMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value });
+
+            return true;
         }
 
         private static Type GetElementType(Type type)

--- a/src/Autofac/Features/AttributeFilters/ParameterFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/ParameterFilterAttribute.cs
@@ -61,7 +61,8 @@ namespace Autofac.Features.AttributeFilters
         /// </summary>
         /// <param name="parameter">The specific parameter being resolved that is marked with this attribute.</param>
         /// <param name="context">The component context under which the parameter is being resolved.</param>
-        /// <returns>The instance of the object that should be used for the parameter value.</returns>
-        public abstract object ResolveParameter(ParameterInfo parameter, IComponentContext context);
+        /// <param name="value">The instance of the object that should be used for the parameter value.</param>
+        /// <returns>true if a value can be supplied; otherwise, false.</returns>
+        public abstract bool TryResolveParameter(ParameterInfo parameter, IComponentContext context, out object value);
     }
 }

--- a/src/Autofac/Features/AttributeFilters/RegistrationExtensions.cs
+++ b/src/Autofac/Features/AttributeFilters/RegistrationExtensions.cs
@@ -66,11 +66,15 @@ namespace Autofac.Features.AttributeFilters
             if (builder == null) throw new ArgumentNullException(nameof(builder));
 
             return builder.WithParameter(
-                (p, c) => p.GetCustomAttributes<ParameterFilterAttribute>(true).Any(),
                 (p, c) =>
                 {
+                    if (!p.GetCustomAttributes<ParameterFilterAttribute>(true).Any())
+                        return (false, null);
+
                     var filter = p.GetCustomAttributes<ParameterFilterAttribute>(true).First();
-                    return filter.ResolveParameter(p, c);
+                    bool canResolve = filter.TryResolveParameter(p, c, out object value);
+
+                    return (canResolve, () => value);
                 });
         }
     }

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -80,8 +80,9 @@ namespace Autofac.Features.OpenGenerics
         private static Parameter[] AddDecoratedComponentParameter(Service service, Type decoratedParameterType, IComponentRegistration decoratedComponent, IList<Parameter> configuredParameters)
         {
             var parameter = new ResolvedParameter(
-                (pi, c) => pi.ParameterType == decoratedParameterType,
-                (pi, c) => c.ResolveComponent(new ResolveRequest(service, decoratedComponent, Enumerable.Empty<Parameter>())));
+                (pi, c) => (
+                pi.ParameterType == decoratedParameterType,
+                () => c.ResolveComponent(new ResolveRequest(service, decoratedComponent, Enumerable.Empty<Parameter>()))));
 
             var resultArray = new Parameter[configuredParameters.Count + 1];
             resultArray[0] = parameter;

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -802,21 +802,19 @@ namespace Autofac
         /// <typeparam name="TReflectionActivatorData">Activator data type.</typeparam>
         /// <typeparam name="TStyle">Registration style.</typeparam>
         /// <param name="registration">Registration to set parameter on.</param>
-        /// <param name="parameterSelector">A predicate selecting the parameter to set.</param>
-        /// <param name="valueProvider">The provider that will generate the parameter value.</param>
+        /// <param name="resolveParameter">A predicate selecting the parameter to set and
+        ///     the provider that will generate the parameter value.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         public static IRegistrationBuilder<TLimit, TReflectionActivatorData, TStyle>
             WithParameter<TLimit, TReflectionActivatorData, TStyle>(
                 this IRegistrationBuilder<TLimit, TReflectionActivatorData, TStyle> registration,
-                Func<ParameterInfo, IComponentContext, bool> parameterSelector,
-                Func<ParameterInfo, IComponentContext, object> valueProvider)
+                Func<ParameterInfo, IComponentContext, (bool, Func<object>)> resolveParameter)
             where TReflectionActivatorData : ReflectionActivatorData
         {
-            if (parameterSelector == null) throw new ArgumentNullException(nameof(parameterSelector));
-            if (valueProvider == null) throw new ArgumentNullException(nameof(valueProvider));
+            if (resolveParameter == null) throw new ArgumentNullException(nameof(resolveParameter));
 
             return registration.WithParameter(
-                new ResolvedParameter(parameterSelector, valueProvider));
+                new ResolvedParameter(resolveParameter));
         }
 
         /// <summary>

--- a/test/Autofac.Test/Core/ResolvedParameterTests.cs
+++ b/test/Autofac.Test/Core/ResolvedParameterTests.cs
@@ -17,8 +17,8 @@ namespace Autofac.Test.Core
                 .UsingConstructor(typeof(char), typeof(int))
                 .WithParameter(new TypedParameter(typeof(int), 5))
                 .WithParameter(new ResolvedParameter(
-                    (pi, ctx) => pi.ParameterType == typeof(char),
-                    (pi, ctx) => ctx.ResolveNamed<char>("character")));
+                    (pi, ctx) => (pi.ParameterType == typeof(char), () => ctx.ResolveNamed<char>("character"))));
+
             var c = cb.Build();
             var s = c.Resolve<string>();
             Assert.Equal("aaaaa", s);
@@ -50,9 +50,9 @@ namespace Autofac.Test.Core
             builder.RegisterGeneric(typeof(ConcreteSomething<>));
 
             var decoratedSomethingArgument = new ResolvedParameter(
-                (pi, c) => pi.Name == "decorated",
-                (pi, c) => c.Resolve(typeof(ConcreteSomething<>).MakeGenericType(
-                                pi.ParameterType.GetGenericArguments())));
+                (pi, c) => (
+                pi.Name == "decorated",
+                () => c.Resolve(typeof(ConcreteSomething<>).MakeGenericType(pi.ParameterType.GetGenericArguments()))));
 
             builder.RegisterGeneric(typeof(SomethingDecorator<>))
                 .As(typeof(ISomething<>))

--- a/test/Autofac.Test/ResolutionExtensionsTests.cs
+++ b/test/Autofac.Test/ResolutionExtensionsTests.cs
@@ -78,11 +78,9 @@ namespace Autofac.Test
 
             builder.RegisterType<Parameterised>()
                 .WithParameter(
-                    (pi, c) => pi.Name == "a",
-                    (pi, c) => a)
+                    (pi, c) => (pi.Name == "a", () => a))
                 .WithParameter(
-                    (pi, c) => pi.Name == "b",
-                    (pi, c) => b);
+                    (pi, c) => (pi.Name == "b", () => b));
 
             var container = builder.Build();
             var result = container.Resolve<Parameterised>();


### PR DESCRIPTION
Fix #1030: Change `ParameterFilterAttribute.ResolveParameter` method signature. Enhanced `KeyFilter` attribute: when key is not found the instance can not be resolved (it also has been mentioned in SO: https://stackoverflow.com/questions/52948278/how-can-i-prevent-autofac-from-injecting-null-when-accidentally-used-an-invalid)