### PR TITLE
Fix #1030 - Allow ParameterFilterAttribute to check if parameter can be resolved

### DIFF
--- a/src/Autofac/Features/AttributeFilters/KeyFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/KeyFilterAttribute.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using Autofac.Core;
 
 namespace Autofac.Features.AttributeFilters
 {
@@ -135,6 +136,19 @@ namespace Autofac.Features.AttributeFilters
             object value;
             context.TryResolveKeyed(Key, parameter.ParameterType, out value);
             return value;
+        }
+
+        /// <summary>
+        /// Checks a constructor parameter can be resolved based on keyed service requirements.
+        /// </summary>
+        /// <param name="parameter">The specific parameter being resolved that is marked with this attribute.</param>
+        /// <param name="context">The component context under which the parameter is being resolved.</param>
+        /// <returns>true if parameter can be resolved; otherwise, false.</returns>
+        public override bool CanResolveParameter(ParameterInfo parameter, IComponentContext context)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+            return context.ComponentRegistry.IsRegistered(new KeyedService(Key, parameter.ParameterType));
         }
     }
 }

--- a/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
@@ -105,6 +105,10 @@ namespace Autofac.Features.AttributeFilters
 
         private static readonly MethodInfo FilterAllMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(FilterAll));
 
+        private static readonly MethodInfo CanResolveOneMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(CanResolveOne));
+
+        private static readonly MethodInfo CanResolveAllMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(CanResolveAll));
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MetadataFilterAttribute"/> class.
         /// </summary>
@@ -165,6 +169,31 @@ namespace Autofac.Features.AttributeFilters
                 : FilterOneMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value });
         }
 
+        /// <summary>
+        /// Checks a constructor parameter can be resolved based on metadata requirements.
+        /// </summary>
+        /// <param name="parameter">The specific parameter being resolved that is marked with this attribute.</param>
+        /// <param name="context">The component context under which the parameter is being resolved.</param>
+        /// <returns>true if parameter can be resolved; otherwise, false.</returns>
+        public override bool CanResolveParameter(ParameterInfo parameter, IComponentContext context)
+        {
+            if (parameter == null) throw new ArgumentNullException(nameof(parameter));
+            if (context == null) throw new ArgumentNullException(nameof(context));
+
+            // GetElementType currently is the effective equivalent of "Determine if the type
+            // is in IEnumerable and if it is, get the type being enumerated." This doesn't support
+            // the other relationship types like Lazy<T>, Func<T>, etc. If we need to add that,
+            // this is the place to do it.
+            var elementType = GetElementType(parameter.ParameterType);
+            var hasMany = elementType != parameter.ParameterType;
+
+            object value = hasMany
+                ? CanResolveAllMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value })
+                : CanResolveOneMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value });
+
+            return (bool)value;
+        }
+
         private static Type GetElementType(Type type)
         {
             return type.IsGenericEnumerableInterfaceType() ? type.GetTypeInfo().GenericTypeArguments[0] : type;
@@ -186,6 +215,20 @@ namespace Autofac.Features.AttributeFilters
                 .Where(m => m.Metadata.ContainsKey(metadataKey) && metadataValue.Equals(m.Metadata[metadataKey]))
                 .Select(m => m.Value.Value)
                 .ToArray();
+        }
+
+        private static bool CanResolveOne<T>(IComponentContext context, string metadataKey, object metadataValue)
+        {
+            // Using Lazy<T> to ensure components that aren't actually used won't get activated.
+            return context.Resolve<IEnumerable<Meta<Lazy<T>>>>()
+                .Any(m => m.Metadata.ContainsKey(metadataKey) && metadataValue.Equals(m.Metadata[metadataKey]));
+        }
+
+        private static bool CanResolveAll<T>(IComponentContext context, string metadataKey, object metadataValue)
+        {
+            // Using Lazy<T> to ensure components that aren't actually used won't get activated.
+            return context.Resolve<IEnumerable<Meta<Lazy<T>>>>()
+                .Any(m => m.Metadata.ContainsKey(metadataKey) && metadataValue.Equals(m.Metadata[metadataKey]));
         }
     }
 }

