### PR TITLE
WIP: Fixes #1113

### DIFF
--- a/bench/Autofac.Benchmarks/Benchmarks.cs
+++ b/bench/Autofac.Benchmarks/Benchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Autofac.Benchmarks.Decorators;
 
 namespace Autofac.Benchmarks
@@ -15,9 +16,13 @@ namespace Autofac.Benchmarks
             typeof(KeyedSimpleBenchmark),
             typeof(KeylessGenericBenchmark),
             typeof(KeylessNestedBenchmark),
+            typeof(KeylessNestedSharedInstanceBenchmark),
             typeof(KeylessNestedLambdaBenchmark),
+            typeof(KeylessNestedSharedInstanceLambdaBenchmark),
             typeof(KeylessSimpleBenchmark),
+            typeof(KeylessSimpleSharedInstanceBenchmark),
             typeof(KeylessSimpleLambdaBenchmark),
+            typeof(KeylessSimpleSharedInstanceLambdaBenchmark),
             typeof(DeepGraphResolveBenchmark),
             typeof(EnumerableResolveBenchmark),
             typeof(PropertyInjectionBenchmark),

--- a/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
+++ b/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
@@ -9,17 +9,33 @@ namespace Autofac.Benchmarks.Decorators
         protected IContainer Container { get; set; }
 
         [Benchmark]
-        public virtual void EnumerableResolve()
+        [Arguments(1)]
+        [Arguments(2)]
+        [Arguments(3)]
+        public virtual void ResolveEnumerableT(int repetitions)
         {
-            var item = this.Container.Resolve<IEnumerable<TCommandHandler>>();
-            GC.KeepAlive(item);
+            var iteration = 1;
+            object item = null;
+            while(iteration++ < repetitions)
+            {
+                item = this.Container.Resolve<IEnumerable<TCommandHandler>>();
+                GC.KeepAlive(item);
+            }
         }
 
         [Benchmark]
-        public virtual void SingleResolve()
+        [Arguments(1)]
+        [Arguments(2)]
+        [Arguments(3)]
+        public virtual void ResolveT(int repetitions)
         {
-            var item = this.Container.Resolve<TCommandHandler>();
-            GC.KeepAlive(item);
+            var iteration = 1;
+            object item = null;
+            while (iteration++ < repetitions)
+            {
+                item = this.Container.Resolve<TCommandHandler>();
+                GC.KeepAlive(item);
+            }
         }
     }
 }

--- a/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks a more complex case of chaining decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessNestedSharedInstanceBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>().SingleInstance();
+            builder.RegisterDecorator<CommandHandlerDecoratorOne, ICommandHandler>();
+            builder.RegisterDecorator<CommandHandlerDecoratorTwo, ICommandHandler>();
+
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceLambdaBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceLambdaBenchmark.cs
@@ -1,0 +1,30 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks a more complex case of chaining decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessNestedSharedInstanceLambdaBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterDecorator<ICommandHandler>(
+                (c, p, i) => new CommandHandlerDecoratorOne(i));
+            builder.RegisterDecorator<ICommandHandler>(
+                (c, p, i) => new CommandHandlerDecoratorTwo(i));
+
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks the shared instance case for decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessSimpleSharedInstanceBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterDecorator<CommandHandlerDecoratorOne, ICommandHandler>();
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceLambdaBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceLambdaBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks the shared instance case for decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessSimpleSharedInstanceLambdaBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterDecorator<ICommandHandler>((c, p, i) => new CommandHandlerDecoratorOne(i));
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Harness.cs
+++ b/bench/Autofac.Benchmarks/Harness.cs
@@ -1,4 +1,4 @@
-// This software is part of the Autofac IoC container
+﻿// This software is part of the Autofac IoC container
 // Copyright © 2011 Autofac Contributors
 // https://autofac.org
 //
@@ -57,13 +57,25 @@ namespace Autofac.Benchmarks
         public void Decorator_Keyless_Nested() => RunBenchmark<KeylessNestedBenchmark>();
 
         [Fact]
+        public void Decorator_Keyless_Nested_Shared_Instance() => RunBenchmark<KeylessNestedSharedInstanceBenchmark>();
+
+        [Fact]
         public void Decorator_Keyless_Nested_Lambda() => RunBenchmark<KeylessNestedLambdaBenchmark>();
