### PR TITLE
Correct defect with concurrency benchmarks (and add nested scope benchmark)

### DIFF
--- a/bench/Autofac.Benchmarks/Benchmarks.cs
+++ b/bench/Autofac.Benchmarks/Benchmarks.cs
@@ -9,6 +9,7 @@ namespace Autofac.Benchmarks
         {
             typeof(ChildScopeResolveBenchmark),
             typeof(ConcurrencyBenchmark),
+            typeof(ConcurrencyNestedScopeBenchmark),
             typeof(KeyedGenericBenchmark),
             typeof(KeyedNestedBenchmark),
             typeof(KeyedSimpleBenchmark),

--- a/bench/Autofac.Benchmarks/ConcurrencyBenchmak.cs
+++ b/bench/Autofac.Benchmarks/ConcurrencyBenchmak.cs
@@ -26,10 +26,10 @@ namespace Autofac.Benchmarks
             _container = builder.Build();
         }
 
-        [Params(10 /*, 100, 1_000 */)]
+        [Params(100 /*, 100, 1_000 */)]
         public int ResolveTaskCount { get; set; }
 
-        [Params(10 /*, 1_000, 10_000 */)]
+        [Params(100 /*, 1_000, 10_000 */)]
         public int ResolvesPerTask { get; set; }
 
         [Benchmark]
@@ -57,7 +57,7 @@ namespace Autofac.Benchmarks
                 tasks.Add(task);
             }
 
-            Task.WhenAll(tasks);
+            Task.WhenAll(tasks).Wait();
         }
 
         internal class A

--- a/bench/Autofac.Benchmarks/ConcurrencyNestedScopeBenchmark.cs
+++ b/bench/Autofac.Benchmarks/ConcurrencyNestedScopeBenchmark.cs
@@ -1,0 +1,92 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Autofac.Benchmarks
+{
+    /// <summary>
+    /// Test the performance of resolving a relatively simple object graph, but within 2 levels of nested lifetime scopes,
+    /// to simulate a 'per-request' scope model, combined with a unit-of-work inside request.
+    /// </summary>
+    public class ConcurrencyNestedScopeBenchmark
+    {
+        private readonly IContainer _container;
+
+        public ConcurrencyNestedScopeBenchmark()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<MockGlobalSingleton>().SingleInstance();
+            builder.RegisterType<MockRequestScopeService1>().InstancePerMatchingLifetimeScope("request");
+            builder.RegisterType<MockRequestScopeService2>().InstancePerMatchingLifetimeScope("request");
+            builder.RegisterType<MockUnitOfWork>().InstancePerLifetimeScope();
+            _container = builder.Build();
+        }
+
+        [Params(100 /*, 100, 1_000 */)]
+        public int ConcurrentRequests { get; set; }
+
+        [Params(10)]
+        public int RepeatCount { get; set; }
+
+        [Benchmark]
+        public void MultipleResolvesOnMultipleTasks()
+        {
+            var tasks = new List<Task>(ConcurrentRequests);
+
+            for (var i = 0; i < ConcurrentRequests; i++)
+            {
+                var task = Task.Run(() =>
+                {
+                    try
+                    {
+                        for (var j = 0; j < RepeatCount; j++)
+                        {
+                            // Start request
+                            using(var requestScope = _container.BeginLifetimeScope("request"))
+                            {
+                                var service1 = requestScope.Resolve<MockRequestScopeService1>();
+                                Assert.NotNull(service1);
+
+                                using (var unitOfWorkScope = requestScope.BeginLifetimeScope())
+                                {
+                                    var nestedRequestService2 = unitOfWorkScope.Resolve<MockRequestScopeService2>();
+                                    Assert.NotNull(nestedRequestService2);
+                                    var unitOfWork = unitOfWorkScope.Resolve<MockUnitOfWork>();
+                                    Assert.NotNull(unitOfWork);
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Assert.True(false, ex.ToString());
+                    }
+                });
+                tasks.Add(task);
+            }
+
+            Task.WhenAll(tasks).Wait();
+        }
+
+        internal class MockGlobalSingleton
+        {   
+        }
+
+        internal class MockRequestScopeService1
+        {
+            public MockRequestScopeService1() { }
+        }
+
+        internal class MockRequestScopeService2
+        {
+            public MockRequestScopeService2(MockRequestScopeService1 service1, MockGlobalSingleton singleton) { }
+        }
+
+        internal class MockUnitOfWork
+        {
+            public MockUnitOfWork(MockGlobalSingleton singleton) {}
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Harness.cs
+++ b/bench/Autofac.Benchmarks/Harness.cs
@@ -39,6 +39,9 @@ namespace Autofac.Benchmarks
         public void Concurrency() => RunBenchmark<ConcurrencyBenchmark>();
 
         [Fact]
+        public void ConcurrencyNestedScopes() => RunBenchmark<ConcurrencyNestedScopeBenchmark>();
+
+        [Fact]
         public void Decorator_Keyed_Generic() => RunBenchmark<KeyedGenericBenchmark>();
 
         [Fact]


### PR DESCRIPTION
When I was adding a new benchmark for testing nested scope concurrency, the concurrency test was taking absolutely forever, plus I got a CLR crash inside the GC, apparently an out of memory error.

I figured out why...it turns out the concurrency benchmark has never tested autofac concurrency, because at the end of the benchmark method, after building it calls:

```csharp
Task.WhenAll(tasks)
```

This doesn't block, so it returns immediately, and the GC can't clean up the tasks. The benchmark was only testing how fast we can add tasks to a list.

When we add the appropriate wait:

```csharp
Task.WhenAll(tasks).Wait()
```

The concurrency tests run in normal time, and *do* measure autofac performance.

Here's the updated latest develop benchmarks, including for the new benchmark I added.

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
AMD Ryzen 5 2500U with Radeon Vega Mobile Gfx, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100
  [Host]     : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT
  DefaultJob : .NET Core 3.0.0 (CoreCLR 4.700.19.46205, CoreFX 4.700.19.46214), X64 RyuJIT


```
|                          Method | ResolveTaskCount | ResolvesPerTask |     Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------------- |---------------- |---------:|----------:|----------:|----------:|------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |              100 |             100 | 1.727 ms | 0.0342 ms | 0.0407 ms | 2542.9688 |     - |     - |   5.05 MB |

|                          Method | ConcurrentRequests | RepeatCount |     Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |------------------- |------------ |---------:|----------:|----------:|----------:|------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |                100 |          10 | 3.282 ms | 0.0607 ms | 0.0568 ms | 3484.3750 |     - |     - |    6.9 MB |

I'd suggest we run the updated benchmarks on the pending immutable changes before we merge those over.