--- a/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
@@ -105,9 +105,7 @@ namespace Autofac.Features.AttributeFilters
 
         private static readonly MethodInfo FilterAllMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(FilterAll));
 
-        private static readonly MethodInfo CanResolveOneMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(CanResolveOne));
-
-        private static readonly MethodInfo CanResolveAllMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(CanResolveAll));
+        private static readonly MethodInfo CanResolveMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(CanResolve));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetadataFilterAttribute"/> class.
@@ -185,13 +183,8 @@ namespace Autofac.Features.AttributeFilters
             // the other relationship types like Lazy<T>, Func<T>, etc. If we need to add that,
             // this is the place to do it.
             var elementType = GetElementType(parameter.ParameterType);
-            var hasMany = elementType != parameter.ParameterType;
 
-            object value = hasMany
-                ? CanResolveAllMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value })
-                : CanResolveOneMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value });
-
-            return (bool)value;
+            return (bool)CanResolveMethod.MakeGenericMethod(elementType).Invoke(null, new[] { context, Key, Value });
         }
 
         private static Type GetElementType(Type type)
@@ -217,14 +210,7 @@ namespace Autofac.Features.AttributeFilters
                 .ToArray();
         }
 
-        private static bool CanResolveOne<T>(IComponentContext context, string metadataKey, object metadataValue)
-        {
-            // Using Lazy<T> to ensure components that aren't actually used won't get activated.
-            return context.Resolve<IEnumerable<Meta<Lazy<T>>>>()
-                .Any(m => m.Metadata.ContainsKey(metadataKey) && metadataValue.Equals(m.Metadata[metadataKey]));
-        }
-
-        private static bool CanResolveAll<T>(IComponentContext context, string metadataKey, object metadataValue)
+        private static bool CanResolve<T>(IComponentContext context, string metadataKey, object metadataValue)
         {
             // Using Lazy<T> to ensure components that aren't actually used won't get activated.
             return context.Resolve<IEnumerable<Meta<Lazy<T>>>>()

--- a/src/Autofac/Features/AttributeFilters/ParameterFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/ParameterFilterAttribute.cs
@@ -63,5 +63,13 @@ namespace Autofac.Features.AttributeFilters
         /// <param name="context">The component context under which the parameter is being resolved.</param>
         /// <returns>The instance of the object that should be used for the parameter value.</returns>
         public abstract object ResolveParameter(ParameterInfo parameter, IComponentContext context);
+
+        /// <summary>
+        /// Implemented in derived classes to check a specific parameter can be resolved.
+        /// </summary>
+        /// <param name="parameter">The specific parameter being resolved that is marked with this attribute.</param>
+        /// <param name="context">The component context under which the parameter is being resolved.</param>
+        /// <returns>true if parameter can be resolved; otherwise, false.</returns>
+        public abstract bool CanResolveParameter(ParameterInfo parameter, IComponentContext context);
     }
 }

