### PR TITLE
Adding CLI to Run a Benchmark to Profile It + Benchmark.NET Upgrade

### DIFF
--- a/Autofac.sln
+++ b/Autofac.sln
@@ -41,6 +41,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Specification.Test"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.Test.Compilation", "test\Autofac.Test.Compilation\Autofac.Test.Compilation.csproj", "{0307A6FE-171A-4642-95A0-90AB80879BB4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Autofac.BenchmarkProfiling", "bench\Autofac.BenchmarkProfiling\Autofac.BenchmarkProfiling.csproj", "{946CF4FE-DB20-4901-80F9-F7363BA06F1E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -149,6 +151,22 @@ Global
 		{0307A6FE-171A-4642-95A0-90AB80879BB4}.Release|x64.Build.0 = Release|Any CPU
 		{0307A6FE-171A-4642-95A0-90AB80879BB4}.Release|x86.ActiveCfg = Release|Any CPU
 		{0307A6FE-171A-4642-95A0-90AB80879BB4}.Release|x86.Build.0 = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|ARM.Build.0 = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|x64.Build.0 = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Debug|x86.Build.0 = Debug|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|ARM.ActiveCfg = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|ARM.Build.0 = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|x64.ActiveCfg = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|x64.Build.0 = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|x86.ActiveCfg = Release|Any CPU
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -160,6 +178,7 @@ Global
 		{49FB428A-28D6-4A60-AF29-B9D5F7552041} = {DEA4A8C6-DE56-4359-A87C-472FB34132E7}
 		{39610DBF-4CAF-45FD-8B9F-D8928D76066A} = {DEA4A8C6-DE56-4359-A87C-472FB34132E7}
 		{0307A6FE-171A-4642-95A0-90AB80879BB4} = {DEA4A8C6-DE56-4359-A87C-472FB34132E7}
+		{946CF4FE-DB20-4901-80F9-F7363BA06F1E} = {48F40A36-C829-4895-99B3-1634CC6594E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2D16574C-61CB-4568-8490-AC9B85A721C0}

--- a/bench/Autofac.BenchmarkProfiling/Autofac.BenchmarkProfiling.csproj
+++ b/bench/Autofac.BenchmarkProfiling/Autofac.BenchmarkProfiling.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Autofac.Benchmarks\Autofac.Benchmarks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/bench/Autofac.BenchmarkProfiling/Program.cs
+++ b/bench/Autofac.BenchmarkProfiling/Program.cs
@@ -18,101 +18,109 @@ namespace Autofac.BenchmarkProfiling
 
             if (args.Length == 0)
             {
-                Console.Error.WriteLine("Must provide the name of a benchmark class. (e.g. ./Autofac.BenchmarkProfiling.exe ChildScopeResolveBenchmark)");
+                Console.WriteLine("Must provide the name of a benchmark class. (e.g. ./Autofac.BenchmarkProfiling.exe ChildScopeResolveBenchmark)");
+                Console.WriteLine("Possible benchmarks are:");
+                PrintBenchmarks(availableBenchmarks);
+                return;
+            }
+
+            var inputType = args[0];
+
+            var selectedBenchmark = availableBenchmarks.FirstOrDefault(x => x.Name.Equals(inputType, StringComparison.InvariantCultureIgnoreCase));
+
+            if (selectedBenchmark is null)
+            {
+                Console.WriteLine("Specified benchmark does not exist.");
+                PrintBenchmarks(availableBenchmarks);
+                return;
+            }
+
+            var benchRunInfo = BenchmarkConverter.TypeToBenchmarks(selectedBenchmark);
+
+            BenchmarkCase selectedCase = null;
+
+            if (benchRunInfo.BenchmarksCases.Length == 0)
+            {
+                Console.WriteLine("No benchmark cases in specified benchmark.");
+                return;
+            }
+            else if(benchRunInfo.BenchmarksCases.Length == 1)
+            {
+                selectedCase = benchRunInfo.BenchmarksCases[0];
             }
             else
             {
-                var inputType = args[0];
-
-                var selectedBenchmark = availableBenchmarks.FirstOrDefault(x => x.Name.Equals(inputType, StringComparison.InvariantCultureIgnoreCase));
-
-                if (selectedBenchmark is null)
+                // Multiple benchmark cases. Has one been supplied?
+                if (args.Length > 1)
                 {
-                    Console.Error.WriteLine("Specified benchmark does not exist. Possible benchmarks are:");
-                    foreach (var bench in availableBenchmarks)
+                    if (uint.TryParse(args[1], out var selection))
                     {
-                        Console.Error.WriteLine("  - " + bench.Name);
-                    }
-                    return;
-                }
-
-                var benchRunInfo = BenchmarkConverter.TypeToBenchmarks(selectedBenchmark);
-
-                BenchmarkCase selectedCase = null;
-
-                if (benchRunInfo.BenchmarksCases.Length == 0)
-                {
-                    Console.Error.WriteLine("No benchmark cases in specified benchmark.");
-                    return;
-                }
-                else if(benchRunInfo.BenchmarksCases.Length == 1)
-                {
-                    selectedCase = benchRunInfo.BenchmarksCases[0];
-                }
-                else
-                {
-                    // Multiple benchmark cases. Has one been supplied?
-                    if (args.Length > 1)
-                    {
-                        if (uint.TryParse(args[1], out var selection))
+                        if (selection < benchRunInfo.BenchmarksCases.Length)
                         {
-                            if (selection < benchRunInfo.BenchmarksCases.Length)
-                            {
-                                selectedCase = benchRunInfo.BenchmarksCases[selection];
-                            }
-                            else
-                            {
-                                Console.Error.WriteLine("Invalid benchmark case number provided. Possible options are: ");
-                                PrintCases(benchRunInfo);
-                            }
+                            selectedCase = benchRunInfo.BenchmarksCases[selection];
                         }
                         else
                         {
-                            Console.Error.WriteLine("Cannot parse provided benchmark case selection.");
-                            return;
+                            Console.WriteLine("Invalid benchmark case number provided. Possible options are: ");
+                            PrintCases(benchRunInfo);
                         }
                     }
                     else
                     {
-                        Console.Error.WriteLine("Specified benchmark has multiple possible cases; a single case must be specified. Possible options are:");
-                        PrintCases(benchRunInfo);
-
+                        Console.WriteLine("Cannot parse provided benchmark case selection.");
                         return;
                     }
                 }
+                else
+                {
+                    Console.WriteLine("Specified benchmark has multiple possible cases; a single case must be specified. Possible options are:");
+                    PrintCases(benchRunInfo);
+
+                    return;
+                }
+            }
                 
