### PR TITLE
Expanded Decorator Benchmarks and tests for #1113

### DIFF
--- a/bench/Autofac.Benchmarks/Benchmarks.cs
+++ b/bench/Autofac.Benchmarks/Benchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Autofac.Benchmarks.Decorators;
 
 namespace Autofac.Benchmarks
@@ -15,9 +16,13 @@ namespace Autofac.Benchmarks
             typeof(KeyedSimpleBenchmark),
             typeof(KeylessGenericBenchmark),
             typeof(KeylessNestedBenchmark),
+            typeof(KeylessNestedSharedInstanceBenchmark),
             typeof(KeylessNestedLambdaBenchmark),
+            typeof(KeylessNestedSharedInstanceLambdaBenchmark),
             typeof(KeylessSimpleBenchmark),
+            typeof(KeylessSimpleSharedInstanceBenchmark),
             typeof(KeylessSimpleLambdaBenchmark),
+            typeof(KeylessSimpleSharedInstanceLambdaBenchmark),
             typeof(DeepGraphResolveBenchmark),
             typeof(EnumerableResolveBenchmark),
             typeof(PropertyInjectionBenchmark),

--- a/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
+++ b/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
@@ -8,18 +8,30 @@ namespace Autofac.Benchmarks.Decorators
     {
         protected IContainer Container { get; set; }
 
+        [Benchmark(Baseline =true)]
+        public virtual void Baseline()
+        {
+            using (var scope = Container.BeginLifetimeScope())
+            {
+                //NO-OP for baseline measurement
+            }
+        }
+
         [Benchmark]
         [Arguments(1)]
         [Arguments(2)]
         [Arguments(3)]
         public virtual void ResolveEnumerableT(int repetitions)
         {
-            var iteration = 1;
-            object item = null;
-            while(iteration++ < repetitions)
+            using (var scope = Container.BeginLifetimeScope())
             {
-                item = this.Container.Resolve<IEnumerable<TCommandHandler>>();
-                GC.KeepAlive(item);
+                var iteration = 0;
+                object item = null;
+                while (iteration++ < repetitions)
+                {
+                    item = scope.Resolve<IEnumerable<TCommandHandler>>();
+                    GC.KeepAlive(item);
+                }
             }
         }
 
@@ -29,12 +41,15 @@ namespace Autofac.Benchmarks.Decorators
         [Arguments(3)]
         public virtual void ResolveT(int repetitions)
         {
-            var iteration = 1;
-            object item = null;
-            while (iteration++ < repetitions)
+            using (var scope = Container.BeginLifetimeScope())
             {
-                item = this.Container.Resolve<TCommandHandler>();
-                GC.KeepAlive(item);
+                var iteration = 0;
+                object item = null;
+                while (iteration++ < repetitions)
+                {
+                    item = scope.Resolve<TCommandHandler>();
+                    GC.KeepAlive(item);
+                }
             }
         }
     }

--- a/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
+++ b/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
@@ -9,17 +9,33 @@ namespace Autofac.Benchmarks.Decorators
         protected IContainer Container { get; set; }
 
         [Benchmark]
-        public virtual void EnumerableResolve()
+        [Arguments(1)]
+        [Arguments(2)]
+        [Arguments(3)]
+        public virtual void ResolveEnumerableT(int repetitions)
         {
-            var item = this.Container.Resolve<IEnumerable<TCommandHandler>>();
-            GC.KeepAlive(item);
+            var iteration = 1;
+            object item = null;
+            while(iteration++ < repetitions)
+            {
+                item = this.Container.Resolve<IEnumerable<TCommandHandler>>();
+                GC.KeepAlive(item);
+            }
         }
 
         [Benchmark]
-        public virtual void SingleResolve()
+        [Arguments(1)]
+        [Arguments(2)]
+        [Arguments(3)]
+        public virtual void ResolveT(int repetitions)
         {
-            var item = this.Container.Resolve<TCommandHandler>();
-            GC.KeepAlive(item);
+            var iteration = 1;
+            object item = null;
+            while (iteration++ < repetitions)
+            {
+                item = this.Container.Resolve<TCommandHandler>();
+                GC.KeepAlive(item);
+            }
         }
     }
 }

--- a/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks a more complex case of chaining decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessNestedSharedInstanceBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>().SingleInstance();
+            builder.RegisterDecorator<CommandHandlerDecoratorOne, ICommandHandler>();
+            builder.RegisterDecorator<CommandHandlerDecoratorTwo, ICommandHandler>();
+
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceBenchmark.cs
@@ -15,9 +15,10 @@ namespace Autofac.Benchmarks.Decorators
 
             builder.RegisterType<CommandHandlerOne>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterType<CommandHandlerTwo>()
