### PR TITLE
Micro Perf - Store a value for 'trace is enabled'

### DIFF
--- a/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
@@ -269,14 +269,9 @@ namespace Autofac.Core.Resolving.Pipeline
                 return (ctxt) =>
                 {
                     // Optimise the path depending on whether a tracer is attached.
-                    if (ctxt.Tracer is null)
+                    if (ctxt.TracingEnabled)
                     {
-                        ctxt.PhaseReached = stage.Phase;
-                        stage.Execute(ctxt, next);
-                    }
-                    else
-                    {
-                        ctxt.Tracer.MiddlewareEntry(ctxt.Operation, ctxt, stage);
+                        ctxt.Tracer!.MiddlewareEntry(ctxt.Operation, ctxt, stage);
                         var succeeded = false;
                         try
                         {
@@ -288,6 +283,11 @@ namespace Autofac.Core.Resolving.Pipeline
                         {
                             ctxt.Tracer.MiddlewareExit(ctxt.Operation, ctxt, stage, succeeded);
                         }
+                    }
+                    else
+                    {
+                        ctxt.PhaseReached = stage.Phase;
+                        stage.Execute(ctxt, next);
                     }
                 };
             }

--- a/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContextBase.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContextBase.cs
@@ -58,6 +58,7 @@ namespace Autofac.Core.Resolving.Pipeline
             Parameters = request.Parameters;
             PhaseReached = PipelinePhase.RequestStart;
             Tracer = tracer;
+            TracingEnabled = tracer is object;
             _resolveRequest = request;
         }
 
@@ -110,6 +111,11 @@ namespace Autofac.Core.Resolving.Pipeline
         /// Gets the active <see cref="IResolvePipelineTracer"/> for the request.
         /// </summary>
         public IResolvePipelineTracer? Tracer { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether tracing is enabled. If this value is true, then <see cref="Tracer"/> will not be null.
+        /// </summary>
+        public bool TracingEnabled { get; }
 
         /// <summary>
         /// Gets the current resolve parameters. These can be changed using the <see cref="ChangeParameters(IEnumerable{Parameter})"/> method.


### PR DESCRIPTION
The 'pipeline progression' function that implements the actual next() call is an extremely hot path, and checks for a Tracer to see if it exists in each call. 

This change is a small optimisation to store a 'TracingEnabled' flag at the start of the request, to speed up that check slightly.

### DeepGraphBenchmark

this PR

|  Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| Resolve | 17.55 us | 0.221 us | 0.196 us | 4.0894 |     - |     - |  16.71 KB |

v6

|  Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| Resolve | 17.83 us | 0.265 us | 0.222 us | 4.0894 |     - |     - |  16.71 KB |