-                var benchInstance = Activator.CreateInstance(selectedCase.Descriptor.Type);
+            var benchInstance = Activator.CreateInstance(selectedCase.Descriptor.Type);
 
-                var setupAction = BenchmarkActionFactory.CreateGlobalSetup(selectedCase.Descriptor, benchInstance);
-                var cleanupAction = BenchmarkActionFactory.CreateGlobalCleanup(selectedCase.Descriptor, benchInstance);
+            var setupAction = BenchmarkActionFactory.CreateGlobalSetup(selectedCase.Descriptor, benchInstance);
+            var cleanupAction = BenchmarkActionFactory.CreateGlobalCleanup(selectedCase.Descriptor, benchInstance);
 
-                // Workload method is generated differently when BenchmarkDotNet actually runs; we'll need to wrap it in the set of parameters.
-                // It's way slower than they way they do it, but it should still give us good profiler results.
-                Action<int> workloadAction = (repeat) =>
+            // Workload method is generated differently when BenchmarkDotNet actually runs; we'll need to wrap it in the set of parameters.
+            // It's way slower than they way they do it, but it should still give us good profiler results.
+            Action<int> workloadAction = (repeat) =>
+            {
+                while (repeat > 0)
                 {
-                    while (repeat > 0)
-                    {
-                        selectedCase.Descriptor.WorkloadMethod.Invoke(benchInstance, selectedCase.Parameters.Items.Select(x => x.Value).ToArray());
-                        repeat--;
-                    }
-                };
+                    selectedCase.Descriptor.WorkloadMethod.Invoke(benchInstance, selectedCase.Parameters.Items.Select(x => x.Value).ToArray());
+                    repeat--;
+                }
+            };
 
-                setupAction.InvokeSingle();
+            setupAction.InvokeSingle();
 
-                // Warmup.
-                workloadAction(100);
+            // Warmup.
+            workloadAction(100);
 
-                // Now start a new thread.
-                var runThread = new Thread(new ThreadStart(() =>
-                {
-                    // Do a lot.
-                    workloadAction(10000);
-                }));
+            // Now start a new thread.
+            var runThread = new Thread(new ThreadStart(() =>
+            {
+                // Do a lot.
+                workloadAction(10000);
+            }));
 
-                runThread.Name = "Workload Thread";
+            runThread.Name = "Workload Thread";
 
-                runThread.Start();
-                runThread.Join();
+            runThread.Start();
+            runThread.Join();
+
+            cleanupAction.InvokeSingle();
+        }
+
+        private static void PrintBenchmarks(Type[] availableBenchmarks)
+        {
+            foreach (var bench in availableBenchmarks)
+            {
+                Console.WriteLine("  - " + bench.Name);
             }
         }
 