-                .As<ICommandHandler>().SingleInstance();
+                .As<ICommandHandler>()
+                .InstancePerLifetimeScope();
             builder.RegisterDecorator<CommandHandlerDecoratorOne, ICommandHandler>();
             builder.RegisterDecorator<CommandHandlerDecoratorTwo, ICommandHandler>();
 

--- a/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceLambdaBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceLambdaBenchmark.cs
@@ -1,0 +1,30 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks a more complex case of chaining decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessNestedSharedInstanceLambdaBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterDecorator<ICommandHandler>(
+                (c, p, i) => new CommandHandlerDecoratorOne(i));
+            builder.RegisterDecorator<ICommandHandler>(
+                (c, p, i) => new CommandHandlerDecoratorTwo(i));
+
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceLambdaBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessNestedSharedInstanceLambdaBenchmark.cs
@@ -15,10 +15,10 @@ namespace Autofac.Benchmarks.Decorators
 
             builder.RegisterType<CommandHandlerOne>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterType<CommandHandlerTwo>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterDecorator<ICommandHandler>(
                 (c, p, i) => new CommandHandlerDecoratorOne(i));
             builder.RegisterDecorator<ICommandHandler>(

--- a/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceBenchmark.cs
@@ -16,10 +16,10 @@ namespace Autofac.Benchmarks.Decorators
             var builder = new ContainerBuilder();
             builder.RegisterType<CommandHandlerOne>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterType<CommandHandlerTwo>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterDecorator<CommandHandlerDecoratorOne, ICommandHandler>();
             this.Container = builder.Build();
         }

--- a/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks the shared instance case for decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessSimpleSharedInstanceBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterDecorator<CommandHandlerDecoratorOne, ICommandHandler>();
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceLambdaBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceLambdaBenchmark.cs
@@ -16,10 +16,10 @@ namespace Autofac.Benchmarks.Decorators
             var builder = new ContainerBuilder();
             builder.RegisterType<CommandHandlerOne>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterType<CommandHandlerTwo>()
                 .As<ICommandHandler>()
-                .SingleInstance();
+                .InstancePerLifetimeScope();
             builder.RegisterDecorator<ICommandHandler>((c, p, i) => new CommandHandlerDecoratorOne(i));
             this.Container = builder.Build();
         }