--- a/src/Autofac/Features/AttributeFilters/RegistrationExtensions.cs
+++ b/src/Autofac/Features/AttributeFilters/RegistrationExtensions.cs
@@ -66,7 +66,11 @@ namespace Autofac.Features.AttributeFilters
             if (builder == null) throw new ArgumentNullException(nameof(builder));
 
             return builder.WithParameter(
-                (p, c) => p.GetCustomAttributes<ParameterFilterAttribute>(true).Any(),
+                (p, c) =>
+                {
+                    var filter = p.GetCustomAttributes<ParameterFilterAttribute>(true).FirstOrDefault();
+                    return filter != null && filter.CanResolveParameter(p, c);
+                },
                 (p, c) =>
                 {
                     var filter = p.GetCustomAttributes<ParameterFilterAttribute>(true).First();

--- a/test/Autofac.Test/Features/AttributeFilters/WithAttributeFilterTestFixture.cs
+++ b/test/Autofac.Test/Features/AttributeFilters/WithAttributeFilterTestFixture.cs
@@ -321,6 +321,32 @@ namespace Autofac.Test.Features.AttributeFilters
             Assert.Equal(2, adapterActivationCount);
         }
 
+        [Fact]
+        public void RequiredParameterWithKeyFilterCanNotBeResolvedWhenNotRegister()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<RequiredParameterWithKeyFilter>()
+              .WithAttributeFiltering()
+              .As<RequiredParameterWithKeyFilter>();
+
+            Assert.Throws<DependencyResolutionException>(() => builder.Build().Resolve<RequiredParameterWithKeyFilter>());
+        }
+
+        [Fact]
+        public void OptionalParameterWithKeyFilterCanBeResolvedBySpecifiedDefaultValue()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<OptionalParameterWithKeyFilter>()
+              .WithAttributeFiltering()
+              .As<OptionalParameterWithKeyFilter>();
+
+            var instance = builder.Build().Resolve<OptionalParameterWithKeyFilter>();
+
+            Assert.Equal(15, instance.Parameter);
+        }
+
         public interface ILogger
         {
         }
@@ -465,6 +491,26 @@ namespace Autofac.Test.Features.AttributeFilters
 
         public class EmptyMetadata
         {
+        }
+
+        public class RequiredParameterWithKeyFilter
+        {
+            public int Parameter { get; set; }
+
+            public RequiredParameterWithKeyFilter([KeyFilter(0)] int parameter)
+            {
+                Parameter = parameter;
+            }
+        }
+
+        public class OptionalParameterWithKeyFilter
+        {
+            public int Parameter { get; set; }
+
+            public OptionalParameterWithKeyFilter([KeyFilter(0)] int parameter = 15)
+            {
+                Parameter = parameter;
+            }
         }
     }
 }

--- a/test/Autofac.Test/Features/AttributeFilters/WithAttributeFilterTestFixture.cs
+++ b/test/Autofac.Test/Features/AttributeFilters/WithAttributeFilterTestFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Autofac.Core;
 using Autofac.Features.AttributeFilters;
 using Autofac.Features.Metadata;
 using Autofac.Features.OwnedInstances;
@@ -79,6 +80,9 @@ namespace Autofac.Test.Features.AttributeFilters
 
             builder.RegisterType<ToolWindowAdapter>()
                 .Keyed<IAdapter>("Other");
+
+            builder.RegisterType<ConsoleLogger>()
+                .Keyed<ILogger>("Solution");
 
             builder.RegisterType<SolutionExplorerKeyed>()
                 .WithAttributeFiltering();
@@ -266,6 +270,10 @@ namespace Autofac.Test.Features.AttributeFilters
                 .WithMetadata<AdapterMetadata>(m => m.For(am => am.Target, "Other"))
                 .As<IAdapter>();
 
+            builder.RegisterType<ConsoleLogger>()
+                .WithMetadata("LoggerName", "Solution")
+                .As<ILogger>();
+
             builder.RegisterType<SolutionExplorerMetadata>().WithAttributeFiltering();
 
             var container = builder.Build();
@@ -298,6 +306,10 @@ namespace Autofac.Test.Features.AttributeFilters
                 .WithMetadata<AdapterMetadata>(m => m.For(am => am.Target, "Other"))
                 .As<IAdapter>()
                 .OnActivating(h => adapterActivationCount++);
+
+            builder.RegisterType<ConsoleLogger>()
+                .WithMetadata("LoggerName", "Solution")
+                .As<ILogger>();
 
             builder.RegisterType<SolutionExplorerMetadata>()
                 .WithAttributeFiltering();


### PR DESCRIPTION
Add new method to `ParameterFilterAttribute` to check if parameter can be resolved.