### PR TITLE
Resolve Issue #925

### DIFF
--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -70,6 +70,13 @@ namespace Autofac.Features.ResolveAnything
                     .Where(t => t.IsAbstract &&
                         !registrationAccessor(new TypedService(t)).Any());
 
+            // If there are not any abstract type parameters, just return true.
+            if (!typeParameters.Any())
+            {
+                return true;
+            }
+
+            // Otherwise check constructors.
             var isValidConstructorFound = false;
             foreach (var constructor in typeInfo.GetConstructors())
             {

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -82,7 +82,7 @@ namespace Autofac.Features.ResolveAnything
             {
                 var parameterTypes = constructor.GetParameters()
                     .Select(p => p.ParameterType)
-                    .ToArray();
+                    .ToList();
 
                 var isTypeParameterInConstructor = typeParameters
                     .Where(t => parameterTypes.Contains(t))

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -63,7 +63,7 @@ namespace Autofac.Features.ResolveAnything
         /// </summary>
         /// <param name="typeInfo">The <see cref="System.Reflection.TypeInfo"/> of the generic type to inspect.</param>
         /// <param name="registrationAccessor">A function that will return existing registrations for a service.</param>
-        /// <returns>Returns true if <paramref name="typeInfo"/> has a constructor that does not depend on a unregistered abstract type.</returns>
+        /// <returns>Returns true if <paramref name="typeInfo"/> has a constructor that does not depend on an unregistered abstract type.</returns>
         private bool IsGenericTypeAValidRegistration(TypeInfo typeInfo, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             var typeParameters = typeInfo.GenericTypeArguments

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -81,7 +81,8 @@ namespace Autofac.Features.ResolveAnything
             foreach (var constructor in typeInfo.GetConstructors())
             {
                 var parameterTypes = constructor.GetParameters()
-                    .Select(p => p.ParameterType);
+                    .Select(p => p.ParameterType)
+                    .ToArray();
 
                 var isTypeParameterInConstructor = typeParameters
                     .Where(t => parameterTypes.Contains(t))

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -91,13 +91,14 @@ namespace Autofac.Features.ResolveAnything
                 return Enumerable.Empty<IComponentRegistration>();
             }
 
-            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Lazy<>))
-            {
-                return Enumerable.Empty<IComponentRegistration>();
-            }
-
+            // Check to resolve issue #925
             if (typeInfo.IsGenericType)
             {
+                if (typeInfo.GetGenericTypeDefinition() == typeof(Lazy<>))
+                {
+                    return Enumerable.Empty<IComponentRegistration>();
+                }
+
                 var typeParameters = typeInfo.GenericTypeArguments
                     .Where(t => t.IsAbstract &&
                         !registrationAccessor(new TypedService(t)).Any());

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -91,6 +91,11 @@ namespace Autofac.Features.ResolveAnything
                 return Enumerable.Empty<IComponentRegistration>();
             }
 
+            if (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Lazy<>))
+            {
+                return Enumerable.Empty<IComponentRegistration>();
+            }
+
             if (typeInfo.IsGenericType)
             {
                 var typeParameters = typeInfo.GenericTypeArguments

--- a/test/Autofac.Test/Features/ResolveAnything/ResolveAnythingTests.cs
+++ b/test/Autofac.Test/Features/ResolveAnything/ResolveAnythingTests.cs
@@ -198,7 +198,7 @@ namespace Autofac.Test.Features.ResolveAnything
             Assert.NotNull(container.Resolve<Progress<Exception>>());
         }
 
-        [Fact(Skip = "Issue #925")]
+        [Fact]
         public void ConstructableOpenGenericsWithUnresolvableTypeParametersCanBeResolved()
         {
             var container = CreateResolveAnythingContainer();

--- a/test/Autofac.Test/Features/ResolveAnything/ResolveAnythingTests.cs
+++ b/test/Autofac.Test/Features/ResolveAnything/ResolveAnythingTests.cs
@@ -209,6 +209,15 @@ namespace Autofac.Test.Features.ResolveAnything
         }
 
         [Fact]
+        public void ConstructableGenericTypeWithGenericTypeArgumentNotMatchingFilterCannotBeResolved()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource(t => t.Name.StartsWith("Generic")));
+            var container = cb.Build();
+            Assert.False(container.IsRegistered<GenericType<AbstractType>>());
+        }
+
+        [Fact]
         public void ConstructableOpenGenericsWithGenericTypeArgumentNotMatchingFilterCanBeResolved()
         {
             var cb = new ContainerBuilder();
@@ -259,6 +268,16 @@ namespace Autofac.Test.Features.ResolveAnything
 
         public abstract class AbstractType
         {
+        }
+
+        public class GenericType<T>
+        {
+            private T _genericParameterInstance;
+
+            public GenericType(T genericParameterInstance)
+            {
+                _genericParameterInstance = genericParameterInstance;
+            }
         }
 
         public class NotRegisteredType


### PR DESCRIPTION
I made an update to try and allow ACTNARS to resolve generic types with abstract type arguments. Essentially, it just checks the constructor of the concrete type to see if the concrete type is dependent on the abstract type arguments. If not, then it provides the registration. I did have to add a special case to make sure it didn't return any Lazy<> registrations that might override the default Lazy<> behavior.