+
+        [Fact]
+        public void Decorator_Keyless_Nested_Lambda_Shared_Instance() => RunBenchmark<KeylessNestedSharedInstanceLambdaBenchmark>();
 
         [Fact]
         public void Decorator_Keyless_Simple() => RunBenchmark<KeylessSimpleBenchmark>();
 
         [Fact]
+        public void Decorator_Keyless_Simple_Shared_Instance() => RunBenchmark<KeylessSimpleSharedInstanceBenchmark>();
+
+        [Fact]
         public void Decorator_Keyless_Simple_Lambda() => RunBenchmark<KeylessSimpleLambdaBenchmark>();
+
+        [Fact]
+        public void Decorator_Keyless_Simple_Lambda_Shared_Instance() => RunBenchmark<KeylessSimpleSharedInstanceLambdaBenchmark>();
 
         [Fact]
         public void DeepGraphResolve() => RunBenchmark<DeepGraphResolveBenchmark>();

--- a/src/Autofac/Core/ISharingLifetimeScope.cs
+++ b/src/Autofac/Core/ISharingLifetimeScope.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using Autofac.Core.Lifetime;
 
 namespace Autofac.Core
 {
@@ -51,11 +52,27 @@ namespace Autofac.Core
         bool TryGetSharedInstance(Guid id, out object value);
 
         /// <summary>
+        /// Try to retrieve a shared instance based on a GUID key.
+        /// </summary>
+        /// <param name="instanceKey">Key to look up.</param>
+        /// <param name="value">The instance that has the specified key.</param>
+        /// <returns><c>true</c> if the key was found; otherwise, <c>false</c>.</returns>
+        bool TryGetSharedInstance(SharedInstanceKey instanceKey, out object value);
+
+        /// <summary>
         /// Creates a shared instance with a GUID key.
         /// </summary>
         /// <param name="id">Key.</param>
         /// <param name="creator">A function that will create the instance when called.</param>
         /// <returns>The shared instance.</returns>
         object CreateSharedInstance(Guid id, Func<object> creator);
+
+        /// <summary>
+        /// Retrieves or creates a shared instance with a GUID key.
+        /// </summary>
+        /// <param name="instanceKey">Key.</param>
+        /// <param name="creator">A function that will create the instance when called.</param>
+        /// <returns>The shared instance.</returns>
+        object CreateSharedInstance(SharedInstanceKey instanceKey, Func<object> creator);
     }
 }

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -24,10 +24,13 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Autofac.Builder;
@@ -48,7 +51,7 @@ namespace Autofac.Core.Lifetime
         /// Protects shared instances from concurrent access. Other members and the base class are threadsafe.
         /// </summary>
         private readonly object _synchRoot = new object();
-        private readonly ConcurrentDictionary<Guid, object> _sharedInstances = new ConcurrentDictionary<Guid, object>();
+        private readonly ConcurrentDictionary<SharedInstanceKey, object> _sharedInstances = new ConcurrentDictionary<SharedInstanceKey, object>();
         private object? _anonymousTag;
         private LifetimeScope? parentScope;
 
@@ -82,7 +85,7 @@ namespace Autofac.Core.Lifetime
         /// <param name="componentRegistry">Components used in the scope.</param>
         public LifetimeScope(IComponentRegistry componentRegistry, object tag)
         {
-            _sharedInstances[SelfRegistrationId] = this;
+            _sharedInstances[new SharedInstanceKey(new[] { SelfRegistrationId })] = this;
             ComponentRegistry = componentRegistry ?? throw new ArgumentNullException(nameof(componentRegistry));
             Tag = tag ?? throw new ArgumentNullException(nameof(tag));
             RootLifetimeScope = this;
@@ -292,24 +295,33 @@ namespace Autofac.Core.Lifetime
         /// <inheritdoc />
         public object CreateSharedInstance(Guid id, Func<object> creator)
         {
+            var key = new SharedInstanceKey(id);
+            return CreateSharedInstance(key, creator);
+        }
+
+        public object CreateSharedInstance(SharedInstanceKey instanceKey, Func<object> creator)
+        {
             if (creator == null) throw new ArgumentNullException(nameof(creator));
 
             lock (_synchRoot)
             {
-                if (_sharedInstances.TryGetValue(id, out var result)) return result;
+                if (_sharedInstances.TryGetValue(instanceKey, out var result)) return result;
 
                 result = creator();
-                if (_sharedInstances.ContainsKey(id))
+                if (_sharedInstances.ContainsKey(instanceKey))
                     throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, LifetimeScopeResources.SelfConstructingDependencyDetected, result.GetType().FullName));
 
-                _sharedInstances.TryAdd(id, result);
+                _sharedInstances.TryAdd(instanceKey, result);
 
                 return result;
             }
         }
 
         /// <inheritdoc />