@@ -123,7 +131,7 @@ namespace Autofac.BenchmarkProfiling
                 var benchCase = benchRunInfo.BenchmarksCases[idx];
                 if (benchCase.HasParameters)
                 {
-                    Console.Error.WriteLine($"  #{idx,-2} - {benchCase.Descriptor.DisplayInfo} ({benchCase.Parameters.DisplayInfo})");
+                    Console.Error.WriteLine($" #{idx,-2} - {benchCase.Descriptor.DisplayInfo} ({benchCase.Parameters.DisplayInfo})");
                 }
                 else
                 {

--- a/bench/Autofac.BenchmarkProfiling/Program.cs
+++ b/bench/Autofac.BenchmarkProfiling/Program.cs
@@ -1,0 +1,135 @@
+﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace Autofac.BenchmarkProfiling
+{
+    /// <summary>
+    /// Simple command-line tool to invoke a benchmark manually in a way that helps with profiling each of the benchmarks.
+    /// </summary>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // Pick a benchmark.
+            var availableBenchmarks = Benchmarks.Benchmarks.All;
+
+            if (args.Length == 0)
+            {
+                Console.Error.WriteLine("Must provide the name of a benchmark class. (e.g. ./Autofac.BenchmarkProfiling.exe ChildScopeResolveBenchmark)");
+            }
+            else
+            {
+                var inputType = args[0];
+
+                var selectedBenchmark = availableBenchmarks.FirstOrDefault(x => x.Name.Equals(inputType, StringComparison.InvariantCultureIgnoreCase));
+
+                if (selectedBenchmark is null)
+                {
+                    Console.Error.WriteLine("Specified benchmark does not exist. Possible benchmarks are:");
+                    foreach (var bench in availableBenchmarks)
+                    {
+                        Console.Error.WriteLine("  - " + bench.Name);
+                    }
+                    return;
+                }
+
+                var benchRunInfo = BenchmarkConverter.TypeToBenchmarks(selectedBenchmark);
+
+                BenchmarkCase selectedCase = null;
+
+                if (benchRunInfo.BenchmarksCases.Length == 0)
+                {
+                    Console.Error.WriteLine("No benchmark cases in specified benchmark.");
+                    return;
+                }
+                else if(benchRunInfo.BenchmarksCases.Length == 1)
+                {
+                    selectedCase = benchRunInfo.BenchmarksCases[0];
+                }
+                else
+                {
+                    // Multiple benchmark cases. Has one been supplied?
+                    if (args.Length > 1)
+                    {
+                        if (uint.TryParse(args[1], out var selection))
+                        {
+                            if (selection < benchRunInfo.BenchmarksCases.Length)
+                            {
+                                selectedCase = benchRunInfo.BenchmarksCases[selection];
+                            }
+                            else
+                            {
+                                Console.Error.WriteLine("Invalid benchmark case number provided. Possible options are: ");
+                                PrintCases(benchRunInfo);
+                            }
+                        }
+                        else
+                        {
+                            Console.Error.WriteLine("Cannot parse provided benchmark case selection.");
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine("Specified benchmark has multiple possible cases; a single case must be specified. Possible options are:");
+                        PrintCases(benchRunInfo);
+
+                        return;
+                    }
+                }
+                
+                var benchInstance = Activator.CreateInstance(selectedCase.Descriptor.Type);
+
+                var setupAction = BenchmarkActionFactory.CreateGlobalSetup(selectedCase.Descriptor, benchInstance);
+                var cleanupAction = BenchmarkActionFactory.CreateGlobalCleanup(selectedCase.Descriptor, benchInstance);
+
+                // Workload method is generated differently when BenchmarkDotNet actually runs; we'll need to wrap it in the set of parameters.
+                // It's way slower than they way they do it, but it should still give us good profiler results.
+                Action<int> workloadAction = (repeat) =>
+                {
+                    while (repeat > 0)
+                    {
+                        selectedCase.Descriptor.WorkloadMethod.Invoke(benchInstance, selectedCase.Parameters.Items.Select(x => x.Value).ToArray());
+                        repeat--;
+                    }
+                };
+
+                setupAction.InvokeSingle();
+
+                // Warmup.
+                workloadAction(100);
+
+                // Now start a new thread.
+                var runThread = new Thread(new ThreadStart(() =>
+                {
+                    // Do a lot.
+                    workloadAction(10000);
+                }));
+
+                runThread.Name = "Workload Thread";
+
+                runThread.Start();
+                runThread.Join();
+            }
+        }
+
+        private static void PrintCases(BenchmarkRunInfo benchRunInfo)
+        {
+            for (int idx = 0; idx < benchRunInfo.BenchmarksCases.Length; idx++)
+            {
+                var benchCase = benchRunInfo.BenchmarksCases[idx];
+                if (benchCase.HasParameters)
+                {
+                    Console.Error.WriteLine($"  #{idx,-2} - {benchCase.Descriptor.DisplayInfo} ({benchCase.Parameters.DisplayInfo})");
+                }
+                else
+                {
+                    Console.Error.WriteLine($" #{idx,-2} - {benchCase.Descriptor.DisplayInfo} ({benchCase.Parameters.DisplayInfo})");                    
+                }
+            }
+        }
+    }
+}

