### PR TITLE
Fixes #1113- Adding multi-id qualification to stored instances in lifetime scope

### DIFF
--- a/src/Autofac/Core/ISharingLifetimeScope.cs
+++ b/src/Autofac/Core/ISharingLifetimeScope.cs
@@ -51,11 +51,31 @@ namespace Autofac.Core
         bool TryGetSharedInstance(Guid id, out object value);
 
         /// <summary>
+        /// Try to retrieve a shared instance based on a primary GUID key and
+        /// possible secondary qualifying GUID key.
+        /// </summary>
+        /// <param name="primaryId">Key to look up.</param>
+        /// <param name="qualifyingId">Secondary key to look up.</param>
+        /// <param name="value">The instance that has the specified key.</param>
+        /// <returns><c>true</c> if the key was found; otherwise, <c>false</c>.</returns>
+        bool TryGetSharedInstance(Guid primaryId, Guid? qualifyingId, out object value);
+
+        /// <summary>
         /// Creates a shared instance with a GUID key.
         /// </summary>
         /// <param name="id">Key.</param>
         /// <param name="creator">A function that will create the instance when called.</param>
         /// <returns>The shared instance.</returns>
         object CreateSharedInstance(Guid id, Func<object> creator);
+
+        /// <summary>
+        /// Creates a shared instance with a primary GUID key and
+        /// possible secondary qualifying GUID key.
+        /// </summary>
+        /// <param name="primaryId">Key.</param>
+        /// <param name="qualifyingId">Secondary key to look up.</param>
+        /// <param name="creator">A function that will create the instance when called.</param>
+        /// <returns>The shared instance.</returns>
+        object CreateSharedInstance(Guid primaryId, Guid? qualifyingId, Func<object> creator);
     }
 }

--- a/src/Autofac/Core/ISharingLifetimeScope.cs
+++ b/src/Autofac/Core/ISharingLifetimeScope.cs
@@ -55,8 +55,11 @@ namespace Autofac.Core
         /// possible secondary qualifying GUID key.
         /// </summary>
         /// <param name="primaryId">Key to look up.</param>
-        /// <param name="qualifyingId">Secondary key to look up.</param>
-        /// <param name="value">The instance that has the specified key.</param>
+        /// <param name="qualifyingId">
+        /// Secondary key to look up, to better identify an instance that wraps around another instance
+        /// or is otherwise "namespaced" by it.
+        /// </param>
+        /// <param name="value">The instance that has the specified keys.</param>
         /// <returns><c>true</c> if the key was found; otherwise, <c>false</c>.</returns>
         bool TryGetSharedInstance(Guid primaryId, Guid? qualifyingId, out object value);
 
@@ -73,7 +76,10 @@ namespace Autofac.Core
         /// possible secondary qualifying GUID key.
         /// </summary>
         /// <param name="primaryId">Key.</param>
-        /// <param name="qualifyingId">Secondary key.</param>
+        /// <param name="qualifyingId">
+        /// Secondary key, to better identify an instance that wraps around another instance
+        /// or is otherwise "namespaced" by it.
+        /// </param>
         /// <param name="creator">A function that will create the instance when called.</param>
         /// <returns>The shared instance.</returns>
         object CreateSharedInstance(Guid primaryId, Guid? qualifyingId, Func<object> creator);

--- a/src/Autofac/Core/ISharingLifetimeScope.cs
+++ b/src/Autofac/Core/ISharingLifetimeScope.cs
@@ -73,7 +73,7 @@ namespace Autofac.Core
         /// possible secondary qualifying GUID key.
         /// </summary>
         /// <param name="primaryId">Key.</param>
-        /// <param name="qualifyingId">Secondary key to look up.</param>
+        /// <param name="qualifyingId">Secondary key.</param>
         /// <param name="creator">A function that will create the instance when called.</param>
         /// <returns>The shared instance.</returns>
         object CreateSharedInstance(Guid primaryId, Guid? qualifyingId, Func<object> creator);

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -48,7 +48,8 @@ namespace Autofac.Core.Lifetime
         /// Protects shared instances from concurrent access. Other members and the base class are threadsafe.
         /// </summary>
         private readonly object _synchRoot = new object();
-        private readonly ConcurrentDictionary<(Guid, Guid?), object> _sharedInstances = new ConcurrentDictionary<(Guid, Guid?), object>();
+        private readonly ConcurrentDictionary<Guid, object> _sharedInstances = new ConcurrentDictionary<Guid, object>();
+        private readonly ConcurrentDictionary<(Guid, Guid), object> _sharedQualifiedInstances = new ConcurrentDictionary<(Guid, Guid), object>();
         private object? _anonymousTag;
         private LifetimeScope? parentScope;
 