-        public bool TryGetSharedInstance(Guid id, out object value) => _sharedInstances.TryGetValue(id, out value);
+        public bool TryGetSharedInstance(Guid id, out object value) => TryGetSharedInstance(new SharedInstanceKey(id), out value);
+
+        /// <inheritdoc />
+        public bool TryGetSharedInstance(SharedInstanceKey instanceKey, out object value) => _sharedInstances.TryGetValue(instanceKey, out value);
 
         /// <summary>
         /// Gets the disposer associated with this container. Instances can be associated

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -85,7 +85,7 @@ namespace Autofac.Core.Lifetime
         /// <param name="componentRegistry">Components used in the scope.</param>
         public LifetimeScope(IComponentRegistry componentRegistry, object tag)
         {
-            _sharedInstances[new SharedInstanceKey(new[] { SelfRegistrationId })] = this;
+            _sharedInstances[new SharedInstanceKey(SelfRegistrationId)] = this;
             ComponentRegistry = componentRegistry ?? throw new ArgumentNullException(nameof(componentRegistry));
             Tag = tag ?? throw new ArgumentNullException(nameof(tag));
             RootLifetimeScope = this;

--- a/src/Autofac/Core/Lifetime/SharedInstanceKey.cs
+++ b/src/Autofac/Core/Lifetime/SharedInstanceKey.cs
@@ -1,0 +1,81 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2011 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Autofac.Core.Lifetime
+{
+    public class SharedInstanceKey : IEquatable<SharedInstanceKey>
+    {
+        public SharedInstanceKey(Guid id)
+            : this(new Guid[] { id })
+        {
+        }
+
+        public SharedInstanceKey(Guid[] ids)
+        {
+            IDs = ids;
+        }
+
+        public IEnumerable<Guid> IDs { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+            else if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return Equals(obj as SharedInstanceKey);
+        }
+
+        public bool Equals(SharedInstanceKey? other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return IDs.SequenceEqual(other.IDs);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = 13;
+            foreach (var id in IDs)
+            {
+                hash ^= id.GetHashCode() * 397;
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -30,6 +30,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using Autofac.Builder;
+using Autofac.Core.Lifetime;
 using Autofac.Features.Decorators;
 
 namespace Autofac.Core.Resolving
@@ -86,10 +87,14 @@ namespace Autofac.Core.Resolving
 
             var resolveParameters = Parameters as Parameter[] ?? Parameters.ToArray();
 
-            if (!_activationScope.TryGetSharedInstance(ComponentRegistration.Id, out var instance))
+            var instanceKey = _decoratorTargetComponent != null ?
+                new SharedInstanceKey(new[] { ComponentRegistration.Id, _decoratorTargetComponent.Id }) :
+                new SharedInstanceKey(ComponentRegistration.Id);
+
+            if (!_activationScope.TryGetSharedInstance(instanceKey, out var instance))
             {
                 instance = sharing == InstanceSharing.Shared
-                    ? _activationScope.CreateSharedInstance(ComponentRegistration.Id, () => CreateInstance(Parameters))
+                    ? _activationScope.CreateSharedInstance(instanceKey, () => CreateInstance(Parameters))
                     : CreateInstance(Parameters);
             }
 

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -209,6 +209,341 @@ namespace Autofac.Specification.Test.Features
         }
 
         [Fact]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecorators()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                });
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                });
+
+            var services2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                services2,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                    Assert.Same(services[0], s); // single instance
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                    Assert.NotSame(services[1], s); // instance per dependency
+                });
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                });
+
+            var services2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                services2,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    Assert.Same(services[0], s); // single instance
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    Assert.NotSame(services[1], s); // instance per dependency
+                });
+        }
+
+        [Fact(Skip ="Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesInstancePerLifetimeScope()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>().InstancePerLifetimeScope();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            IDecoratedService[] innerServices;
+
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerServices = innerScope.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+                Assert.Collection(
+                    innerServices,
+                    s =>
+                    {
+                        Assert.IsType<DecoratorA>(s);
+                        Assert.IsType<ImplementorA>(s.Decorated);
+                    },
+                    s =>
+                    {
+                        Assert.IsType<DecoratorA>(s);
+                        Assert.IsType<ImplementorB>(s.Decorated);
+                    });
+            }
+
+            var outerServices = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                    Assert.NotSame(innerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                    Assert.NotSame(innerServices[1], s); // instance per lifetime scope
+                });
+
+            var outerServices2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices2,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                    Assert.NotSame(outerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                    Assert.Same(outerServices[1], s); // instance per lifetime scope
+                });
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsInstancePerLifetimeScope()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>().InstancePerLifetimeScope();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            IDecoratedService[] innerServices;
+
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerServices = innerScope.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+                Assert.Collection(
+                    innerServices,
+                    s =>
+                    {
+                        Assert.IsType<DecoratorB>(s);
+                        Assert.IsType<DecoratorA>(s.Decorated);
+                        Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    },
+                    s =>
+                    {
+                        Assert.IsType<DecoratorB>(s);
+                        Assert.IsType<DecoratorA>(s.Decorated);
+                        Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    });
+            }
+
+            var outerServices = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    Assert.NotSame(innerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    Assert.NotSame(innerServices[1], s); // instance per lifetime scope
+                });
+
+            var outerServices2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices2,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    Assert.NotSame(outerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    Assert.Same(outerServices[1], s); // instance per lifetime scope
+                });
+        }
+
+        [Fact]
+        public void CanResolveMultipleDecoratedServicesThenLatestService()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                });
+
+            var service = container.Resolve<IDecoratedService>();
+            Assert.IsType<DecoratorA>(service);
+            Assert.IsType<ImplementorB>(service.Decorated);
+        }
+
+        [Fact]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsThenLatestService()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                });
+
+            var service = container.Resolve<IDecoratedService>();
+            Assert.IsType<DecoratorB>(service);
+            Assert.IsType<DecoratorA>(service.Decorated);
+            Assert.IsType<ImplementorB>(service.Decorated.Decorated);
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesThenLatestServiceWithSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                });
+
+            var service = container.Resolve<IDecoratedService>();
+            Assert.IsType<DecoratorA>(service);
+            Assert.IsType<ImplementorB>(service.Decorated);
+        }
+
+        [Fact]
         public void DecoratedRegistrationCanIncludeImplementationType()
         {
             var builder = new ContainerBuilder();
@@ -262,6 +597,9 @@ namespace Autofac.Specification.Test.Features
                 decorator = (DisposableDecorator)instance;
                 decorated = (DisposableImplementor)instance.Decorated;
             }
+
+            var instance2 = container.Resolve<IDecoratedService>();
+            Assert.NotSame(decorator, instance2);
 
             Assert.Equal(1, decorator.DisposeCallCount);
             Assert.Equal(1, decorated.DisposeCallCount);

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -236,7 +236,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesSingleInstance()
         {
             var builder = new ContainerBuilder();
@@ -277,7 +277,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsSingleInstance()
         {
             var builder = new ContainerBuilder();
@@ -323,7 +323,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip ="Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesInstancePerLifetimeScope()
         {
             var builder = new ContainerBuilder();
@@ -384,7 +384,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsInstancePerLifetimeScope()
         {
             var builder = new ContainerBuilder();
@@ -514,7 +514,7 @@ namespace Autofac.Specification.Test.Features
             Assert.IsType<ImplementorB>(service.Decorated.Decorated);
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesThenLatestServiceWithSingleInstance()
         {
             var builder = new ContainerBuilder();


### PR DESCRIPTION
Introduced class that can generate predictable GUIDS, per RFC 4122 subsection 4.3, and used in InstanceLookup to generate a sort of "composite" guid to store shared instances of decorators in isolation.

Raising this as a WIP to get feedback on approach. If approved, I'll add unit tests for the DeterministicGuid class.