--- a/bench/Autofac.BenchmarkProfiling/Properties/launchSettings.json
+++ b/bench/Autofac.BenchmarkProfiling/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Autofac.BenchmarkProfiling": {
+      "commandName": "Project",
+      "commandLineArgs": "KeyedNestedBenchmark 2"
+    }
+  }
+}

--- a/bench/Autofac.Benchmarks/Autofac.Benchmarks.csproj
+++ b/bench/Autofac.Benchmarks/Autofac.Benchmarks.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bench/Autofac.Benchmarks/BenchmarkConfig.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkConfig.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 
@@ -14,7 +14,7 @@ namespace Autofac.Benchmarks
             var runFolder = DateTime.Now.ToString("u").Replace(' ', '_').Replace(':', '-');
             ArtifactsPath = $"{rootFolder}\\BenchmarkDotNet.Artifacts\\{runFolder}";
 
-            Add(MemoryDiagnoser.Default);
+            AddDiagnoser(MemoryDiagnoser.Default);
         }
     }
 }

--- a/bench/Autofac.Benchmarks/Benchmarks.cs
+++ b/bench/Autofac.Benchmarks/Benchmarks.cs
@@ -4,9 +4,9 @@ using Autofac.Benchmarks.Decorators;
 
 namespace Autofac.Benchmarks
 {
-    internal static class Benchmarks
+    public static class Benchmarks
     {
-        internal static readonly Type[] All =
+        public static readonly Type[] All =
         {
             typeof(ChildScopeResolveBenchmark),
             typeof(ConcurrencyBenchmark),


### PR DESCRIPTION
I'm profiling some of the performance stuff in v6, and decided that rather than have a manual external tool that duplicates our benchmark code somewhere else, I'd add a simple tool to let you simulate benchmark executions in a way that lets you attach a profiler.

Thought it would be handy to bring into the solution.

In addition, I've upgraded Benchmark.NET to the newest version.

To use it, run dotTrace (or similar), profiling the `Autofac.BenchmarkProfiling` exe. Give the benchmark class name as an argument (and if there are multiple cases, a number to indicate the case).

The tool will run the global setup method of the benchmark, then a few loops of the benchmark itself (to elimate warmup/caching).

It then kicks off a "Workload Thread" to run 10,000 iterations of the benchmark. 

Example output:

```psh
PS D:\ProfilingDemo> .\Autofac.BenchmarkProfiling.exe                                                                                 Must provide the name of a benchmark class. (e.g. ./Autofac.BenchmarkProfiling.exe ChildScopeResolveBenchmark)
Possible benchmarks are:
  - ChildScopeResolveBenchmark
  - ConcurrencyBenchmark
  - ConcurrencyNestedScopeBenchmark
  - KeyedGenericBenchmark
  - KeyedNestedBenchmark
  - KeyedSimpleBenchmark
  - KeylessGenericBenchmark
  - KeylessNestedBenchmark
  - KeylessNestedSharedInstanceBenchmark
  - KeylessNestedLambdaBenchmark
  - KeylessNestedSharedInstanceLambdaBenchmark
  - KeylessSimpleBenchmark
  - KeylessSimpleSharedInstanceBenchmark
  - KeylessSimpleLambdaBenchmark
  - KeylessSimpleSharedInstanceLambdaBenchmark
  - DeepGraphResolveBenchmark
  - EnumerableResolveBenchmark
  - PropertyInjectionBenchmark
  - RootContainerResolveBenchmark
  - OpenGenericBenchmark
PS D:\ProfilingDemo> .\Autofac.BenchmarkProfiling.exe KeyedNestedBenchmark                                                            Specified benchmark has multiple possible cases; a single case must be specified. Possible options are:
 #0  - KeyedNestedBenchmark.Baseline ()
 #1  - KeyedNestedBenchmark.ResolveEnumerableT ([repetitions=1])
 #2  - KeyedNestedBenchmark.ResolveT ([repetitions=1])
 #3  - KeyedNestedBenchmark.ResolveEnumerableT ([repetitions=2])
 #4  - KeyedNestedBenchmark.ResolveT ([repetitions=2])
 #5  - KeyedNestedBenchmark.ResolveEnumerableT ([repetitions=3])
 #6  - KeyedNestedBenchmark.ResolveT ([repetitions=3])
PS D:\ProfilingDemo> .\Autofac.BenchmarkProfiling.exe KeyedNestedBenchmark 1                                                          PS D:\ProfilingDemo>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
```

The workload thread is named:

![image](https://user-images.githubusercontent.com/19165743/83647579-f6b16400-a5ac-11ea-8cc5-d6f2239466e7.png)



