### PR TITLE
Max resolve stack depth is now configurable via extension method

### DIFF
--- a/src/Autofac/Core/Resolving/CircularDependencyDetector.cs
+++ b/src/Autofac/Core/Resolving/CircularDependencyDetector.cs
@@ -34,10 +34,12 @@ namespace Autofac.Core.Resolving
     internal class CircularDependencyDetector
     {
         /// <summary>
-        /// Catch circular dependencies that are triggered by post-resolve processing (e.g. 'OnActivated').
+        /// Gets or sets the value that helps catch circular dependencies that are triggered by post-resolve processing (e.g. 'OnActivated').
         /// </summary>
         [SuppressMessage("SA1306", "SA1306", Justification = "Changed const to static on temporary basis until we can solve circular dependencies without a limit.")]
-        private static int MaxResolveDepth = 50;
+        internal static int MaxResolveDepth { get; set; } = DefaultMaxResolveDepth;
+
+        internal const int DefaultMaxResolveDepth = 50;
 
         private static string CreateDependencyGraphTo(IComponentRegistration registration, Stack<InstanceLookup> activationStack)
         {
@@ -60,7 +62,7 @@ namespace Autofac.Core.Resolving
             if (registration == null) throw new ArgumentNullException(nameof(registration));
 
             if (callDepth > MaxResolveDepth)
-                throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.MaxDepthExceeded, registration));
+                throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, CircularDependencyDetectorResources.MaxDepthExceeded, callDepth, MaxResolveDepth, registration));
 
             // Checks for circular dependency
             foreach (var a in activationStack)

--- a/src/Autofac/Core/Resolving/CircularDependencyDetectorResources.Designer.cs
+++ b/src/Autofac/Core/Resolving/CircularDependencyDetectorResources.Designer.cs
@@ -71,7 +71,7 @@ namespace Autofac.Core.Resolving {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Probable circular dependency between factory-scoped components. Chain includes &apos;{0}&apos;.
+        ///   Looks up a localized string similar to The call stack depth has reached {0}. This exceeded the threshold value {1} (you can set up it with WithMaxResolveStackDepth method). Usually, this means probable circular dependency between factory-scoped components. Chain includes &apos;{2}&apos;.
         /// </summary>
         internal static string MaxDepthExceeded {
             get {

--- a/src/Autofac/Core/Resolving/CircularDependencyDetectorResources.resx
+++ b/src/Autofac/Core/Resolving/CircularDependencyDetectorResources.resx
@@ -121,6 +121,6 @@
     <value>Circular component dependency detected: {0}.</value>
   </data>
   <data name="MaxDepthExceeded" xml:space="preserve">
-    <value>Probable circular dependency between factory-scoped components. Chain includes '{0}'</value>
+    <value>The call stack depth has reached {0}. This exceeded the threshold value {1} (you can set up it with WithMaxResolveStackDepth method). Usually, this means probable circular dependency between factory-scoped components. Chain includes '{2}'</value>
   </data>
 </root>

--- a/src/Autofac/OptionsExtensions.cs
+++ b/src/Autofac/OptionsExtensions.cs
@@ -1,0 +1,53 @@
+﻿// This software is part of the Autofac IoC container
+// Copyright © 2011 Autofac Contributors
+// https://autofac.org
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+using Autofac.Core.Resolving;
+
+namespace Autofac
+{
+    /// <summary>
+    /// Adds possibility to configure internal options.
+    /// </summary>
+    public static class OptionsExtensions
+    {
+        /// <summary>
+        /// Set the maximum resolve stack depth.
+        /// </summary>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="maxStackResolveDepth">The maximum stack resolve depth.</param>
+        /// <returns>Container builder.</returns>
+        public static ContainerBuilder WithMaxResolveStackDepth(this ContainerBuilder builder, int maxStackResolveDepth)
+        {
+            if (maxStackResolveDepth < CircularDependencyDetector.DefaultMaxResolveDepth)
+            {
+                maxStackResolveDepth = CircularDependencyDetector.DefaultMaxResolveDepth;
+            }
+
+            CircularDependencyDetector.MaxResolveDepth = maxStackResolveDepth;
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
My PR based on [#924](https://github.com/autofac/Autofac/pull/924). I carefully read the discussion in this thread. Please let me put my two cents.

First of all, I spent a lot of time investigating such a problem in our codebase. And in the end, I think that we should change the exception message at least. The current message doesn't give any idea of what is really going on.

So my story begins with the decision to replace IoC Container in huge project from old one to Autofac. I can't say that the existing codebase can be called clean architecture but we start working to achieve this goal as a future. As a result of it, when we trying to resolve several controllers we getting a big resolution graph. But this is just one side of the problem. The second one, that we also need to define several child scopes for special registrations based on per scope lifetime.

I thought both of these reasons are played a bad joke with us. I found confirmation that additional scope can be lead to behavior when Autofac will resolve the same service multiply times. [Here](https://stackoverflow.com/questions/59305813/autofac-registers-components-multiple-times) detail description of what I also can see.

Now about #924. It was published more than two years ago. And how I can see nothing was changed with CircularDependencyDetector.cs so I can say that it wasn't a good idea to reject those request. I saw that Travis Illig suggest as a solution for this problem to use some reflection to change MaxResolveDepth value at runtime but how I can say this is not a good way for me/us - because we will create some dirty hack that we need to remember about and support it in future. And this is not a good way for enterprise code.

TL;DR this problem is real, hard to investigate and we don't have any nice and simple way to fix it.

How I think this simple extension method can provide a clean way to resolve such an issue. If someday Autofac contributes will decide to rewrite CircularDependencyDetector there's no problem to support this extension a few versions after to provide compatibility. The payload of it can be removed and the method can be marked as obsolete.