@@ -82,7 +83,7 @@ namespace Autofac.Core.Lifetime
         /// <param name="componentRegistry">Components used in the scope.</param>
         public LifetimeScope(IComponentRegistry componentRegistry, object tag)
         {
-            _sharedInstances[(SelfRegistrationId, null)] = this;
+            _sharedInstances[SelfRegistrationId] = this;
             ComponentRegistry = componentRegistry ?? throw new ArgumentNullException(nameof(componentRegistry));
             Tag = tag ?? throw new ArgumentNullException(nameof(tag));
             RootLifetimeScope = this;
@@ -292,35 +293,56 @@ namespace Autofac.Core.Lifetime
         /// <inheritdoc />
         public object CreateSharedInstance(Guid id, Func<object> creator)
         {
-            return CreateSharedInstance(id, null, creator);
+            if (creator == null) throw new ArgumentNullException(nameof(creator));
+            lock (_synchRoot)
+            {
+                if (_sharedInstances.TryGetValue(id, out var result)) return result;
+
+                result = creator();
+                if (_sharedInstances.ContainsKey(id))
+                    throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, LifetimeScopeResources.SelfConstructingDependencyDetected, result.GetType().FullName));
+
+                _sharedInstances.TryAdd(id, result);
+
+                return result;
+            }
         }
 
         /// <inheritdoc/>
         public object CreateSharedInstance(Guid primaryId, Guid? qualifyingId, Func<object> creator)
         {
             if (creator == null) throw new ArgumentNullException(nameof(creator));
+            if (qualifyingId == null)
+            {
+                return CreateSharedInstance(primaryId, creator);
+            }
 
             lock (_synchRoot)
             {
-                var instanceKey = (primaryId, qualifyingId);
+                var instanceKey = (primaryId, qualifyingId.Value);
 
-                if (_sharedInstances.TryGetValue(instanceKey, out var result)) return result;
+                if (_sharedQualifiedInstances.TryGetValue(instanceKey, out var result)) return result;
 
                 result = creator();
-                if (_sharedInstances.ContainsKey(instanceKey))
+                if (_sharedQualifiedInstances.ContainsKey(instanceKey))
                     throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, LifetimeScopeResources.SelfConstructingDependencyDetected, result.GetType().FullName));
 
-                _sharedInstances.TryAdd(instanceKey, result);
+                _sharedQualifiedInstances.TryAdd(instanceKey, result);
 
                 return result;
             }
         }
 
         /// <inheritdoc />
-        public bool TryGetSharedInstance(Guid id, out object value) => TryGetSharedInstance(id, null, out value);
+        public bool TryGetSharedInstance(Guid id, out object value) => _sharedInstances.TryGetValue(id, out value);
 
         /// <inheritdoc/>
-        public bool TryGetSharedInstance(Guid primaryId, Guid? qualifyingId, out object value) => _sharedInstances.TryGetValue((primaryId, qualifyingId), out value);
+        public bool TryGetSharedInstance(Guid primaryId, Guid? qualifyingId, out object value)
+        {
+            return qualifyingId == null
+                ? TryGetSharedInstance(primaryId, out value)
+                : _sharedQualifiedInstances.TryGetValue((primaryId, qualifyingId.Value), out value);
+        }
 
         /// <summary>
         /// Gets the disposer associated with this container. Instances can be associated

--- a/src/Autofac/Core/Resolving/InstanceLookup.cs
+++ b/src/Autofac/Core/Resolving/InstanceLookup.cs
@@ -86,10 +86,10 @@ namespace Autofac.Core.Resolving
 
             var resolveParameters = Parameters as Parameter[] ?? Parameters.ToArray();
 
