### PR TITLE
Fixes #1108 - Stop secondary invocation of OnActivating() handlers with decorated instance

### DIFF
--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -102,9 +102,6 @@ namespace Autofac.Core.Resolving
                 _activationScope,
                 resolveParameters);
 
-            if (instance != decoratorTarget)
-                ComponentRegistration.RaiseActivating(this, resolveParameters, ref instance);
-
             var handler = InstanceLookupEnding;
             handler?.Invoke(this, new InstanceLookupEndingEventArgs(this, NewInstanceActivated));
 

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -749,6 +749,92 @@ namespace Autofac.Specification.Test.Features
         }
 
         [Fact]
+        public void ResolvesDecoratedServiceWhenTargetHasOnActivatingHandlerOnType()
+        {
+            var activatingInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>()
+                .OnActivating(args => activatingInstances.Add(args.Instance));
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var instance = container.Resolve<IDecoratedService>();
+
+            Assert.IsType<DecoratorA>(instance);
+            Assert.IsType<ImplementorA>(instance.Decorated);
+
+            Assert.Single(activatingInstances);
+            Assert.IsType<ImplementorA>(activatingInstances[0]);
+        }
+
+        [Fact]
+        public void ResolvesDecoratedServiceWhenTargetHasOnActivatingHandlerOnInterface()
+        {
+            var activatingInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<ImplementorA>().AsSelf();
+            builder.Register<IDecoratedService>(c => c.Resolve<ImplementorA>())
+                .OnActivating(args => activatingInstances.Add(args.Instance));
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var instance = container.Resolve<IDecoratedService>();
+
+            Assert.IsType<DecoratorA>(instance);
+            Assert.IsType<ImplementorA>(instance.Decorated);
+
+            Assert.Single(activatingInstances);
+            Assert.IsType<ImplementorA>(activatingInstances[0]);
+        }
+
+        [Fact]
+        public void ResolvesDecoratedServiceWhenTargetHasOnActivatedHandlerOnType()
+        {
+            var activatedInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>()
+                .OnActivated(args => activatedInstances.Add(args.Instance));
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var instance = container.Resolve<IDecoratedService>();
+
+            Assert.IsType<DecoratorA>(instance);
+            Assert.IsType<ImplementorA>(instance.Decorated);
+
+            Assert.Single(activatedInstances);
+            Assert.IsType<ImplementorA>(activatedInstances[0]);
+        }
+
+        [Fact]
+        public void ResolvesDecoratedServiceWhenTargetHasOnActivatedHandlerOnInterface()
+        {
+            var activatedInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<ImplementorA>().AsSelf();
+            builder.Register<IDecoratedService>(c => c.Resolve<ImplementorA>())
+                .OnActivated(args => activatedInstances.Add(args.Instance));
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var instance = container.Resolve<IDecoratedService>();
+
+            Assert.IsType<DecoratorA>(instance);
+            Assert.IsType<ImplementorA>(instance.Decorated);
+
+            Assert.Single(activatedInstances);
+            Assert.IsType<ImplementorA>(activatedInstances[0]);
+        }
+
+        [Fact]
         public void StartableTypesCanBeDecorated()
         {
             var builder = new ContainerBuilder();

--- a/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
@@ -74,6 +74,30 @@ namespace Autofac.Specification.Test.Lifetime
         }
 
         [Fact]
+        public void MultilpeOnActivatingEventsCanPassReplacementOnward()
+        {
+            var builder = new ContainerBuilder();
+
+            var activatingInstances = new List<object>();
+
+            builder.RegisterType<AService>()
+                .OnActivating(e =>
+                {
+                    activatingInstances.Add(e.Instance);
+                    e.ReplaceInstance(new AServiceChild());
+                })
+                .OnActivating(e => activatingInstances.Add(e.Instance));
+
+            var container = builder.Build();
+            var result = container.Resolve<AService>();
+
+            Assert.IsType<AServiceChild>(result);
+            Assert.Equal(2, activatingInstances.Count);
+            Assert.IsType<AService>(activatingInstances[0]);
+            Assert.IsType<AServiceChild>(activatingInstances[1]);
+        }
+
+        [Fact]
         public void ChainedOnActivatedEventsAreInvokedWithinASingleResolveOperation()
         {
             var builder = new ContainerBuilder();
@@ -435,6 +459,10 @@ namespace Autofac.Specification.Test.Lifetime
         }
 
         private class AService : IService
