### PR TITLE
Check if parent scopes are disposed when checking scope IsDisposed

### DIFF
--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -68,8 +68,9 @@ namespace Autofac.Core.Lifetime
         /// <param name="componentRegistry">Components used in the scope.</param>
         /// <param name="parent">Parent scope.</param>
         protected LifetimeScope(IComponentRegistry componentRegistry, LifetimeScope parent, object tag)
-            : this(parent)
+            : base(parent)
         {
+            _sharedInstances[SelfRegistrationId] = this;
             ComponentRegistry = componentRegistry ?? throw new ArgumentNullException(nameof(componentRegistry));
             Tag = tag ?? throw new ArgumentNullException(nameof(tag));
             ParentLifetimeScope = parent ?? throw new ArgumentNullException(nameof(parent));

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -69,10 +69,8 @@ namespace Autofac.Core.Lifetime
         /// <param name="componentRegistry">Components used in the scope.</param>
         /// <param name="parent">Parent scope.</param>
         protected LifetimeScope(IComponentRegistry componentRegistry, LifetimeScope parent, object tag)
+            : this(componentRegistry, tag)
         {
-            _sharedInstances[SelfRegistrationId] = this;
-            ComponentRegistry = componentRegistry ?? throw new ArgumentNullException(nameof(componentRegistry));
-            Tag = tag ?? throw new ArgumentNullException(nameof(tag));
             parentScope = parent ?? throw new ArgumentNullException(nameof(parent));
             RootLifetimeScope = parentScope.RootLifetimeScope;
         }

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -68,8 +68,10 @@ namespace Autofac.Core.Lifetime
         /// <param name="componentRegistry">Components used in the scope.</param>
         /// <param name="parent">Parent scope.</param>
         protected LifetimeScope(IComponentRegistry componentRegistry, LifetimeScope parent, object tag)
-            : this(componentRegistry, tag)
+            : this(parent)
         {
+            ComponentRegistry = componentRegistry ?? throw new ArgumentNullException(nameof(componentRegistry));
+            Tag = tag ?? throw new ArgumentNullException(nameof(tag));
             ParentLifetimeScope = parent ?? throw new ArgumentNullException(nameof(parent));
             RootLifetimeScope = ParentLifetimeScope.RootLifetimeScope;
         }
@@ -384,7 +386,7 @@ namespace Autofac.Core.Lifetime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CheckNotDisposed()
         {
-            if (IsDisposed)
+            if (IsTreeDisposed())
                 throw new ObjectDisposedException(LifetimeScopeResources.ScopeIsDisposed, innerException: null);
         }
 

--- a/src/Autofac/Core/Lifetime/LifetimeScopeResources.Designer.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScopeResources.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Autofac.Core.Lifetime {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -20,7 +19,7 @@ namespace Autofac.Core.Lifetime {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LifetimeScopeResources {
@@ -40,7 +39,7 @@ namespace Autofac.Core.Lifetime {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Autofac.Core.Lifetime.LifetimeScopeResources", typeof(LifetimeScopeResources).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Autofac.Core.Lifetime.LifetimeScopeResources", typeof(LifetimeScopeResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -71,7 +70,7 @@ namespace Autofac.Core.Lifetime {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope as it has already been disposed..
+        ///   Looks up a localized string similar to Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope as it (or one of its parent scopes) has already been disposed..
         /// </summary>
         internal static string ScopeIsDisposed {
             get {

--- a/src/Autofac/Core/Lifetime/LifetimeScopeResources.resx
+++ b/src/Autofac/Core/Lifetime/LifetimeScopeResources.resx
@@ -121,7 +121,7 @@
     <value>The tag '{0}' has already been assigned to a parent lifetime scope. If you are using Owned&lt;T&gt; this indicates you may have a circular dependency chain.</value>
   </data>
   <data name="ScopeIsDisposed" xml:space="preserve">
-    <value>Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope as it has already been disposed.</value>
+    <value>Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope as it (or one of its parent scopes) has already been disposed.</value>
   </data>
   <data name="SelfConstructingDependencyDetected" xml:space="preserve">
     <value>The constructor of type '{0}' attempted to create another instance of itself. This is not permitted because the service is configured to only allowed a single instance per lifetime scope.</value>

--- a/src/Autofac/Util/Disposable.cs
+++ b/src/Autofac/Util/Disposable.cs
@@ -37,7 +37,7 @@ namespace Autofac.Util
     {
         private const int DisposedFlag = 1;
         private int _isDisposed;
-        private Disposable _parentDisposable;
+        private Disposable? _parentDisposable;
 
         public Disposable()
         {

--- a/src/Autofac/Util/Disposable.cs
+++ b/src/Autofac/Util/Disposable.cs
@@ -37,16 +37,6 @@ namespace Autofac.Util
     {
         private const int DisposedFlag = 1;
         private int _isDisposed;
-        private Disposable? _parentDisposable;
-
-        public Disposable()
-        {
-        }
-
-        public Disposable(Disposable parentDisposable)
-        {
-            _parentDisposable = parentDisposable;
-        }
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
@@ -80,16 +70,6 @@ namespace Autofac.Util
                 Interlocked.MemoryBarrier();
                 return _isDisposed == DisposedFlag;
             }
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether this or any of the parent disposables have been disposed.
-        /// </summary>
-        /// <returns>true if this instance of any of the parent instances have been disposed.</returns>
-        protected bool IsTreeDisposed()
-        {
-            Interlocked.MemoryBarrier();
-            return _isDisposed == DisposedFlag || (_parentDisposable != null && _parentDisposable.IsTreeDisposed());
         }
 
         [SuppressMessage(

--- a/src/Autofac/Util/Disposable.cs
+++ b/src/Autofac/Util/Disposable.cs
@@ -37,6 +37,16 @@ namespace Autofac.Util
     {
         private const int DisposedFlag = 1;
         private int _isDisposed;
+        private Disposable _parentDisposable;
+
+        public Disposable()
+        {
+        }
+
+        public Disposable(Disposable parentDisposable)
+        {
+            _parentDisposable = parentDisposable;
+        }
 
         /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
@@ -70,6 +80,16 @@ namespace Autofac.Util
                 Interlocked.MemoryBarrier();
                 return _isDisposed == DisposedFlag;
             }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this or any of the parent disposables have been disposed.
+        /// </summary>
+        /// <returns>true if this instance of any of the parent instances have been disposed.</returns>
+        protected bool IsTreeDisposed()
+        {
+            Interlocked.MemoryBarrier();
+            return _isDisposed == DisposedFlag || (_parentDisposable != null && _parentDisposable.IsTreeDisposed());
         }
 
         [SuppressMessage(

--- a/test/Autofac.Specification.Test/Lifetime/DisposalTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/DisposalTests.cs
@@ -146,6 +146,62 @@ namespace Autofac.Specification.Test.Lifetime
             Assert.True(rootInstance.IsDisposed);
         }
 
+        [Fact]
+        public void DisposalOfContainerPreventsResolveInLifetimeScope()
+        {
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.Register(c => 1);
+
+            var container = containerBuilder.Build();
+
+            var scope = container.BeginLifetimeScope();
+
+            container.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                scope.Resolve<int>();
+            });
+        }
+
+        [Fact]
+        public void DisposalOfParentScopePreventsResolveInNestedScope()
+        {
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.Register(c => 1);
+
+            var container = containerBuilder.Build();
+
+            var outerScope = container.BeginLifetimeScope();
+            var innerScope = outerScope.BeginLifetimeScope();
+
+            outerScope.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                innerScope.Resolve<int>();
+            });
+        }
+
+        [Fact]
+        public void DisposalOfContainerPreventsResolveInNestedScope()
+        {
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.Register(c => 1);
+
+            var container = containerBuilder.Build();
+
+            var outerScope = container.BeginLifetimeScope();
+            var innerScope = outerScope.BeginLifetimeScope();
+
+            container.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                innerScope.Resolve<int>();
+            });
+        }
+
         private class A : DisposeTracker
         {
         }


### PR DESCRIPTION
Proposed change that fixes #1020 by making disposal exceptions consistently thrown.

This change uses a new ``IsTreeDisposed`` method in ``Disposable``, which checks up the tree of parent scopes to see if any are disposed.

You then always get the correct disposal exception thrown if some part of the scope tree is no longer valid.

I've run the benchmarks on the change, and the effect appears to be minimal; I will supply the raw benchmark results on this over the next few days; thought I'd present the solution as an option.