### PR TITLE
Fixes #1102 - AutoActivate Instance Registrations if they have Activation/ed handlers

### DIFF
--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -1465,13 +1465,11 @@ namespace Autofac
             // .OnActivating() handler may call .ReplaceInstance() and we'll
             // have closed over the wrong thing.
             registration.ExternallyOwned();
-
             registration.RegistrationData.ActivatingHandlers.Add((s, e) =>
             {
                 var ra = new ReleaseAction<TLimit>(releaseAction, () => (TLimit)e.Instance);
                 e.Context.Resolve<ILifetimeScope>().Disposer.AddInstanceForDisposal(ra);
             });
-
             return registration;
         }
 

--- a/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
@@ -153,6 +153,36 @@ namespace Autofac.Specification.Test.Lifetime
             Assert.False(dt.IsDisposed);
         }
 
+        [Fact]
+        public void OnReleaseForSingletonStillFiresIfNotResolved()
+        {
+            var builder = new ContainerBuilder();
+
+            var instance = new ReleasingClass();
+
+            builder.RegisterInstance(instance)
+                   .OnRelease(s => s.Dispose());
+
+            using (var container = builder.Build())
+            {
+                using (var scope = container.BeginLifetimeScope())
+                {
+                }
+            }
+
+            Assert.True(instance.Disposed);
+        }
+
+        private class ReleasingClass : IDisposable
+        {
+            public bool Disposed { get; set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+
         private class MethodInjection
         {
             public int Param { get; private set; }

--- a/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
@@ -161,7 +161,7 @@ namespace Autofac.Specification.Test.Lifetime
             var instance = new ReleasingClass();
 
             builder.RegisterInstance(instance)
-                   .OnRelease(s => s.Dispose());
+                   .OnRelease(s => s.Release());
 
             using (var container = builder.Build())
             {
@@ -170,16 +170,16 @@ namespace Autofac.Specification.Test.Lifetime
                 }
             }
 
-            Assert.True(instance.Disposed);
+            Assert.True(instance.Released);
         }
 
-        private class ReleasingClass : IDisposable
+        private class ReleasingClass
         {
-            public bool Disposed { get; set; }
+            public bool Released { get; set; }
 
-            public void Dispose()
+            public void Release()
             {
-                Disposed = true;
+                Released = true;
             }
         }
 


### PR DESCRIPTION
I considered other more complicated options to fix this that didn't use AutoActivate, but simplicity won out here.

I'll put a reference to the original issue on the pipeline event issue, to be considered when we get there.