### PR TITLE
Success Request List Performance Improvement

### DIFF
--- a/src/Autofac/Core/Resolving/ResolveOperationBase.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperationBase.cs
@@ -39,6 +39,7 @@ namespace Autofac.Core.Resolving
         private bool _ended;
         private IResolvePipelineTracer? _pipelineTracer;
         private List<ResolveRequestContext> _successfulRequests = new List<ResolveRequestContext>();
+        private int _nextCompleteSuccessfulRequestStartPos = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResolveOperationBase"/> class.
@@ -241,9 +242,10 @@ namespace Autofac.Core.Resolving
         {
             var completed = _successfulRequests;
             int count = completed.Count;
+            var startPosition = _nextCompleteSuccessfulRequestStartPos;
             ResetSuccessfulRequests();
 
-            for (int i = 0; i < count; i++)
+            for (int i = startPosition; i < count; i++)
             {
                 completed[i].Complete();
             }
@@ -251,7 +253,7 @@ namespace Autofac.Core.Resolving
 
         private void ResetSuccessfulRequests()
         {
-            _successfulRequests = new List<ResolveRequestContext>();
+            _nextCompleteSuccessfulRequestStartPos = _successfulRequests.Count;
         }
 
         private void End(Exception? exception = null)

--- a/src/Autofac/Core/Resolving/ResolveOperationBase.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperationBase.cs
@@ -36,9 +36,11 @@ namespace Autofac.Core.Resolving
     /// </summary>
     public abstract class ResolveOperationBase : IResolveOperation, ITracingIdentifer
     {
+        private const int SuccessListInitialCapacity = 32;
+
         private bool _ended;
         private IResolvePipelineTracer? _pipelineTracer;
-        private List<ResolveRequestContext> _successfulRequests = new List<ResolveRequestContext>();
+        private List<ResolveRequestContext> _successfulRequests = new List<ResolveRequestContext>(SuccessListInitialCapacity);
         private int _nextCompleteSuccessfulRequestStartPos = 0;
 
         /// <summary>


### PR DESCRIPTION
Switched to tracking the 'next' position in the list, rather than resetting it.

Also experimented with the initial capacity. Ended up settling on an initial capacity of 32. It's a fair bit bigger than the default, but for complex graphs performance does improve some. I think it's worth the small amount of extra memory in simple graphs, to give us better performance in complex graphs.

Used the Deep Graph bench because that has a lot of requests in it.

### Original (v6)

|  Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| Resolve | 18.37 us | 0.135 us | 0.120 us | 4.1504 |     - |     - |  17.05 KB |

### Track Position

|  Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| Resolve | 17.57 us | 0.189 us | 0.177 us | 4.1504 |     - |     - |     17 KB |

### Track Position + Allocate Custom Initial Capacity (12)

|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|------:|----------:|
| Resolve | 17.62 us | 0.123 us | 0.109 us | 4.1809 | 0.0305 |     - |  17.16 KB |

### Track Position + Allocate Custom Initial Capacity (32)

|  Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| Resolve | 17.45 us | 0.178 us | 0.139 us | 4.0894 |     - |     - |  16.71 KB |