--- a/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceLambdaBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeylessSimpleSharedInstanceLambdaBenchmark.cs
@@ -1,0 +1,27 @@
+﻿using Autofac.Benchmarks.Decorators.Scenario;
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+
+namespace Autofac.Benchmarks.Decorators
+{
+    /// <summary>
+    /// Benchmarks the shared instance case for decorators using the new keyless syntax.
+    /// </summary>
+    public class KeylessSimpleSharedInstanceLambdaBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+    {
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<CommandHandlerOne>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterType<CommandHandlerTwo>()
+                .As<ICommandHandler>()
+                .SingleInstance();
+            builder.RegisterDecorator<ICommandHandler>((c, p, i) => new CommandHandlerDecoratorOne(i));
+            this.Container = builder.Build();
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/Harness.cs
+++ b/bench/Autofac.Benchmarks/Harness.cs
@@ -1,4 +1,4 @@
-// This software is part of the Autofac IoC container
+﻿// This software is part of the Autofac IoC container
 // Copyright © 2011 Autofac Contributors
 // https://autofac.org
 //
@@ -57,13 +57,25 @@ namespace Autofac.Benchmarks
         public void Decorator_Keyless_Nested() => RunBenchmark<KeylessNestedBenchmark>();
 
         [Fact]
+        public void Decorator_Keyless_Nested_Shared_Instance() => RunBenchmark<KeylessNestedSharedInstanceBenchmark>();
+
+        [Fact]
         public void Decorator_Keyless_Nested_Lambda() => RunBenchmark<KeylessNestedLambdaBenchmark>();
+
+        [Fact]
+        public void Decorator_Keyless_Nested_Lambda_Shared_Instance() => RunBenchmark<KeylessNestedSharedInstanceLambdaBenchmark>();
 
         [Fact]
         public void Decorator_Keyless_Simple() => RunBenchmark<KeylessSimpleBenchmark>();
 
         [Fact]
+        public void Decorator_Keyless_Simple_Shared_Instance() => RunBenchmark<KeylessSimpleSharedInstanceBenchmark>();
+
+        [Fact]
         public void Decorator_Keyless_Simple_Lambda() => RunBenchmark<KeylessSimpleLambdaBenchmark>();
+
+        [Fact]
+        public void Decorator_Keyless_Simple_Lambda_Shared_Instance() => RunBenchmark<KeylessSimpleSharedInstanceLambdaBenchmark>();
 
         [Fact]
         public void DeepGraphResolve() => RunBenchmark<DeepGraphResolveBenchmark>();

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -209,6 +209,341 @@ namespace Autofac.Specification.Test.Features
         }
 
         [Fact]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecorators()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                });
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                });
+
+            var services2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                services2,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                    Assert.Same(services[0], s); // single instance
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                    Assert.NotSame(services[1], s); // instance per dependency
+                });
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                });
+
+            var services2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                services2,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    Assert.Same(services[0], s); // single instance
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    Assert.NotSame(services[1], s); // instance per dependency
+                });
+        }
+
+        [Fact(Skip ="Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesInstancePerLifetimeScope()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>().InstancePerLifetimeScope();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            IDecoratedService[] innerServices;
+
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerServices = innerScope.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+                Assert.Collection(
+                    innerServices,
+                    s =>
+                    {
+                        Assert.IsType<DecoratorA>(s);
+                        Assert.IsType<ImplementorA>(s.Decorated);
+                    },
+                    s =>
+                    {
+                        Assert.IsType<DecoratorA>(s);
+                        Assert.IsType<ImplementorB>(s.Decorated);
+                    });
+            }
+
+            var outerServices = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                    Assert.NotSame(innerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                    Assert.NotSame(innerServices[1], s); // instance per lifetime scope
+                });
+
+            var outerServices2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices2,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                    Assert.NotSame(outerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                    Assert.Same(outerServices[1], s); // instance per lifetime scope
+                });
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsInstancePerLifetimeScope()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>().InstancePerLifetimeScope();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            IDecoratedService[] innerServices;
+
+            using (var innerScope = container.BeginLifetimeScope())
+            {
+                innerServices = innerScope.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+                Assert.Collection(
+                    innerServices,
+                    s =>
+                    {
+                        Assert.IsType<DecoratorB>(s);
+                        Assert.IsType<DecoratorA>(s.Decorated);
+                        Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    },
+                    s =>
+                    {
+                        Assert.IsType<DecoratorB>(s);
+                        Assert.IsType<DecoratorA>(s.Decorated);
+                        Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    });
+            }
+
+            var outerServices = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    Assert.NotSame(innerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    Assert.NotSame(innerServices[1], s); // instance per lifetime scope
+                });
+
+            var outerServices2 = container.Resolve<IEnumerable<IDecoratedService>>().ToArray();
+            Assert.Collection(
+                outerServices2,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                    Assert.NotSame(outerServices[0], s); // instance per dependency
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                    Assert.Same(outerServices[1], s); // instance per lifetime scope
+                });
+        }
+
+        [Fact]
+        public void CanResolveMultipleDecoratedServicesThenLatestService()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                });
+
+            var service = container.Resolve<IDecoratedService>();
+            Assert.IsType<DecoratorA>(service);
+            Assert.IsType<ImplementorB>(service.Decorated);
+        }
+
+        [Fact]
+        public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsThenLatestService()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            builder.RegisterDecorator<DecoratorB, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorA>(s.Decorated.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorB>(s);
+                    Assert.IsType<DecoratorA>(s.Decorated);
+                    Assert.IsType<ImplementorB>(s.Decorated.Decorated);
+                });
+
+            var service = container.Resolve<IDecoratedService>();
+            Assert.IsType<DecoratorB>(service);
+            Assert.IsType<DecoratorA>(service.Decorated);
+            Assert.IsType<ImplementorB>(service.Decorated.Decorated);
+        }
+
+        [Fact(Skip = "Issue 1113")]
+        public void CanResolveMultipleDecoratedServicesThenLatestServiceWithSingleInstance()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ImplementorA>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterType<ImplementorB>().As<IDecoratedService>().SingleInstance();
+            builder.RegisterDecorator<DecoratorA, IDecoratedService>();
+            var container = builder.Build();
+
+            var services = container.Resolve<IEnumerable<IDecoratedService>>();
+
+            Assert.Collection(
+                services,
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorA>(s.Decorated);
+                },
+                s =>
+                {
+                    Assert.IsType<DecoratorA>(s);
+                    Assert.IsType<ImplementorB>(s.Decorated);
+                });
+
+            var service = container.Resolve<IDecoratedService>();
+            Assert.IsType<DecoratorA>(service);
+            Assert.IsType<ImplementorB>(service.Decorated);
+        }
+
+        [Fact]
         public void DecoratedRegistrationCanIncludeImplementationType()
         {
             var builder = new ContainerBuilder();
@@ -262,6 +597,9 @@ namespace Autofac.Specification.Test.Features
                 decorator = (DisposableDecorator)instance;
                 decorated = (DisposableImplementor)instance.Decorated;
             }
+
+            var instance2 = container.Resolve<IDecoratedService>();
+            Assert.NotSame(decorator, instance2);
 
             Assert.Equal(1, decorator.DisposeCallCount);
             Assert.Equal(1, decorated.DisposeCallCount);


### PR DESCRIPTION
A response to good feedback from PR #1114 that I subsequently abandoned to start on a clean slate.

This adds skipped unit tests that illustrate issue #1113 and adds/expands on the decorator benchmarks.