-            if (!_activationScope.TryGetSharedInstance(ComponentRegistration.Id, out var instance))
+            if (!_activationScope.TryGetSharedInstance(ComponentRegistration.Id, _decoratorTargetComponent?.Id, out var instance))
             {
                 instance = sharing == InstanceSharing.Shared
-                    ? _activationScope.CreateSharedInstance(ComponentRegistration.Id, () => CreateInstance(Parameters))
+                    ? _activationScope.CreateSharedInstance(ComponentRegistration.Id, _decoratorTargetComponent?.Id, () => CreateInstance(Parameters))
                     : CreateInstance(Parameters);
             }
 

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -236,7 +236,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesSingleInstance()
         {
             var builder = new ContainerBuilder();
@@ -277,7 +277,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsSingleInstance()
         {
             var builder = new ContainerBuilder();
@@ -323,7 +323,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip ="Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesInstancePerLifetimeScope()
         {
             var builder = new ContainerBuilder();
@@ -384,7 +384,7 @@ namespace Autofac.Specification.Test.Features
                 });
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesWithMultipleDecoratorsInstancePerLifetimeScope()
         {
             var builder = new ContainerBuilder();
@@ -514,7 +514,7 @@ namespace Autofac.Specification.Test.Features
             Assert.IsType<ImplementorB>(service.Decorated.Decorated);
         }
 
-        [Fact(Skip = "Issue 1113")]
+        [Fact]
         public void CanResolveMultipleDecoratedServicesThenLatestServiceWithSingleInstance()
         {
             var builder = new ContainerBuilder();


### PR DESCRIPTION
Fixes #1113
As noted in the investigation of #1113, the fact that shared instances are only stored with the registration ID results in some bad behavior when multiple services end up being decorated via Resolve<IEnumerable<T>> and some of the targets are shared.

After trying a fix in #1114, the feedback pointed out the original approach was too expensive for such a commonly executed path. This PR uses the approach that was suggested in the original PR with the below benchmarks. It seems that this change does cost an additional ~300ns per lookup/resolution performed.

# Original
<details><summary>Expand</summary>

```Autofac.Benchmarks.ChildScopeResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.201
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| Resolve | 41.08 us | 0.203 us | 0.180 us | 6.1646 | 0.3662 |     - |   50.7 KB |

```Autofac.Benchmarks.ConcurrencyBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.201
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                          Method | ResolveTaskCount | ResolvesPerTask |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------------- |---------------- |---------:|----------:|----------:|---------:|--------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |              100 |             100 | 2.041 ms | 0.0402 ms | 0.0376 ms | 617.1875 | 27.3438 |     - |    4.9 MB |

```Autofac.Benchmarks.Decorators.KeylessNestedSharedInstanceLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **477.0 ns** |  **2.84 ns** |  **2.52 ns** |  **1.00** |    **0.00** | **0.2093** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **4,066.8 ns** | **43.22 ns** | **40.43 ns** |     **?** |       **?** | **0.9613** | **0.0076** |     **-** |    **7.9 KB** |
|           ResolveT |           1 | 2,151.8 ns |  9.01 ns |  8.43 ns |     ? |       ? | 0.5875 | 0.0038 |     - |   4.83 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **6,679.9 ns** | **37.64 ns** | **35.21 ns** |     **?** |       **?** | **1.5945** | **0.0153** |     **-** |  **13.05 KB** |
|           ResolveT |           2 | 3,270.0 ns | 12.28 ns | 11.49 ns |     ? |       ? | 0.8812 | 0.0076 |     - |    7.2 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **9,114.3 ns** | **39.82 ns** | **37.25 ns** |     **?** |       **?** | **2.2278** | **0.0153** |     **-** |  **18.21 KB** |
|           ResolveT |           3 | 4,120.2 ns |  7.43 ns |  6.95 ns |     ? |       ? | 1.1673 | 0.0076 |     - |   9.58 KB |

```Autofac.Benchmarks.PropertyInjectionBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|----------:|----------:|-------:|-------:|------:|----------:|
| Resolve | 3.635 us | 0.0158 us | 0.0148 us | 0.7706 | 0.0038 |     - |    6.3 KB |

```Autofac.Benchmarks.OpenGenericBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| ResolveOpenGeneric | 328.5 ns | 5.94 ns | 5.56 ns | 0.0820 |     - |     - |     688 B |

```Autofac.Benchmarks.DeepGraphResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| Resolve | 11.31 us | 0.036 us | 0.034 us | 2.2430 | 0.0458 |     - |  18.45 KB |

```Autofac.Benchmarks.ConcurrencyBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                          Method | ResolveTaskCount | ResolvesPerTask |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------------- |---------------- |---------:|----------:|----------:|---------:|--------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |              100 |             100 | 1.941 ms | 0.0386 ms | 0.0460 ms | 617.1875 | 27.3438 |     - |    4.9 MB |

```Autofac.Benchmarks.Decorators.KeylessSimpleLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **479.6 ns** |  **2.39 ns** |  **2.24 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,985.5 ns** | **22.68 ns** | **21.21 ns** |     **?** |       **?** | **0.6714** | **0.0038** |     **-** |   **5.49 KB** |
|           ResolveT |           1 | 1,399.8 ns |  8.95 ns |  8.37 ns |     ? |       ? | 0.4158 |      - |     - |    3.4 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **5,271.4 ns** | **30.99 ns** | **28.99 ns** |     **?** |       **?** | **1.1292** | **0.0076** |     **-** |   **9.27 KB** |
|           ResolveT |           2 | 2,263.0 ns | 12.28 ns | 11.48 ns |     ? |       ? | 0.6218 | 0.0038 |     - |   5.09 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **7,591.6 ns** | **25.30 ns** | **23.66 ns** |     **?** |       **?** | **1.5945** | **0.0153** |     **-** |  **13.05 KB** |
|           ResolveT |           3 | 3,122.5 ns | 18.08 ns | 16.03 ns |     ? |       ? | 0.8278 | 0.0038 |     - |   6.77 KB |

```Autofac.Benchmarks.Decorators.KeylessNestedLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |        Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |------------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |    **478.3 ns** |  **1.47 ns** |  **1.37 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** |  **4,070.9 ns** |  **9.48 ns** |  **8.87 ns** |     **?** |       **?** | **0.9308** | **0.0076** |     **-** |   **7.65 KB** |
|           ResolveT |           1 |  1,894.9 ns |  9.34 ns |  8.74 ns |     ? |       ? | 0.5474 | 0.0038 |     - |   4.48 KB |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** |  **7,164.8 ns** | **18.07 ns** | **16.90 ns** |     **?** |       **?** | **1.6632** | **0.0153** |     **-** |  **13.59 KB** |
|           ResolveT |           2 |  3,293.6 ns | 14.04 ns | 13.13 ns |     ? |       ? | 0.8850 | 0.0076 |     - |   7.24 KB |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **10,575.3 ns** | **23.66 ns** | **22.14 ns** |     **?** |       **?** | **2.3804** | **0.0153** |     **-** |  **19.52 KB** |
|           ResolveT |           3 |  4,532.6 ns | 27.35 ns | 25.58 ns |     ? |       ? | 1.2207 | 0.0076 |     - |  10.01 KB |

```Autofac.Benchmarks.RootContainerResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                     Method |       Mean |     Error |    StdDev |  Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |-----------:|----------:|----------:|-------:|--------:|-------:|------:|------:|----------:|
|                OperatorNew |   2.571 ns | 0.0302 ns | 0.0283 ns |   1.00 |    0.00 | 0.0029 |     - |     - |      24 B |
| NonSharedReflectionResolve | 335.762 ns | 2.2634 ns | 2.1172 ns | 130.62 |    1.70 | 0.0820 |     - |     - |     688 B |
|   NonSharedDelegateResolve | 253.400 ns | 1.2290 ns | 1.1496 ns |  98.58 |    1.05 | 0.0639 |     - |     - |     536 B |
|              SharedResolve | 229.811 ns | 0.5025 ns | 0.4700 ns |  89.40 |    0.95 | 0.0610 |     - |     - |     512 B |

```Autofac.Benchmarks.Decorators.KeylessNestedSharedInstanceBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **477.8 ns** |  **2.03 ns** |  **1.80 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **4,340.2 ns** | **15.22 ns** | **14.24 ns** |     **?** |       **?** | **1.0376** | **0.0076** |     **-** |   **8.48 KB** |
|           ResolveT |           1 | 2,268.8 ns |  5.55 ns |  5.19 ns |     ? |       ? | 0.6599 | 0.0038 |     - |   5.41 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **6,719.7 ns** | **28.59 ns** | **26.75 ns** |     **?** |       **?** | **1.6632** | **0.0153** |     **-** |  **13.63 KB** |
|           ResolveT |           2 | 3,247.4 ns |  7.98 ns |  7.46 ns |     ? |       ? | 0.9499 | 0.0076 |     - |   7.78 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **8,997.0 ns** | **37.94 ns** | **35.49 ns** |     **?** |       **?** | **2.2888** | **0.0153** |     **-** |  **18.79 KB** |
|           ResolveT |           3 | 4,280.1 ns | 15.04 ns | 14.07 ns |     ? |       ? | 1.2360 | 0.0076 |     - |  10.16 KB |

```Autofac.Benchmarks.ConcurrencyNestedScopeBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                          Method | ConcurrentRequests | RepeatCount |     Mean |     Error |    StdDev |   Median |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|-------------------------------- |------------------- |------------ |---------:|----------:|----------:|---------:|---------:|---------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |                100 |          10 | 1.820 ms | 0.0358 ms | 0.0536 ms | 1.793 ms | 863.2813 | 156.2500 |     - |   6.83 MB |

```Autofac.Benchmarks.Decorators.KeyedNestedBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **476.0 ns** |  **1.29 ns** |  **1.20 ns** |  **1.00** |    **0.00** | **0.2093** | **0.0005** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,772.6 ns** |  **8.81 ns** |  **8.24 ns** |     **?** |       **?** | **0.5455** | **0.0038** |     **-** |   **4.48 KB** |
|           ResolveT |           1 | 1,345.6 ns |  4.43 ns |  4.14 ns |     ? |       ? | 0.3490 | 0.0019 |     - |   2.85 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **4,917.2 ns** | **14.56 ns** | **13.62 ns** |     **?** |       **?** | **0.8850** | **0.0076** |     **-** |   **7.26 KB** |
|           ResolveT |           2 | 2,101.8 ns | 13.48 ns | 12.61 ns |     ? |       ? | 0.4883 |      - |     - |   3.99 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **6,977.8 ns** | **25.24 ns** | **23.61 ns** |     **?** |       **?** | **1.2207** | **0.0076** |     **-** |  **10.03 KB** |
|           ResolveT |           3 | 2,929.2 ns |  9.47 ns |  8.86 ns |     ? |       ? | 0.6256 | 0.0038 |     - |   5.13 KB |

```Autofac.Benchmarks.Decorators.KeylessNestedBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |        Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |------------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |    **479.3 ns** |  **1.24 ns** |  **1.16 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** |  **4,198.6 ns** | **11.59 ns** | **10.84 ns** |     **?** |       **?** | **1.0757** | **0.0076** |     **-** |    **8.8 KB** |
|           ResolveT |           1 |  1,998.2 ns |  6.73 ns |  6.30 ns |     ? |       ? | 0.6180 | 0.0038 |     - |   5.05 KB |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** |  **7,809.8 ns** | **21.39 ns** | **20.01 ns** |     **?** |       **?** | **1.9379** | **0.0153** |     **-** |   **15.9 KB** |
|           ResolveT |           2 |  3,404.2 ns | 10.92 ns | 10.22 ns |     ? |       ? | 1.0262 | 0.0076 |     - |    8.4 KB |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **11,193.8 ns** | **27.98 ns** | **26.17 ns** |     **?** |       **?** | **2.8076** | **0.0153** |     **-** |  **22.99 KB** |
|           ResolveT |           3 |  4,833.8 ns |  7.86 ns |  6.97 ns |     ? |       ? | 1.4343 | 0.0076 |     - |  11.74 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **474.8 ns** |  **1.82 ns** |  **1.62 ns** |  **1.00** |    **0.00** | **0.2093** | **0.0005** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,913.3 ns** | **10.41 ns** |  **9.74 ns** |     **?** |       **?** | **0.7401** | **0.0038** |     **-** |   **6.07 KB** |
|           ResolveT |           1 | 1,440.7 ns |  2.61 ns |  2.18 ns |     ? |       ? | 0.4501 | 0.0019 |     - |   3.69 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **5,232.2 ns** | **34.12 ns** | **30.25 ns** |     **?** |       **?** | **1.2741** | **0.0076** |     **-** |  **10.43 KB** |
|           ResolveT |           2 | 2,383.1 ns |  6.77 ns |  6.00 ns |     ? |       ? | 0.6905 | 0.0038 |     - |   5.66 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **7,802.9 ns** | **34.28 ns** | **26.77 ns** |     **?** |       **?** | **1.8005** | **0.0153** |     **-** |  **14.79 KB** |
|           ResolveT |           3 | 3,306.1 ns |  8.58 ns |  8.03 ns |     ? |       ? | 0.9346 | 0.0076 |     - |   7.64 KB |

```Autofac.Benchmarks.ChildScopeResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| Resolve | 40.12 us | 0.356 us | 0.333 us | 6.1646 | 0.3662 |     - |   50.7 KB |

```Autofac.Benchmarks.Decorators.KeylessGenericBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **481.8 ns** |  **9.25 ns** |  **9.09 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,914.0 ns** | **33.25 ns** | **29.48 ns** |     **?** |       **?** | **0.7057** | **0.0038** |     **-** |   **5.79 KB** |
|           ResolveT |           1 | 1,412.9 ns | 15.78 ns | 13.99 ns |     ? |       ? | 0.4330 | 0.0019 |     - |   3.55 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **4,999.8 ns** | **46.34 ns** | **43.35 ns** |     **?** |       **?** | **1.2054** | **0.0076** |     **-** |   **9.87 KB** |
|           ResolveT |           2 | 2,245.1 ns |  7.98 ns |  7.47 ns |     ? |       ? | 0.6561 | 0.0038 |     - |   5.38 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **7,210.7 ns** | **24.58 ns** | **22.99 ns** |     **?** |       **?** | **1.7014** | **0.0153** |     **-** |  **13.95 KB** |
|           ResolveT |           3 | 2,955.0 ns | 14.06 ns | 13.16 ns |     ? |       ? | 0.8812 | 0.0038 |     - |   7.22 KB |

```Autofac.Benchmarks.EnumerableResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|               Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|   ResolveIEnumerable | 2.380 us | 0.0052 us | 0.0046 us | 0.4311 |     - |     - |   3.54 KB |
| ResolveIReadOnlyList | 2.407 us | 0.0074 us | 0.0069 us | 0.4349 |     - |     - |   3.57 KB |
|         ResolveArray | 2.395 us | 0.0058 us | 0.0054 us | 0.4311 |     - |     - |   3.54 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleSharedInstanceBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **475.8 ns** |  **1.85 ns** |  **1.73 ns** |  **1.00** |    **0.00** | **0.2093** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,197.1 ns** |  **5.28 ns** |  **4.68 ns** |     **?** |       **?** | **0.7362** | **0.0038** |     **-** |   **6.02 KB** |
|           ResolveT |           1 | 1,679.8 ns |  6.60 ns |  6.18 ns |     ? |       ? | 0.4787 | 0.0038 |     - |   3.92 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **4,889.0 ns** | **30.37 ns** | **28.40 ns** |     **?** |       **?** | **1.1292** | **0.0076** |     **-** |   **9.24 KB** |
|           ResolveT |           2 | 2,278.6 ns | 12.41 ns | 11.61 ns |     ? |       ? | 0.6523 |      - |     - |   5.33 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **6,405.0 ns** | **25.09 ns** | **23.47 ns** |     **?** |       **?** | **1.5182** | **0.0076** |     **-** |  **12.46 KB** |
|           ResolveT |           3 | 2,888.5 ns | 33.04 ns | 30.90 ns |     ? |       ? | 0.8240 | 0.0038 |     - |   6.73 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleSharedInstanceLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **479.9 ns** |  **4.96 ns** |  **4.63 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,061.2 ns** | **10.73 ns** | **10.04 ns** |     **?** |       **?** | **0.7019** | **0.0038** |     **-** |   **5.73 KB** |
|           ResolveT |           1 | 1,608.9 ns |  8.39 ns |  7.85 ns |     ? |       ? | 0.4444 | 0.0019 |     - |   3.63 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **4,845.8 ns** | **24.08 ns** | **22.53 ns** |     **?** |       **?** | **1.0910** | **0.0076** |     **-** |   **8.95 KB** |
|           ResolveT |           2 | 2,246.8 ns |  5.09 ns |  4.76 ns |     ? |       ? | 0.6142 | 0.0038 |     - |   5.04 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **6,631.4 ns** | **13.26 ns** | **12.40 ns** |     **?** |       **?** | **1.4877** | **0.0076** |     **-** |  **12.17 KB** |
|           ResolveT |           3 | 2,784.6 ns | 25.19 ns | 23.56 ns |     ? |       ? | 0.7858 | 0.0038 |     - |   6.45 KB |

```Autofac.Benchmarks.Decorators.KeyedGenericBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **477.2 ns** |  **1.18 ns** |  **1.10 ns** |  **1.00** |    **0.00** | **0.2093** | **0.0010** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,487.0 ns** | **11.16 ns** | **10.44 ns** |     **?** |       **?** | **0.5684** | **0.0038** |     **-** |   **4.67 KB** |
|           ResolveT |           1 | 1,212.4 ns |  2.92 ns |  2.73 ns |     ? |       ? | 0.3605 | 0.0019 |     - |   2.95 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **4,496.7 ns** | **35.23 ns** | **32.96 ns** |     **?** |       **?** | **0.9308** | **0.0076** |     **-** |   **7.63 KB** |
|           ResolveT |           2 | 1,890.0 ns |  8.18 ns |  7.65 ns |     ? |       ? | 0.5112 | 0.0019 |     - |   4.18 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **6,476.4 ns** | **15.99 ns** | **14.96 ns** |     **?** |       **?** | **1.2894** | **0.0076** |     **-** |  **10.59 KB** |
|           ResolveT |           3 | 2,621.5 ns | 12.05 ns | 11.27 ns |     ? |       ? | 0.6599 | 0.0038 |     - |   5.41 KB |

```Autofac.Benchmarks.Decorators.KeyedSimpleBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **476.4 ns** |  **3.38 ns** |  **3.16 ns** |  **1.00** |    **0.00** | **0.2089** |      **-** |     **-** |   **1.71 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,382.0 ns** | **17.09 ns** | **15.99 ns** |     **?** |       **?** | **0.4883** | **0.0038** |     **-** |   **4.02 KB** |
|           ResolveT |           1 | 1,079.1 ns |  4.29 ns |  4.01 ns |     ? |       ? | 0.3185 |      - |     - |   2.62 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **3,962.4 ns** | **16.25 ns** | **15.20 ns** |     **?** |       **?** | **0.7706** |      **-** |     **-** |   **6.32 KB** |
|           ResolveT |           2 | 1,633.9 ns |  4.82 ns |  4.51 ns |     ? |       ? | 0.4311 | 0.0019 |     - |   3.52 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **5,574.7 ns** | **17.23 ns** | **16.12 ns** |     **?** |       **?** | **1.0529** | **0.0076** |     **-** |   **8.63 KB** |
|           ResolveT |           3 | 2,204.8 ns | 10.00 ns |  9.36 ns |     ? |       ? | 0.5417 |      - |     - |   4.43 KB |
</details>

# Post-Change
<details><summary>Expand</summary>

```Autofac.Benchmarks.ChildScopeResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| Resolve | 44.49 us | 0.845 us | 0.791 us | 6.1646 | 0.3662 |     - |  50.82 KB |

```Autofac.Benchmarks.ConcurrencyBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                          Method | ResolveTaskCount | ResolvesPerTask |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------------- |---------------- |---------:|----------:|----------:|---------:|--------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |              100 |             100 | 1.996 ms | 0.0395 ms | 0.1082 ms | 617.1875 | 27.3438 |     - |    4.9 MB |

```Autofac.Benchmarks.ConcurrencyNestedScopeBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                          Method | ConcurrentRequests | RepeatCount |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 | Gen 2 | Allocated |
|-------------------------------- |------------------- |------------ |---------:|----------:|----------:|---------:|---------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |                100 |          10 | 1.537 ms | 0.0297 ms | 0.0292 ms | 878.9063 | 169.9219 |     - |   6.95 MB |

```Autofac.Benchmarks.Decorators.KeyedGenericBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **535.7 ns** |   **1.90 ns** |   **1.69 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,856.5 ns** |   **4.62 ns** |   **3.85 ns** |     **?** |       **?** | **0.5722** | **0.0038** |     **-** |    **4.7 KB** |
|           ResolveT |           1 | 1,396.1 ns |  10.07 ns |   9.42 ns |     ? |       ? | 0.3624 | 0.0019 |     - |   2.97 KB |
|                    |             |            |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **5,089.4 ns** |  **32.94 ns** |  **30.82 ns** |     **?** |       **?** | **0.9308** | **0.0076** |     **-** |   **7.66 KB** |
|           ResolveT |           2 | 2,179.0 ns |  17.50 ns |  14.62 ns |     ? |       ? | 0.5112 | 0.0038 |     - |    4.2 KB |
|                    |             |            |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **7,394.2 ns** | **143.13 ns** | **159.08 ns** |     **?** |       **?** | **1.2970** | **0.0076** |     **-** |  **10.62 KB** |
|           ResolveT |           3 | 2,999.8 ns |  27.10 ns |  25.35 ns |     ? |       ? | 0.6638 | 0.0038 |     - |   5.44 KB |

```Autofac.Benchmarks.Decorators.KeyedNestedBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **543.9 ns** |  **6.13 ns** |  **5.12 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,172.0 ns** | **51.76 ns** | **48.42 ns** |     **?** |       **?** | **0.5493** |      **-** |     **-** |   **4.51 KB** |
|           ResolveT |           1 | 1,578.1 ns |  6.28 ns |  5.88 ns |     ? |       ? | 0.3510 | 0.0019 |     - |   2.88 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **5,536.8 ns** | **53.30 ns** | **49.86 ns** |     **?** |       **?** | **0.8850** | **0.0076** |     **-** |   **7.28 KB** |
|           ResolveT |           2 | 2,441.3 ns |  9.91 ns |  8.78 ns |     ? |       ? | 0.4883 |      - |     - |   4.02 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **8,193.1 ns** | **84.64 ns** | **70.68 ns** |     **?** |       **?** | **1.2207** |      **-** |     **-** |  **10.05 KB** |
|           ResolveT |           3 | 3,449.1 ns | 39.59 ns | 37.03 ns |     ? |       ? | 0.6294 | 0.0038 |     - |   5.16 KB |

```Autofac.Benchmarks.Decorators.KeyedSimpleBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **538.9 ns** |  **3.93 ns** |  **3.68 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **2,601.5 ns** | **22.47 ns** | **21.02 ns** |     **?** |       **?** | **0.4921** | **0.0038** |     **-** |   **4.04 KB** |
|           ResolveT |           1 | 1,232.2 ns |  9.93 ns |  9.29 ns |     ? |       ? | 0.3223 | 0.0019 |     - |   2.64 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **4,517.9 ns** | **76.31 ns** | **71.38 ns** |     **?** |       **?** | **0.7706** |      **-** |     **-** |   **6.34 KB** |
|           ResolveT |           2 | 1,910.6 ns |  6.68 ns |  6.25 ns |     ? |       ? | 0.4330 | 0.0019 |     - |   3.55 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **6,330.0 ns** | **62.59 ns** | **52.26 ns** |     **?** |       **?** | **1.0529** | **0.0076** |     **-** |   **8.65 KB** |
|           ResolveT |           3 | 2,462.8 ns | 16.95 ns | 15.86 ns |     ? |       ? | 0.5417 | 0.0038 |     - |   4.45 KB |

```Autofac.Benchmarks.Decorators.KeylessGenericBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **557.5 ns** | **11.17 ns** | **12.87 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,237.7 ns** | **31.49 ns** | **26.30 ns** |     **?** |       **?** | **0.7095** | **0.0038** |     **-** |   **5.81 KB** |
|           ResolveT |           1 | 1,519.3 ns |  9.42 ns |  7.86 ns |     ? |       ? | 0.4368 | 0.0019 |     - |   3.57 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **5,793.5 ns** | **51.78 ns** | **48.44 ns** |     **?** |       **?** | **1.2054** | **0.0076** |     **-** |   **9.89 KB** |
|           ResolveT |           2 | 2,454.5 ns | 19.12 ns | 17.89 ns |     ? |       ? | 0.6599 | 0.0038 |     - |   5.41 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **8,145.7 ns** | **99.29 ns** | **82.91 ns** |     **?** |       **?** | **1.7090** | **0.0153** |     **-** |  **13.97 KB** |
|           ResolveT |           3 | 3,380.0 ns | 24.98 ns | 19.51 ns |     ? |       ? | 0.8850 | 0.0076 |     - |   7.24 KB |

```Autofac.Benchmarks.Decorators.KeylessNestedBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |------------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |    **551.2 ns** |  **11.00 ns** |  **10.29 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** |  **4,946.9 ns** |  **53.06 ns** |  **49.63 ns** |     **?** |       **?** | **1.0757** | **0.0076** |     **-** |   **8.83 KB** |
|           ResolveT |           1 |  2,326.5 ns |  16.65 ns |  15.58 ns |     ? |       ? | 0.6180 | 0.0038 |     - |   5.08 KB |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** |  **8,942.1 ns** | **241.94 ns** | **248.46 ns** |     **?** |       **?** | **1.9379** | **0.0153** |     **-** |  **15.92 KB** |
|           ResolveT |           2 |  4,083.1 ns |  79.47 ns |  88.33 ns |     ? |       ? | 1.0300 | 0.0076 |     - |   8.42 KB |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **13,020.5 ns** | **225.73 ns** | **200.10 ns** |     **?** |       **?** | **2.8076** | **0.0305** |     **-** |  **23.02 KB** |
|           ResolveT |           3 |  5,586.3 ns |  58.32 ns |  54.55 ns |     ? |       ? | 1.4343 | 0.0076 |     - |  11.77 KB |

```Autofac.Benchmarks.Decorators.KeylessNestedLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |------------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |    **522.9 ns** |   **1.73 ns** |   **1.62 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** |  **4,427.8 ns** |  **77.71 ns** |  **72.69 ns** |     **?** |       **?** | **0.9384** | **0.0076** |     **-** |   **7.67 KB** |
|           ResolveT |           1 |  2,171.4 ns |  12.13 ns |  11.35 ns |     ? |       ? | 0.5493 | 0.0038 |     - |    4.5 KB |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** |  **8,023.8 ns** | **110.85 ns** |  **98.26 ns** |     **?** |       **?** | **1.6632** | **0.0153** |     **-** |  **13.61 KB** |
|           ResolveT |           2 |  3,622.1 ns |  35.28 ns |  31.28 ns |     ? |       ? | 0.8888 | 0.0076 |     - |   7.27 KB |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **11,730.0 ns** | **171.26 ns** | **160.20 ns** |     **?** |       **?** | **2.3804** | **0.0153** |     **-** |  **19.55 KB** |
|           ResolveT |           3 |  5,129.2 ns |  16.77 ns |  15.69 ns |     ? |       ? | 1.2207 | 0.0076 |     - |  10.03 KB |

```Autofac.Benchmarks.Decorators.KeylessNestedSharedInstanceBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |        Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |------------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |    **543.7 ns** |   **4.62 ns** |   **4.09 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** |  **5,699.2 ns** | **100.04 ns** |  **88.68 ns** |     **?** |       **?** | **1.1826** | **0.0076** |     **-** |   **9.67 KB** |
|           ResolveT |           1 |  2,744.7 ns |  64.60 ns |  57.27 ns |     ? |       ? | 0.6714 | 0.0038 |     - |    5.5 KB |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** |  **8,848.4 ns** | **170.56 ns** | **167.51 ns** |     **?** |       **?** | **1.8005** | **0.0153** |     **-** |  **14.83 KB** |
|           ResolveT |           2 |  3,972.5 ns |  75.80 ns |  70.90 ns |     ? |       ? | 0.9613 | 0.0076 |     - |   7.88 KB |
|                    |             |             |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **11,565.2 ns** | **168.62 ns** | **149.48 ns** |     **?** |       **?** | **2.4414** | **0.0153** |     **-** |  **19.98 KB** |
|           ResolveT |           3 |  5,091.2 ns |  42.06 ns |  32.84 ns |     ? |       ? | 1.2512 | 0.0076 |     - |  10.25 KB |

```Autofac.Benchmarks.Decorators.KeylessNestedSharedInstanceLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |        Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |------------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |    **513.6 ns** |  **3.05 ns** |  **2.85 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** |  **5,293.3 ns** | **43.86 ns** | **36.62 ns** |     **?** |       **?** | **1.0376** | **0.0076** |     **-** |   **8.52 KB** |
|           ResolveT |           1 |  2,564.6 ns | 44.36 ns | 41.49 ns |     ? |       ? | 0.5989 | 0.0038 |     - |   4.92 KB |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** |  **8,112.2 ns** | **29.98 ns** | **28.05 ns** |     **?** |       **?** | **1.6632** | **0.0153** |     **-** |  **13.67 KB** |
|           ResolveT |           2 |  3,645.1 ns | 19.36 ns | 17.16 ns |     ? |       ? | 0.8926 | 0.0076 |     - |    7.3 KB |
|                    |             |             |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **11,030.0 ns** | **42.61 ns** | **39.86 ns** |     **?** |       **?** | **2.3041** | **0.0153** |     **-** |  **18.83 KB** |
|           ResolveT |           3 |  4,723.4 ns | 85.58 ns | 80.05 ns |     ? |       ? | 1.1826 | 0.0076 |     - |   9.67 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **539.6 ns** |  **1.95 ns** |  **1.63 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,461.7 ns** | **57.39 ns** | **50.88 ns** |     **?** |       **?** | **0.7439** | **0.0038** |     **-** |   **6.09 KB** |
|           ResolveT |           1 | 1,669.8 ns | 31.55 ns | 29.52 ns |     ? |       ? | 0.4539 | 0.0019 |     - |   3.71 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **6,296.5 ns** | **90.47 ns** | **84.62 ns** |     **?** |       **?** | **1.2741** | **0.0076** |     **-** |  **10.45 KB** |
|           ResolveT |           2 | 2,731.2 ns | 27.75 ns | 23.17 ns |     ? |       ? | 0.6943 | 0.0038 |     - |   5.69 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **9,003.4 ns** | **35.84 ns** | **33.53 ns** |     **?** |       **?** | **1.8005** | **0.0153** |     **-** |  **14.81 KB** |
|           ResolveT |           3 | 3,754.0 ns | 36.71 ns | 34.34 ns |     ? |       ? | 0.9346 | 0.0076 |     - |   7.66 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **546.1 ns** |  **9.61 ns** |  **8.99 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,371.4 ns** | **34.49 ns** | **30.57 ns** |     **?** |       **?** | **0.6752** | **0.0038** |     **-** |   **5.52 KB** |
|           ResolveT |           1 | 1,626.4 ns | 31.87 ns | 29.81 ns |     ? |       ? | 0.4177 |      - |     - |   3.42 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **5,883.0 ns** | **22.83 ns** | **19.07 ns** |     **?** |       **?** | **1.1368** | **0.0076** |     **-** |    **9.3 KB** |
|           ResolveT |           2 | 2,601.1 ns | 51.62 ns | 53.01 ns |     ? |       ? | 0.6218 | 0.0038 |     - |   5.11 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **8,398.0 ns** | **50.89 ns** | **47.61 ns** |     **?** |       **?** | **1.5869** | **0.0153** |     **-** |  **13.08 KB** |
|           ResolveT |           3 | 3,634.8 ns | 72.50 ns | 71.20 ns |     ? |       ? | 0.8316 | 0.0038 |     - |    6.8 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleSharedInstanceBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|---------:|---------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **547.3 ns** |  **8.57 ns** |  **7.60 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **4,138.7 ns** | **21.78 ns** | **19.31 ns** |     **?** |       **?** | **0.8087** | **0.0076** |     **-** |   **6.66 KB** |
|           ResolveT |           1 | 1,945.8 ns | 29.91 ns | 26.51 ns |     ? |       ? | 0.4883 |      - |     - |   3.99 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **6,038.4 ns** | **27.90 ns** | **24.73 ns** |     **?** |       **?** | **1.2054** | **0.0076** |     **-** |   **9.88 KB** |
|           ResolveT |           2 | 2,757.4 ns | 17.81 ns | 16.66 ns |     ? |       ? | 0.6599 | 0.0038 |     - |    5.4 KB |
|                    |             |            |          |          |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **8,080.5 ns** | **66.63 ns** | **62.32 ns** |     **?** |       **?** | **1.6022** | **0.0153** |     **-** |  **13.09 KB** |
|           ResolveT |           3 | 3,463.7 ns | 65.89 ns | 67.66 ns |     ? |       ? | 0.8316 | 0.0038 |     - |    6.8 KB |

```Autofac.Benchmarks.Decorators.KeylessSimpleSharedInstanceLambdaBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method | repetitions |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------- |------------ |-----------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
|           **Baseline** |           **?** |   **540.3 ns** |   **3.09 ns** |   **2.89 ns** |  **1.00** |    **0.00** | **0.2117** | **0.0010** |     **-** |   **1.73 KB** |
|                    |             |            |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **1** | **3,799.6 ns** |  **12.38 ns** |  **10.97 ns** |     **?** |       **?** | **0.7401** | **0.0076** |     **-** |   **6.08 KB** |
|           ResolveT |           1 | 1,880.0 ns |  11.25 ns |   9.98 ns |     ? |       ? | 0.4520 | 0.0019 |     - |    3.7 KB |
|                    |             |            |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **2** | **6,058.6 ns** |  **27.67 ns** |  **25.89 ns** |     **?** |       **?** | **1.1368** | **0.0076** |     **-** |    **9.3 KB** |
|           ResolveT |           2 | 2,635.9 ns |  15.04 ns |  14.07 ns |     ? |       ? | 0.6218 | 0.0038 |     - |   5.11 KB |
|                    |             |            |           |           |       |         |        |        |       |           |
| **ResolveEnumerableT** |           **3** | **7,987.4 ns** | **117.49 ns** | **104.15 ns** |     **?** |       **?** | **1.5259** | **0.0153** |     **-** |  **12.52 KB** |
|           ResolveT |           3 | 3,408.4 ns |  65.61 ns |  61.37 ns |     ? |       ? | 0.7973 | 0.0038 |     - |   6.52 KB |

```Autofac.Benchmarks.DeepGraphResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| Resolve | 12.19 us | 0.151 us | 0.126 us | 2.2430 | 0.0458 |     - |  18.45 KB |

```Autofac.Benchmarks.EnumerableResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|               Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|   ResolveIEnumerable | 2.785 us | 0.0085 us | 0.0079 us | 0.4311 |     - |     - |   3.54 KB |
| ResolveIReadOnlyList | 2.729 us | 0.0138 us | 0.0129 us | 0.4349 |     - |     - |   3.57 KB |
|         ResolveArray | 2.779 us | 0.0543 us | 0.0508 us | 0.4311 |     - |     - |   3.54 KB |

```Autofac.Benchmarks.OpenGenericBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|             Method |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| ResolveOpenGeneric | 378.6 ns | 6.70 ns | 5.59 ns | 0.0820 |     - |     - |     688 B |

```Autofac.Benchmarks.PropertyInjectionBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|  Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| Resolve | 3.951 us | 0.0532 us | 0.0498 us | 0.7706 |     - |     - |    6.3 KB |

```Autofac.Benchmarks.RootContainerResolveBenchmark-report-github.md```
``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18363
Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.200
  [Host]     : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.3 (CoreCLR 4.700.20.11803, CoreFX 4.700.20.12001), X64 RyuJIT


```
|                     Method |       Mean |     Error |    StdDev |  Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |-----------:|----------:|----------:|-------:|--------:|-------:|------:|------:|----------:|
|                OperatorNew |   2.667 ns | 0.0778 ns | 0.1362 ns |   1.00 |    0.00 | 0.0029 |     - |     - |      24 B |
| NonSharedReflectionResolve | 370.904 ns | 0.9369 ns | 0.8764 ns | 137.43 |    6.71 | 0.0820 |     - |     - |     688 B |
|   NonSharedDelegateResolve | 295.481 ns | 5.8152 ns | 5.1550 ns | 109.17 |    6.25 | 0.0639 |     - |     - |     536 B |
|              SharedResolve | 279.118 ns | 3.0317 ns | 2.5316 ns | 103.04 |    5.63 | 0.0610 |     - |     - |     512 B |
</details>