+        {
+        }
+
+        private class AServiceChild : AService
         {
         }
 

--- a/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/LifetimeEventTests.cs
@@ -88,7 +88,7 @@ namespace Autofac.Specification.Test.Lifetime
         }
 
         [Fact]
-        public void PreparingRaisedForEachResolve()
+        public void PreparingRaisedForEachResolveInstancePerDependency()
         {
             var preparingRaised = 0;
             var cb = new ContainerBuilder();
@@ -98,6 +98,152 @@ namespace Autofac.Specification.Test.Lifetime
             Assert.Equal(1, preparingRaised);
             container.Resolve<object>();
             Assert.Equal(2, preparingRaised);
+        }
+
+        [Fact]
+        public void PreparingRaisedOnceSingleInstance()
+        {
+            var preparingRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>()
+                .SingleInstance()
+                .OnPreparing(e => preparingRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, preparingRaised);
+            container.Resolve<object>();
+            Assert.Equal(1, preparingRaised);
+        }
+
+        [Fact]
+        public void PreparingRaisedForFirstResolveInEachLifetimeScope()
+        {
+            var preparingRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>()
+                .InstancePerLifetimeScope()
+                .OnPreparing(e => preparingRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, preparingRaised);
+            container.Resolve<object>();
+            Assert.Equal(1, preparingRaised);
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerScope.Resolve<object>();
+                Assert.Equal(2, preparingRaised);
+                innerScope.Resolve<object>();
+                Assert.Equal(2, preparingRaised);
+            }
+
+            container.Resolve<object>();
+            Assert.Equal(2, preparingRaised);
+        }
+
+        [Fact]
+        public void ActivatingRaisedForEachResolveInstancePerDependency()
+        {
+            var activatingRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>().OnActivating(e => activatingRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, activatingRaised);
+            container.Resolve<object>();
+            Assert.Equal(2, activatingRaised);
+        }
+
+        [Fact]
+        public void ActivatingRaisedOnceSingleInstance()
+        {
+            var activatingRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>()
+                .SingleInstance()
+                .OnActivating(e => activatingRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, activatingRaised);
+            container.Resolve<object>();
+            Assert.Equal(1, activatingRaised);
+        }
+
+        [Fact]
+        public void ActivatingRaisedForFirstResolveInEachLifetimeScope()
+        {
+            var activatingRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>()
+                .InstancePerLifetimeScope()
+                .OnActivating(e => activatingRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, activatingRaised);
+            container.Resolve<object>();
+            Assert.Equal(1, activatingRaised);
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerScope.Resolve<object>();
+                Assert.Equal(2, activatingRaised);
+                innerScope.Resolve<object>();
+                Assert.Equal(2, activatingRaised);
+            }
+
+            container.Resolve<object>();
+            Assert.Equal(2, activatingRaised);
+        }
+
+        [Fact]
+        public void ActivatedRaisedForEachResolveInstancePerDependency()
+        {
+            var activatedRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>().OnActivated(e => activatedRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, activatedRaised);
+            container.Resolve<object>();
+            Assert.Equal(2, activatedRaised);
+        }
+
+        [Fact]
+        public void ActivatedRaisedOnceSingleInstance()
+        {
+            var activatedRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>()
+                .SingleInstance()
+                .OnActivated(e => activatedRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, activatedRaised);
+            container.Resolve<object>();
+            Assert.Equal(1, activatedRaised);
+        }
+
+        [Fact]
+        public void ActivatedRaisedForFirstResolveInEachLifetimeScope()
+        {
+            var activatedRaised = 0;
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>()
+                .InstancePerLifetimeScope()
+                .OnActivated(e => activatedRaised++);
+            var container = cb.Build();
+            container.Resolve<object>();
+            Assert.Equal(1, activatedRaised);
+            container.Resolve<object>();
+            Assert.Equal(1, activatedRaised);
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerScope.Resolve<object>();
+                Assert.Equal(2, activatedRaised);
+                innerScope.Resolve<object>();
+                Assert.Equal(2, activatedRaised);
+            }
+
+            container.Resolve<object>();
+            Assert.Equal(2, activatedRaised);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1108, specifically the most critical part, as it stops the casting exception from occurring or unexpectedly calling an OnActivating() delegate multiple times.

It also brings OnActivating() back into alignment with the other lifetime events when decorators are in play