### PR TITLE
Enabled SA1600 (Elements must have docs) - Added required comments

### DIFF
--- a/Autofac.sln
+++ b/Autofac.sln
@@ -7,7 +7,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5A54DF18-E3F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DEA4A8C6-DE56-4359-A87C-472FB34132E7}"
 	ProjectSection(SolutionItems) = preProject
-		test\TestSuppressions.cs = test\TestSuppressions.cs
+		test\Directory.Build.props = test\Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B324E70-6C86-4E09-B150-CAE9DD2BADCC}"

--- a/Autofac.sln
+++ b/Autofac.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5A54DF18-E3F3-4929-876D-00650A15763E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{DEA4A8C6-DE56-4359-A87C-472FB34132E7}"
+	ProjectSection(SolutionItems) = preProject
+		test\TestSuppressions.cs = test\TestSuppressions.cs
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6B324E70-6C86-4E09-B150-CAE9DD2BADCC}"
 	ProjectSection(SolutionItems) = preProject

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -1,61 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="14.0">
-  <!-- https://github.com/dotnet/roslyn/blob/master/docs/compilers/Rule%20Set%20Format.md -->
+<RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
-    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
-    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
-    <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
-    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
-    <!-- Prefix local calls with this -->
     <Rule Id="SA1101" Action="None" />
-    <!-- Use built-in type alias -->
     <Rule Id="SA1121" Action="None" />
-    <!-- Use String.Empty instead of "" -->
     <Rule Id="SA1122" Action="None" />
-    <!-- Using statements must be inside a namespace -->
     <Rule Id="SA1200" Action="None" />
-    <!-- Enforce order of class members by member type -->
     <Rule Id="SA1201" Action="None" />
-    <!-- Enforce order of class members by member visibility -->
     <Rule Id="SA1202" Action="None" />
-    <!-- Enforce order of constantand static members -->
     <Rule Id="SA1203" Action="None" />
-    <!-- Enforce order of static vs. non-static members -->
     <Rule Id="SA1204" Action="None" />
-    <!-- Enforce order of readonly vs. non-readonly members -->
     <Rule Id="SA1214" Action="None" />
-    <!-- Fields can't start with underscore -->
     <Rule Id="SA1309" Action="None" />
-    <!-- Suppressions must have a justification -->
     <Rule Id="SA1404" Action="None" />
-    <!-- Use trailing comma in initializers - lots of false positives for enums in StyleCop 1.1.0-beta004 -->
     <Rule Id="SA1413" Action="None" />
-    <!-- No single-line statements involving braces -->
     <Rule Id="SA1501" Action="None" />
-    <!-- Braces must not be omitted -->
     <Rule Id="SA1503" Action="None" />
-    <!-- Element must be documented -->
-    <Rule Id="SA1600" Action="None" />
-    <!-- Parameter documentation mus be in the right order -->
     <Rule Id="SA1612" Action="None" />
-    <!-- Return value must be documented -->
     <Rule Id="SA1615" Action="None" />
-    <!-- Generic type parameters must be documented -->
     <Rule Id="SA1618" Action="None" />
-    <!-- Don't copy/paste documentation -->
     <Rule Id="SA1625" Action="None" />
-    <!-- Exception documentation must not be empty -->
     <Rule Id="SA1627" Action="None" />
-    <!-- File must have header -->
     <Rule Id="SA1633" Action="None" />
-    <!-- Enable XML documentation output-->
     <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/build/Analyzers.ruleset
+++ b/build/Analyzers.ruleset
@@ -2,32 +2,57 @@
 <RuleSet Name="Autofac Analyzer Rules" Description="Analyzer rules for Autofac assemblies." ToolsVersion="16.0">
   <IncludeAll Action="Warning" />
   <Rules AnalyzerId="Microsoft.Usage" RuleNamespace="Microsoft.Usage">
+    <!-- Implement standard exception constructors - not all of the exception constructors (e.g., parameterless) are desired in our system. -->
     <Rule Id="CA1032" Action="None" />
+    <!-- Change names to avoid reserved word overlaps (e.g., Delegate, GetType, etc.) - too many of these in the public API, we'd break if we fixed it. -->
     <Rule Id="CA1716" Action="None" />
+    <!-- Implement serialization constructors - false positive when building .NET Core -->
     <Rule Id="CA2229" Action="None" />
+    <!-- Mark ISerializable types with SerializableAttribute - false positive when building .NET Core -->
     <Rule Id="CA2237" Action="None" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Prefix local calls with this -->
     <Rule Id="SA1101" Action="None" />
+    <!-- Use built-in type alias -->
     <Rule Id="SA1121" Action="None" />
+    <!-- Use String.Empty instead of "" -->
     <Rule Id="SA1122" Action="None" />
+    <!-- Using statements must be inside a namespace -->
     <Rule Id="SA1200" Action="None" />
+    <!-- Enforce order of class members by member type -->
     <Rule Id="SA1201" Action="None" />
+    <!-- Enforce order of class members by member visibility -->
     <Rule Id="SA1202" Action="None" />
+    <!-- Enforce order of constantand static members -->
     <Rule Id="SA1203" Action="None" />
+    <!-- Enforce order of static vs. non-static members -->
     <Rule Id="SA1204" Action="None" />
+    <!-- Enforce order of readonly vs. non-readonly members -->
     <Rule Id="SA1214" Action="None" />
+    <!-- Fields can't start with underscore -->
     <Rule Id="SA1309" Action="None" />
+    <!-- Suppressions must have a justification -->
     <Rule Id="SA1404" Action="None" />
+    <!-- Use trailing comma in initializers - lots of false positives for enums in StyleCop 1.1.0-beta004 -->
     <Rule Id="SA1413" Action="None" />
+    <!-- No single-line statements involving braces -->
     <Rule Id="SA1501" Action="None" />
+    <!-- Braces must not be omitted -->
     <Rule Id="SA1503" Action="None" />
+    <!-- Parameter documentation mus be in the right order -->
     <Rule Id="SA1612" Action="None" />
+    <!-- Return value must be documented -->
     <Rule Id="SA1615" Action="None" />
+    <!-- Generic type parameters must be documented -->
     <Rule Id="SA1618" Action="None" />
+    <!-- Don't copy/paste documentation -->
     <Rule Id="SA1625" Action="None" />
+    <!-- Exception documentation must not be empty -->
     <Rule Id="SA1627" Action="None" />
+    <!-- File must have header -->
     <Rule Id="SA1633" Action="None" />
+    <!-- Enable XML documentation output-->
     <Rule Id="SA1652" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/Autofac/Builder/BuildCallbackManager.cs
+++ b/src/Autofac/Builder/BuildCallbackManager.cs
@@ -28,6 +28,9 @@ using Autofac.Core;
 
 namespace Autofac.Builder
 {
+    /// <summary>
+    /// Provides support for accessing/invoking the set of build callbacks, invoked on scope/container build.
+    /// </summary>
     internal static class BuildCallbackManager
     {
         private static readonly TypedService CallbackServiceType = new TypedService(typeof(BuildCallbackService));

--- a/src/Autofac/Builder/BuildCallbackService.cs
+++ b/src/Autofac/Builder/BuildCallbackService.cs
@@ -47,6 +47,10 @@ namespace Autofac.Builder
             _callbacks.Add(callback);
         }
 
+        /// <summary>
+        /// Execute the callback for each build callback registered in this service.
+        /// </summary>
+        /// <param name="scope">The scope that has been built.</param>
         public void Execute(ILifetimeScope scope)
         {
             if (scope == null) throw new ArgumentNullException(nameof(scope));

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -58,6 +58,9 @@ namespace Autofac.Builder
         [EditorBrowsable(EditorBrowsableState.Never)]
         TRegistrationStyle RegistrationStyle { get; }
 
+        /// <summary>
+        /// Gets the resolve pipeline for this registration.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         IResolvePipelineBuilder ResolvePipeline { get; }
 

--- a/src/Autofac/Builder/MetadataConfiguration.cs
+++ b/src/Autofac/Builder/MetadataConfiguration.cs
@@ -42,6 +42,9 @@ namespace Autofac.Builder
     {
         private readonly IDictionary<string, object?> _properties = new Dictionary<string, object?>();
 
+        /// <summary>
+        /// Gets the set of properties that have been provided.
+        /// </summary>
         internal IEnumerable<KeyValuePair<string, object?>> Properties => _properties;
 
         /// <summary>

--- a/src/Autofac/Builder/MetadataKeys.cs
+++ b/src/Autofac/Builder/MetadataKeys.cs
@@ -25,16 +25,33 @@
 
 namespace Autofac.Builder
 {
+    /// <summary>
+    /// Internal metadata keys.
+    /// </summary>
     internal static class MetadataKeys
     {
+        /// <summary>
+        /// Key containing the registration order.
+        /// </summary>
         internal const string RegistrationOrderMetadataKey = "__RegistrationOrder";
 
+        /// <summary>
+        /// Key containing a value indicating whether the registration has been auto activated.
+        /// </summary>
         internal const string AutoActivated = "__AutoActivated";
 
+        /// <summary>
+        /// Key containing a value indicating whether the registration should be started on activation.
+        /// </summary>
         internal const string StartOnActivatePropertyKey = "__StartOnActivate";
 
+        /// <summary>
+        /// Key containing the container build options.
+        /// </summary>
         internal const string ContainerBuildOptions = "__ContainerBuildOptions";
 
+        // TODO: Change the registration builder event handler to not use these.
+        #pragma warning disable SA1600 // Elements should be documented
         internal const string RegisteredPropertyKey = "__RegisteredKey";
 
         internal const string RegistrationSourceAddedPropertyKey = "__RegistrationSourceAddedKey";
@@ -42,5 +59,6 @@ namespace Autofac.Builder
         internal const string InternalRegisteredPropertyKey = "__InternalRegisteredKey";
 
         internal const string InternalRegistrationSourceAddedPropertyKey = "__InternalRegistrationSourceAddedKey";
+        #pragma warning restore SA1600 // Elements should be documented
     }
 }

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -30,15 +30,27 @@ using System.Linq;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Core.Lifetime;
-using Autofac.Core.Resolving;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Features.OwnedInstances;
 
 namespace Autofac.Builder
 {
+    /// <summary>
+    /// Data structure used to construct registrations.
+    /// </summary>
+    /// <typeparam name="TLimit">The most specific type to which instances of the registration
+    /// can be cast.</typeparam>
+    /// <typeparam name="TActivatorData">Activator builder type.</typeparam>
+    /// <typeparam name="TRegistrationStyle">Registration style type.</typeparam>
     internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> : IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>, IHideObjectMembers
         where TLimit : notnull
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}"/> class.
+        /// </summary>
+        /// <param name="defaultService">The default service.</param>
+        /// <param name="activatorData">The activator data.</param>
+        /// <param name="style">The registration style.</param>
         public RegistrationBuilder(Service defaultService, TActivatorData activatorData, TRegistrationStyle style)
         {
             if (defaultService == null) throw new ArgumentNullException(nameof(defaultService));
@@ -69,6 +81,9 @@ namespace Autofac.Builder
         [EditorBrowsable(EditorBrowsableState.Never)]
         public RegistrationData RegistrationData { get; }
 
+        /// <summary>
+        /// Gets the resolve pipeline builder, that can be used to add middleware to the pipeline.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public IResolvePipelineBuilder ResolvePipeline { get; }
 

--- a/src/Autofac/Builder/RegistrationOrderExtensions.cs
+++ b/src/Autofac/Builder/RegistrationOrderExtensions.cs
@@ -27,14 +27,31 @@ using Autofac.Core;
 
 namespace Autofac.Builder
 {
+    /// <summary>
+    /// Extension methods for controlling and accessing registration order.
+    /// </summary>
     internal static class RegistrationOrderExtensions
     {
+        /// <summary>
+        /// Gets the registration order value from the registration.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <returns>The original registration order value.</returns>
         internal static long GetRegistrationOrder(this IComponentRegistration registration)
         {
             object? value;
             return registration.Metadata.TryGetValue(MetadataKeys.RegistrationOrderMetadataKey, out value) ? (long)value! : long.MaxValue;
         }
 
+        /// <summary>
+        /// Indicates that a registration should inherit its registration order from another registration.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TActivatorData">The activator data type.</typeparam>
+        /// <typeparam name="TSingleRegistrationStyle">The registration style type.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="source">The source registration to take the order from.</param>
+        /// <returns>The registration builder.</returns>
         internal static IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> InheritRegistrationOrderFrom<TLimit, TActivatorData, TSingleRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, TActivatorData, TSingleRegistrationStyle> registration,
                 IComponentRegistration source)

--- a/src/Autofac/Builder/StartableManager.cs
+++ b/src/Autofac/Builder/StartableManager.cs
@@ -5,6 +5,9 @@ using Autofac.Core;
 
 namespace Autofac.Builder
 {
+    /// <summary>
+    /// Helper functions for starting 'startable' components.
+    /// </summary>
     internal static class StartableManager
     {
         /// <summary>

--- a/src/Autofac/Core/Activators/DelegatePropertySelector.cs
+++ b/src/Autofac/Core/Activators/DelegatePropertySelector.cs
@@ -22,6 +22,7 @@ namespace Autofac.Core
             _finder = finder;
         }
 
+        /// <inheritdoc/>
         public bool InjectProperty(PropertyInfo property, object instance)
         {
             return _finder(property, instance);

--- a/src/Autofac/Core/Activators/InstanceActivator.cs
+++ b/src/Autofac/Core/Activators/InstanceActivator.cs
@@ -59,6 +59,9 @@ namespace Autofac.Core.Activators
             return LimitType.Name + " (" + GetType().Name + ")";
         }
 
+        /// <summary>
+        /// Asserts that the activator has not been disposed.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void CheckNotDisposed()
         {

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -32,9 +32,15 @@ using Autofac.Util;
 
 namespace Autofac.Core.Activators.Reflection
 {
+    /// <summary>
+    /// Provide helper methods for injecting property values.
+    /// </summary>
     internal static class AutowiringPropertyInjector
     {
-        public const string InstanceTypeNamedParameter = "Autofac.AutowiringPropertyInjector.InstanceType";
+        /// <summary>
+        /// Name of the parameter containing the instance type provided when resolving an injected service.
+        /// </summary>
+        internal const string InstanceTypeNamedParameter = "Autofac.AutowiringPropertyInjector.InstanceType";
 
         private static readonly ConcurrentDictionary<PropertyInfo, Action<object, object?>> PropertySetters =
             new ConcurrentDictionary<PropertyInfo, Action<object, object?>>();
@@ -45,6 +51,13 @@ namespace Autofac.Core.Activators.Reflection
         private static readonly MethodInfo CallPropertySetterOpenGenericMethod =
             typeof(AutowiringPropertyInjector).GetTypeInfo().GetDeclaredMethod(nameof(CallPropertySetter));
 
+        /// <summary>
+        /// Inject properties onto an instance, filtered by a property selector.
+        /// </summary>
+        /// <param name="context">The component context to resolve dependencies from.</param>
+        /// <param name="instance">The instance to inject onto.</param>
+        /// <param name="propertySelector">The property selector.</param>
+        /// <param name="parameters">The set of parameters for the resolve that can be used to satisfy injectable properties.</param>
         public static void InjectProperties(IComponentContext context, object instance, IPropertySelector propertySelector, IEnumerable<Parameter> parameters)
         {
             if (context == null)

--- a/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
@@ -186,7 +186,7 @@ namespace Autofac.Core.Activators.Reflection
             return lambdaExpression.Compile();
         }
 
-        public static MethodCallExpression ConvertPrimitiveType(Expression valueExpression, Type conversionType)
+        private static MethodCallExpression ConvertPrimitiveType(Expression valueExpression, Type conversionType)
         {
             var changeTypeMethod = typeof(Convert).GetRuntimeMethod(nameof(Convert.ChangeType), new[] { typeof(object), typeof(Type) });
             return Expression.Call(changeTypeMethod, valueExpression, Expression.Constant(conversionType));

--- a/src/Autofac/Core/Activators/Reflection/NoConstructorsFoundException.cs
+++ b/src/Autofac/Core/Activators/Reflection/NoConstructorsFoundException.cs
@@ -28,6 +28,9 @@ using System.Globalization;
 
 namespace Autofac.Core.Activators.Reflection
 {
+    /// <summary>
+    /// Exception thrown when no suitable constructors could be found on a type.
+    /// </summary>
     public class NoConstructorsFoundException : Exception
     {
         /// <summary>

--- a/src/Autofac/Core/DependencyResolutionException.cs
+++ b/src/Autofac/Core/DependencyResolutionException.cs
@@ -1,4 +1,4 @@
-// This software is part of the Autofac IoC container
+﻿// This software is part of the Autofac IoC container
 // Copyright © 2011 Autofac Contributors
 // https://autofac.org
 //
@@ -37,6 +37,11 @@ namespace Autofac.Core
     [Serializable]
     public class DependencyResolutionException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DependencyResolutionException"/> class.
+        /// </summary>
+        /// <param name="info">The serialisation info.</param>
+        /// <param name="context">The serialisation streaming context.</param>
         protected DependencyResolutionException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/src/Autofac/Core/Diagnostics/OperationTraceCompletedArgs.cs
+++ b/src/Autofac/Core/Diagnostics/OperationTraceCompletedArgs.cs
@@ -2,16 +2,30 @@
 
 namespace Autofac.Core.Diagnostics
 {
+    /// <summary>
+    /// Event data for the <see cref="DefaultDiagnosticTracer.OperationCompleted"/> event.
+    /// </summary>
     public sealed class OperationTraceCompletedArgs
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationTraceCompletedArgs"/> class.
+        /// </summary>
+        /// <param name="operation">The operation for which a trace has completed.</param>
+        /// <param name="traceContent">The content of the trace.</param>
         public OperationTraceCompletedArgs(ResolveOperationBase operation, string traceContent)
         {
             Operation = operation;
             TraceContent = traceContent;
         }
 
+        /// <summary>
+        /// Gets the operation for which a trace is available.
+        /// </summary>
         public ResolveOperationBase Operation { get; }
 
+        /// <summary>
+        /// Gets the content of the trace.
+        /// </summary>
         public string TraceContent { get; }
     }
 }

--- a/src/Autofac/Core/Disposer.cs
+++ b/src/Autofac/Core/Disposer.cs
@@ -94,6 +94,7 @@ namespace Autofac.Core
             base.Dispose(disposing);
         }
 
+        /// <inheritdoc/>
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)

--- a/src/Autofac/Core/IComponentRegistryServices.cs
+++ b/src/Autofac/Core/IComponentRegistryServices.cs
@@ -28,6 +28,9 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Autofac.Core
 {
+    /// <summary>
+    /// Defines an interface for accessing the set of services available during pipeline build time.
+    /// </summary>
     public interface IComponentRegistryServices
     {
         /// <summary>

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -55,6 +55,9 @@ namespace Autofac.Core.Lifetime
         private LifetimeScope? _parentScope;
         private IResolvePipelineTracer? _tracer;
 
+        /// <summary>
+        /// Gets the id of the lifetime scope self-registration.
+        /// </summary>
         internal static Guid SelfRegistrationId { get; } = Guid.NewGuid();
 
         /// <summary>
@@ -410,6 +413,7 @@ namespace Autofac.Core.Lifetime
             base.Dispose(disposing);
         }
 
+        /// <inheritdoc/>
         protected override async ValueTask DisposeAsync(bool disposing)
         {
             if (disposing)

--- a/src/Autofac/Core/Registration/ComponentPipelineBuildingArgs.cs
+++ b/src/Autofac/Core/Registration/ComponentPipelineBuildingArgs.cs
@@ -35,16 +35,30 @@ using Autofac.Util;
 
 namespace Autofac.Core.Registration
 {
+    /// <summary>
+    /// Event arguments for the <see cref="IComponentRegistration.PipelineBuilding"/> event.
+    /// </summary>
     public class ComponentPipelineBuildingArgs
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentPipelineBuildingArgs"/> class.
+        /// </summary>
+        /// <param name="registration">The registration.</param>
+        /// <param name="pipelineBuilder">The pipeline builder.</param>
         public ComponentPipelineBuildingArgs(IComponentRegistration registration, IResolvePipelineBuilder pipelineBuilder)
         {
             Registration = registration;
             PipelineBuilder = pipelineBuilder;
         }
 
+        /// <summary>
+        /// Gets the component registration whose pipeline is being built.
+        /// </summary>
         public IComponentRegistration Registration { get; }
 
+        /// <summary>
+        /// Gets the pipeline builder for the registration. Add middleware to the builder to add to the component behaviour.
+        /// </summary>
         public IResolvePipelineBuilder PipelineBuilder { get; }
     }
 }

--- a/src/Autofac/Core/Registration/ComponentRegistration.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistration.cs
@@ -52,6 +52,18 @@ namespace Autofac.Core.Registration
             SharingMiddleware.Instance,
         };
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentRegistration"/> class.
+        /// </summary>
+        /// <param name="id">The registration id.</param>
+        /// <param name="activator">The component activator.</param>
+        /// <param name="lifetime">The lifetime for activated instances.</param>
+        /// <param name="sharing">The sharing setting for the registration.</param>
+        /// <param name="ownership">The ownership setting for the registration.</param>
+        /// <param name="services">The set of services provided by the registration.</param>
+        /// <param name="metadata">Any metadata associated with the registration.</param>
+        /// <param name="target">The target/inner registration.</param>
+        /// <param name="isAdapterForIndividualComponents">Indicates whether this registration is an adapter for individual components (Meta, Func, etc).</param>
         public ComponentRegistration(
            Guid id,
            IInstanceActivator activator,
@@ -66,6 +78,16 @@ namespace Autofac.Core.Registration
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentRegistration"/> class.
+        /// </summary>
+        /// <param name="id">Unique identifier for the component.</param>
+        /// <param name="activator">Activator used to activate instances.</param>
+        /// <param name="lifetime">Determines how the component will be associated with its lifetime.</param>
+        /// <param name="sharing">Whether the component is shared within its lifetime scope.</param>
+        /// <param name="ownership">Whether the component instances are disposed at the end of their lifetimes.</param>
+        /// <param name="services">Services the component provides.</param>
+        /// <param name="metadata">Data associated with the component.</param>
         public ComponentRegistration(
            Guid id,
            IInstanceActivator activator,
@@ -160,7 +182,10 @@ namespace Autofac.Core.Registration
         /// </summary>
         public Guid Id { get; }
 
-        public IInstanceActivator Activator { get; set; }
+        /// <summary>
+        /// Gets the activator for the registration.
+        /// </summary>
+        public IInstanceActivator Activator { get; }
 
         /// <summary>
         /// Gets the lifetime associated with the component.
@@ -217,6 +242,15 @@ namespace Autofac.Core.Registration
             ResolvePipeline = BuildResolvePipeline(registryServices, _lateBuildPipeline);
         }
 
+        /// <summary>
+        /// Populates the resolve pipeline with middleware based on the registration, and builds the pipeline.
+        /// </summary>
+        /// <param name="registryServices">The known set of all services.</param>
+        /// <param name="pipelineBuilder">The registration's pipeline builder (with user-added middleware already in it).</param>
+        /// <returns>The built pipeline.</returns>
+        /// <remarks>
+        /// A derived implementation can use this to add additional middleware, or return a completely different pipeline if required.
+        /// </remarks>
         protected virtual IResolvePipeline BuildResolvePipeline(IComponentRegistryServices registryServices, IResolvePipelineBuilder pipelineBuilder)
         {
             _lateBuildPipeline.UseRange(_defaultStages);

--- a/src/Autofac/Core/Registration/ComponentRegistrationExtensions.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistrationExtensions.cs
@@ -25,8 +25,16 @@
 
 namespace Autofac.Core.Registration
 {
+    /// <summary>
+    /// Extension methods for component registrations.
+    /// </summary>
     internal static class ComponentRegistrationExtensions
     {
+        /// <summary>
+        /// Gets a value indicating whether a given registration is adapting another registration.
+        /// </summary>
+        /// <param name="componentRegistration">The component registration.</param>
+        /// <returns>True if adapting; false otherwise.</returns>
         public static bool IsAdapting(this IComponentRegistration componentRegistration)
         {
             return componentRegistration.Target != componentRegistration;

--- a/src/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
@@ -39,43 +39,61 @@ namespace Autofac.Core.Registration
     {
         private readonly IComponentRegistration _inner;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ComponentRegistrationLifetimeDecorator"/> class.
+        /// </summary>
+        /// <param name="inner">The inner registration.</param>
+        /// <param name="lifetime">The enforced lifetime.</param>
         public ComponentRegistrationLifetimeDecorator(IComponentRegistration inner, IComponentLifetime lifetime)
         {
             _inner = inner ?? throw new ArgumentNullException(nameof(inner));
             Lifetime = lifetime ?? throw new ArgumentNullException(nameof(lifetime));
         }
 
+        /// <inheritdoc/>
         public Guid Id => _inner.Id;
 
+        /// <inheritdoc/>
         public IInstanceActivator Activator => _inner.Activator;
 
+        /// <inheritdoc/>
         public IComponentLifetime Lifetime { get; }
 
+        /// <inheritdoc/>
         public InstanceSharing Sharing => _inner.Sharing;
 
+        /// <inheritdoc/>
         public InstanceOwnership Ownership => _inner.Ownership;
 
+        /// <inheritdoc/>
         public IEnumerable<Service> Services => _inner.Services;
 
+        /// <inheritdoc/>
         public IDictionary<string, object?> Metadata => _inner.Metadata;
 
+        /// <inheritdoc/>
         public IComponentRegistration Target => _inner.IsAdapting() ? _inner.Target : this;
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponent => _inner.IsAdapterForIndividualComponent;
 
+        /// <inheritdoc/>
         public IResolvePipeline ResolvePipeline => _inner.ResolvePipeline;
 
+        /// <inheritdoc/>
         public event EventHandler<IResolvePipelineBuilder> PipelineBuilding
         {
             add => _inner.PipelineBuilding += value;
             remove => _inner.PipelineBuilding -= value;
         }
 
+        /// <inheritdoc/>
         public void BuildResolvePipeline(IComponentRegistryServices registryServices)
         {
             _inner.BuildResolvePipeline(registryServices);
         }
 
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             _inner.Dispose();

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -43,6 +43,9 @@ namespace Autofac.Core.Registration
         /// </summary>
         private readonly object _synchRoot = new object();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultRegisteredServicesTracker"/> class.
+        /// </summary>
         public DefaultRegisteredServicesTracker()
         {
             _registrationAccessor = RegistrationsFor;

--- a/src/Autofac/Core/Registration/ExternalComponentRegistration.cs
+++ b/src/Autofac/Core/Registration/ExternalComponentRegistration.cs
@@ -33,11 +33,17 @@ namespace Autofac.Core.Registration
     /// </summary>
     internal class ExternalComponentRegistration : ComponentRegistration
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalComponentRegistration"/> class.
+        /// </summary>
+        /// <param name="service">The service to register for.</param>
+        /// <param name="target">The target registration ID.</param>
         public ExternalComponentRegistration(Service service, IComponentRegistration target)
             : base(target.Id, new NoOpActivator(target.Activator.LimitType), target.Lifetime, target.Sharing, target.Ownership, new[] { service }, target.Metadata, target, false)
         {
         }
 
+        /// <inheritdoc/>
         protected override IResolvePipeline BuildResolvePipeline(IComponentRegistryServices registryServices, IResolvePipelineBuilder pipelineBuilder)
         {
             // Just use the external pipeline.

--- a/src/Autofac/Core/Registration/ScopeRestrictedRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/ScopeRestrictedRegisteredServicesTracker.cs
@@ -11,6 +11,10 @@ namespace Autofac.Core.Registration
     {
         private readonly IComponentLifetime _restrictedRootScopeLifetime;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScopeRestrictedRegisteredServicesTracker"/> class.
+        /// </summary>
+        /// <param name="restrictedRootScopeLifetime">The scope to which registrations are restricted.</param>
         internal ScopeRestrictedRegisteredServicesTracker(IComponentLifetime restrictedRootScopeLifetime)
         {
             _restrictedRootScopeLifetime = restrictedRootScopeLifetime;

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -126,6 +126,12 @@ namespace Autofac.Core.Registration
             _sourceImplementations != null ||
             _preserveDefaultImplementations != null;
 
+        /// <summary>
+        /// Add an implementation for the service.
+        /// </summary>
+        /// <param name="registration">The component registration.</param>
+        /// <param name="preserveDefaults">Whether to preserve the defaults.</param>
+        /// <param name="originatedFromSource">Whether the registration originated from a dynamic source.</param>
         public void AddImplementation(IComponentRegistration registration, bool preserveDefaults, bool originatedFromSource)
         {
             if (preserveDefaults)
@@ -163,6 +169,11 @@ namespace Autofac.Core.Registration
                 _registeredImplementations = new Lazy<IList<IComponentRegistration>>(InitializeComponentRegistrations);
         }
 
+        /// <summary>
+        /// Attempts to access the implementing registration for this service, selecting the correct one based on defaults and all known registrations.
+        /// </summary>
+        /// <param name="registration">The output registration.</param>
+        /// <returns>True if a registration was found; false otherwise.</returns>
         public bool TryGetRegistration([NotNullWhen(returnValue: true)] out IComponentRegistration? registration)
         {
             RequiresInitialization();
@@ -174,6 +185,10 @@ namespace Autofac.Core.Registration
             return registration != null;
         }
 
+        /// <summary>
+        /// Include a registration source in the list of sources for the registration info.
+        /// </summary>
+        /// <param name="source">The registration source.</param>
         public void Include(IRegistrationSource source)
         {
             if (IsInitialized)
@@ -187,10 +202,20 @@ namespace Autofac.Core.Registration
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether this service info is initialising.
+        /// </summary>
         public bool IsInitializing => !IsInitialized && _sourcesToQuery != null;
 
+        /// <summary>
+        /// Gets a value indicating whether there are any sources left to query.
+        /// </summary>
         public bool HasSourcesToQuery => IsInitializing && _sourcesToQuery!.Count != 0;
 
+        /// <summary>
+        /// Begin the initialisation process for this service info, given the set of dynamic sources.
+        /// </summary>
+        /// <param name="sources">The set of sources.</param>
         public void BeginInitialization(IEnumerable<IRegistrationSource> sources)
         {
             IsInitialized = false;
@@ -198,6 +223,10 @@ namespace Autofac.Core.Registration
             _sourcesToQuery = new Queue<IRegistrationSource>(sources);
         }
 
+        /// <summary>
+        /// Skip a given source in the set of dynamic sources.
+        /// </summary>
+        /// <param name="source">The source to skip.</param>
         public void SkipSource(IRegistrationSource source)
         {
             EnforceDuringInitialization();
@@ -212,6 +241,10 @@ namespace Autofac.Core.Registration
                 throw new InvalidOperationException(ServiceRegistrationInfoResources.NotDuringInitialization);
         }
 
+        /// <summary>
+        /// Dequeue the next registration source.
+        /// </summary>
+        /// <returns>The source.</returns>
         public IRegistrationSource DequeueNextSource()
         {
             EnforceDuringInitialization();
@@ -220,6 +253,9 @@ namespace Autofac.Core.Registration
             return _sourcesToQuery!.Dequeue();
         }
 
+        /// <summary>
+        /// Complete initialisation of the service info.
+        /// </summary>
         public void CompleteInitialization()
         {
             // Does not EnforceDuringInitialization() because the recursive algorithm

--- a/src/Autofac/Core/Resolving/ActivatorExtensions.cs
+++ b/src/Autofac/Core/Resolving/ActivatorExtensions.cs
@@ -27,11 +27,18 @@ using Autofac.Core.Activators.Delegate;
 
 namespace Autofac.Core.Resolving
 {
+    /// <summary>
+    /// Extension methods for activators.
+    /// </summary>
     internal static class ActivatorExtensions
     {
-        // This shorthand name for the activator is used in exception messages; for activator types
-        // where the limit type generally describes the activator exactly, we use that; for delegate
-        // activators, a variation on the type name is used to indicate this.
+        /// <summary>
+        /// This shorthand name for the activator is used in exception messages; for activator types
+        /// where the limit type generally describes the activator exactly, we use that; for delegate
+        /// activators, a variation on the type name is used to indicate this.
+        /// </summary>
+        /// <param name="activator">The activator instance.</param>
+        /// <returns>A display name.</returns>
         public static string DisplayName(this IInstanceActivator activator)
         {
             var fullName = activator.LimitType.FullName ?? "";

--- a/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
@@ -36,19 +36,31 @@ namespace Autofac.Core.Resolving.Middleware
     /// </summary>
     internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
     {
+        /// <summary>
+        /// Defines the default max resolve depth.
+        /// </summary>
         public const int DefaultMaxResolveDepth = 50;
 
+        /// <summary>
+        /// Gets the default instance of <see cref="CircularDependencyDetectorMiddleware"/>.
+        /// </summary>
         public static CircularDependencyDetectorMiddleware Default { get; } = new CircularDependencyDetectorMiddleware(DefaultMaxResolveDepth);
 
         private readonly int _maxResolveDepth;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularDependencyDetectorMiddleware"/> class.
+        /// </summary>
+        /// <param name="maxResolveDepth">The max resolve depth.</param>
         public CircularDependencyDetectorMiddleware(int maxResolveDepth)
         {
             _maxResolveDepth = maxResolveDepth;
         }
 
+        /// <inheritdoc/>
         public PipelinePhase Phase => PipelinePhase.RequestStart;
 
+        /// <inheritdoc/>
         public void Execute(ResolveRequestContextBase context, Action<ResolveRequestContextBase> next)
         {
             var activationDepth = context.Operation.RequestDepth;
@@ -92,6 +104,7 @@ namespace Autofac.Core.Resolving.Middleware
             }
         }
 
+        /// <inheritdoc/>
         public override string ToString() => nameof(CircularDependencyDetectorMiddleware);
 
         private static string CreateDependencyGraphTo(IComponentRegistration registration, IEnumerable<ResolveRequestContextBase> requestStack)

--- a/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
@@ -33,10 +33,14 @@ namespace Autofac.Core.Resolving.Middleware
     /// </summary>
     internal class DisposalTrackingMiddleware : IResolveMiddleware
     {
+        /// <summary>
+        /// Gets the singleton instance of the <see cref="DisposalTrackingMiddleware"/>.
+        /// </summary>
         public static DisposalTrackingMiddleware Instance { get; } = new DisposalTrackingMiddleware();
 
         private DisposalTrackingMiddleware()
         {
+            // Singleton use only.
         }
 
         /// <inheritdoc />

--- a/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
@@ -35,6 +35,9 @@ namespace Autofac.Core.Resolving.Middleware
     /// </summary>
     internal class ScopeSelectionMiddleware : IResolveMiddleware
     {
+        /// <summary>
+        /// Gets the singleton instance of the <see cref="ScopeSelectionMiddleware"/>.
+        /// </summary>
         public static ScopeSelectionMiddleware Instance => new ScopeSelectionMiddleware();
 
         private ScopeSelectionMiddleware()
@@ -42,8 +45,10 @@ namespace Autofac.Core.Resolving.Middleware
             // Only want to use the static instance.
         }
 
+        /// <inheritdoc/>
         public PipelinePhase Phase => PipelinePhase.ScopeSelection;
 
+        /// <inheritdoc/>
         public void Execute(ResolveRequestContextBase context, Action<ResolveRequestContextBase> next)
         {
             try
@@ -66,6 +71,7 @@ namespace Autofac.Core.Resolving.Middleware
             next(context);
         }
 
+        /// <inheritdoc/>
         public override string ToString() => nameof(ScopeSelectionMiddleware);
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
@@ -34,12 +34,16 @@ namespace Autofac.Core.Resolving.Middleware
     /// </summary>
     internal class StartableMiddleware : IResolveMiddleware
     {
+        /// <summary>
+        /// Gets the singleton instance of the <see cref="StartableMiddleware"/>.
+        /// </summary>
         public static StartableMiddleware Instance { get; } = new StartableMiddleware();
 
         private StartableMiddleware()
         {
         }
 
+        /// <inheritdoc/>
         public PipelinePhase Phase => PipelinePhase.Activation;
 
         /// <inheritdoc />
@@ -59,6 +63,7 @@ namespace Autofac.Core.Resolving.Middleware
             }
         }
 
+        /// <inheritdoc/>
         public override string ToString() => nameof(StartableMiddleware);
     }
 }

--- a/src/Autofac/Core/Resolving/Pipeline/IResolvePipelineBuilder.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/IResolvePipelineBuilder.cs
@@ -40,6 +40,11 @@ namespace Autofac.Core.Resolving.Pipeline
         IResolvePipeline Build();
 
         /// <summary>
+        /// Gets the set of middleware currently registered.
+        /// </summary>
+        IEnumerable<IResolveMiddleware> Middleware { get; }
+
+        /// <summary>
         /// Use a piece of middleware in a resolve pipeline.
         /// </summary>
         /// <param name="middleware">The middleware instance.</param>
@@ -106,11 +111,6 @@ namespace Autofac.Core.Resolving.Pipeline
         /// <param name="insertionMode">The insertion mode specifying whether to add at the start or end of the phase.</param>
         /// <returns>The same builder instance.</returns>
         IResolvePipelineBuilder UseRange(IEnumerable<IResolveMiddleware> middleware, MiddlewareInsertionMode insertionMode = MiddlewareInsertionMode.EndOfPhase);
-
-        /// <summary>
-        /// Gets the set of middleware currently registered.
-        /// </summary>
-        IEnumerable<IResolveMiddleware> Middleware { get; }
 
         /// <summary>
         /// Clone this builder, returning a new builder containing the set of middleware already added.

--- a/src/Autofac/Core/Resolving/Pipeline/MiddlewareDeclaration.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/MiddlewareDeclaration.cs
@@ -30,6 +30,10 @@ namespace Autofac.Core.Resolving.Pipeline
     /// </summary>
     internal sealed class MiddlewareDeclaration
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MiddlewareDeclaration"/> class.
+        /// </summary>
+        /// <param name="middleware">The middleware that is encapsulated in this declaration.</param>
         public MiddlewareDeclaration(IResolveMiddleware middleware)
         {
             Middleware = middleware;

--- a/src/Autofac/Core/Resolving/Pipeline/PipelineBuilderEnumerator.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/PipelineBuilderEnumerator.cs
@@ -38,6 +38,10 @@ namespace Autofac.Core.Resolving.Pipeline
         private MiddlewareDeclaration? _current;
         private bool _ended;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PipelineBuilderEnumerator"/> class.
+        /// </summary>
+        /// <param name="first">The first middleware declaration.</param>
         public PipelineBuilderEnumerator(MiddlewareDeclaration? first)
         {
             _first = first;

--- a/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
@@ -62,8 +62,10 @@ namespace Autofac.Core.Resolving.Pipeline
         private MiddlewareDeclaration? _first;
         private MiddlewareDeclaration? _last;
 
+        /// <inheritdoc/>
         public IEnumerable<IResolveMiddleware> Middleware => this;
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder Use(IResolveMiddleware stage, MiddlewareInsertionMode insertionMode = MiddlewareInsertionMode.EndOfPhase)
         {
             if (stage is null)
@@ -76,6 +78,7 @@ namespace Autofac.Core.Resolving.Pipeline
             return this;
         }
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder Use(PipelinePhase phase, Action<ResolveRequestContextBase, Action<ResolveRequestContextBase>> callback)
         {
             Use(phase, MiddlewareInsertionMode.EndOfPhase, callback);
@@ -83,6 +86,7 @@ namespace Autofac.Core.Resolving.Pipeline
             return this;
         }
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder Use(PipelinePhase phase, MiddlewareInsertionMode insertionMode, Action<ResolveRequestContextBase, Action<ResolveRequestContextBase>> callback)
         {
             Use(AnonymousName, phase, insertionMode, callback);
@@ -90,6 +94,7 @@ namespace Autofac.Core.Resolving.Pipeline
             return this;
         }
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder Use(string name, PipelinePhase phase, Action<ResolveRequestContextBase, Action<ResolveRequestContextBase>> callback)
         {
             Use(new DelegateMiddleware(name, phase, callback), MiddlewareInsertionMode.EndOfPhase);
@@ -97,6 +102,7 @@ namespace Autofac.Core.Resolving.Pipeline
             return this;
         }
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder Use(string name, PipelinePhase phase, MiddlewareInsertionMode insertionMode, Action<ResolveRequestContextBase, Action<ResolveRequestContextBase>> callback)
         {
             Use(new DelegateMiddleware(name, phase, callback), insertionMode);
@@ -104,6 +110,7 @@ namespace Autofac.Core.Resolving.Pipeline
             return this;
         }
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder UseRange(IEnumerable<IResolveMiddleware> stages, MiddlewareInsertionMode insertionMode = MiddlewareInsertionMode.EndOfPhase)
         {
             // Use multiple stages.
@@ -302,6 +309,7 @@ namespace Autofac.Core.Resolving.Pipeline
             return new ResolvePipeline(currentInvoke);
         }
 
+        /// <inheritdoc/>
         public IResolvePipelineBuilder Clone()
         {
             // To clone a pipeline, we create a new instance, then insert the same stage
@@ -318,11 +326,13 @@ namespace Autofac.Core.Resolving.Pipeline
             return newPipeline;
         }
 
+        /// <inheritdoc/>
         public IEnumerator<IResolveMiddleware> GetEnumerator()
         {
             return new PipelineBuilderEnumerator(_first);
         }
 
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();

--- a/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContext.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContext.cs
@@ -48,11 +48,13 @@ namespace Autofac.Core.Resolving.Pipeline
         {
         }
 
+        /// <inheritdoc/>
         public override object ResolveComponent(ResolveRequest request)
         {
             return Operation.GetOrCreateInstance(ActivationScope, request);
         }
 
+        /// <inheritdoc/>
         public override object ResolveComponentWithNewOperation(ResolveRequest request)
         {
             // Create a new operation, with the current ActivationScope and Tracer.
@@ -61,6 +63,9 @@ namespace Autofac.Core.Resolving.Pipeline
             return operation.Execute(request);
         }
 
+        /// <summary>
+        /// Completes the request context; invokes any event handlers.
+        /// </summary>
         public void Complete()
         {
             // Let the base class raise events.

--- a/src/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperation.cs
@@ -78,6 +78,7 @@ namespace Autofac.Core.Resolving
             return ExecuteOperation(request);
         }
 
+        /// <inheritdoc/>
         protected override void ExecuteRequest(ResolveRequestContextBase requestContext)
         {
             // Get pipeline from the registration.

--- a/src/Autofac/Core/Resolving/ResolveOperationBase.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperationBase.cs
@@ -87,6 +87,9 @@ namespace Autofac.Core.Resolving
         /// </summary>
         public ResolveRequestContextBase? ActiveRequestContext { get; private set; }
 
+        /// <summary>
+        /// Gets the current lifetime scope of the operation; based on the most recently executed request.
+        /// </summary>
         public ISharingLifetimeScope CurrentScope { get; private set; }
 
         /// <summary>

--- a/src/Autofac/Core/SelfComponentRegistration.cs
+++ b/src/Autofac/Core/SelfComponentRegistration.cs
@@ -13,6 +13,9 @@ namespace Autofac.Core
     /// </summary>
     internal sealed class SelfComponentRegistration : ComponentRegistration
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelfComponentRegistration"/> class.
+        /// </summary>
         public SelfComponentRegistration()
             : base(
                 LifetimeScope.SelfRegistrationId,

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -150,8 +150,10 @@ namespace Autofac.Features.Collections
             return new IComponentRegistration[] { registration };
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => false;
 
+        /// <inheritdoc/>
         public override string ToString()
             => CollectionRegistrationSourceResources.CollectionRegistrationSourceDescription;
 

--- a/src/Autofac/Features/Decorators/DecoratorContext.cs
+++ b/src/Autofac/Features/Decorators/DecoratorContext.cs
@@ -28,6 +28,9 @@ using System.Collections.Generic;
 
 namespace Autofac.Features.Decorators
 {
+    /// <summary>
+    /// Implements the decorator context, exposing the state of the decoration process.
+    /// </summary>
     public sealed class DecoratorContext : IDecoratorContext
     {
         /// <inheritdoc />
@@ -59,11 +62,23 @@ namespace Autofac.Features.Decorators
             AppliedDecorators = appliedDecorators ?? new List<object>(0);
         }
 
+        /// <summary>
+        /// Create a new <see cref="DecoratorContext"/>.
+        /// </summary>
+        /// <param name="implementationType">The type of the concrete implementation.</param>
+        /// <param name="serviceType">The service type being decorated.</param>
+        /// <param name="implementationInstance">The instance of the implementation to be decorated.</param>
+        /// <returns>A new decorator context.</returns>
         internal static DecoratorContext Create(Type implementationType, Type serviceType, object implementationInstance)
         {
             return new DecoratorContext(implementationType, serviceType, implementationInstance);
         }
 
+        /// <summary>
+        /// Creates a new decorator context that consumes the specified decorator instance.
+        /// </summary>
+        /// <param name="decoratorInstance">The decorated instance.</param>
+        /// <returns>A new context.</returns>
         internal DecoratorContext UpdateContext(object decoratorInstance)
         {
             var appliedDecorators = new List<object>(AppliedDecorators.Count + 1);

--- a/src/Autofac/Features/Decorators/IDecoratorContext.cs
+++ b/src/Autofac/Features/Decorators/IDecoratorContext.cs
@@ -28,6 +28,9 @@ using System.Collections.Generic;
 
 namespace Autofac.Features.Decorators
 {
+    /// <summary>
+    /// Defines the context interface used during the decoration process.
+    /// </summary>
     public interface IDecoratorContext
     {
         /// <summary>

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationExtensions.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationExtensions.cs
@@ -29,8 +29,20 @@ using Autofac.Core;
 
 namespace Autofac.Features.GeneratedFactories
 {
+    /// <summary>
+    /// Helper methods for registering factories.
+    /// </summary>
     internal static class GeneratedFactoryRegistrationExtensions
     {
+        /// <summary>
+        /// Registers a factory delegate.
+        /// </summary>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="delegateType">Factory type to generate.</param>
+        /// <param name="service">The service that the delegate will return instances of.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        /// <remarks>Factory delegates are provided automatically in Autofac 2, and
+        /// this method is generally not required.</remarks>
         internal static IRegistrationBuilder<TLimit, GeneratedFactoryActivatorData, SingleRegistrationStyle>
             RegisterGeneratedFactory<TLimit>(ContainerBuilder builder, Type delegateType, Service service)
             where TLimit : notnull

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
@@ -33,7 +33,7 @@ using Autofac.Util;
 namespace Autofac.Features.GeneratedFactories
 {
     /// <summary>
-    /// Registration source for generated factory methods (i.e. when resolving <![CDATA[Func<TService>]]> or some variant).
+    /// Registration source for generated factory methods (i.e. when resolving <see cref="Func{T}"/> or some variant).
     /// </summary>
     internal class GeneratedFactoryRegistrationSource : IRegistrationSource
     {

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationSource.cs
@@ -32,6 +32,9 @@ using Autofac.Util;
 
 namespace Autofac.Features.GeneratedFactories
 {
+    /// <summary>
+    /// Registration source for generated factory methods (i.e. when resolving <![CDATA[Func<TService>]]> or some variant).
+    /// </summary>
     internal class GeneratedFactoryRegistrationSource : IRegistrationSource
     {
         /// <summary>
@@ -68,8 +71,10 @@ namespace Autofac.Features.GeneratedFactories
                 });
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return GeneratedFactoryRegistrationSourceResources.GeneratedFactoryRegistrationSourceDescription;

--- a/src/Autofac/Features/Indexed/KeyedServiceIndex.cs
+++ b/src/Autofac/Features/Indexed/KeyedServiceIndex.cs
@@ -28,11 +28,20 @@ using Autofac.Core;
 
 namespace Autofac.Features.Indexed
 {
+    /// <summary>
+    /// Provides components by lookup operations via an index (key) type.
+    /// </summary>
+    /// <typeparam name="TKey">The index key type.</typeparam>
+    /// <typeparam name="TValue">The index value type.</typeparam>
     internal class KeyedServiceIndex<TKey, TValue> : IIndex<TKey, TValue>
         where TKey : notnull
     {
         private readonly IComponentContext _context;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyedServiceIndex{TKey, TValue}"/> class.
+        /// </summary>
+        /// <param name="context">The current component context.</param>
         public KeyedServiceIndex(IComponentContext context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
@@ -40,8 +49,10 @@ namespace Autofac.Features.Indexed
             _context = context;
         }
 
+        /// <inheritdoc/>
         public TValue this[TKey key] => (TValue)_context.ResolveService(GetService(key));
 
+        /// <inheritdoc/>
         public bool TryGetValue(TKey key, out TValue value)
         {
             if (_context.TryResolveService(GetService(key), out var result))

--- a/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
@@ -43,6 +43,7 @@ namespace Autofac.Features.LazyDependencies
     {
         private static readonly MethodInfo CreateLazyRegistrationMethod = typeof(LazyRegistrationSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateLazyRegistration));
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (registrationAccessor == null) throw new ArgumentNullException(nameof(registrationAccessor));
@@ -61,8 +62,10 @@ namespace Autofac.Features.LazyDependencies
                 .Cast<IComponentRegistration>();
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return LazyRegistrationSourceResources.LazyRegistrationSourceDescription;

--- a/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
@@ -47,6 +47,7 @@ namespace Autofac.Features.LazyDependencies
 
         private delegate IComponentRegistration RegistrationCreator(Service providedService, Service valueService, IComponentRegistration valueRegistration);
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (registrationAccessor == null)
@@ -73,8 +74,10 @@ namespace Autofac.Features.LazyDependencies
                 .Select(v => registrationCreator(service, valueService, v));
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return LazyWithMetadataRegistrationSourceResources.LazyWithMetadataRegistrationSourceDescription;

--- a/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationExtensions.cs
+++ b/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationExtensions.cs
@@ -30,8 +30,22 @@ using Autofac.Core;
 
 namespace Autofac.Features.LightweightAdapters
 {
+    /// <summary>
+    /// Extension methods for registering adapters.
+    /// </summary>
     internal static class LightweightAdapterRegistrationExtensions
     {
+        /// <summary>
+        /// Adapt all components implementing service <typeparamref name="TFrom"/>
+        /// to provide <typeparamref name="TTo"/> using the provided <paramref name="adapter"/>
+        /// function.
+        /// </summary>
+        /// <typeparam name="TFrom">Service type to adapt from.</typeparam>
+        /// <typeparam name="TTo">Service type to adapt to. Must not be the
+        /// same as <typeparamref name="TFrom"/>.</typeparam>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="adapter">Function adapting <typeparamref name="TFrom"/> to
+        /// service <typeparamref name="TTo"/>, given the context and parameters.</param>
         public static IRegistrationBuilder<TTo, LightweightAdapterActivatorData, DynamicRegistrationStyle>
             RegisterAdapter<TFrom, TTo>(
                 ContainerBuilder builder,
@@ -41,6 +55,17 @@ namespace Autofac.Features.LightweightAdapters
             return RegisterAdapter(builder, adapter, new TypedService(typeof(TFrom)), new TypedService(typeof(TTo)));
         }
 
+        /// <summary>
+        /// Decorate all components implementing service <typeparamref name="TService"/>
+        /// using the provided <paramref name="decorator"/> function.
+        /// The <paramref name="fromKey"/> and <paramref name="toKey"/> parameters must be different values.
+        /// </summary>
+        /// <typeparam name="TService">Service type being decorated.</typeparam>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="decorator">Function decorating a component instance that provides
+        /// <typeparamref name="TService"/>, given the context and parameters.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
         public static IRegistrationBuilder<TService, LightweightAdapterActivatorData, DynamicRegistrationStyle>
             RegisterDecorator<TService>(
                 ContainerBuilder builder,

--- a/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
+++ b/src/Autofac/Features/LightweightAdapters/LightweightAdapterRegistrationSource.cs
@@ -32,11 +32,19 @@ using Autofac.Core;
 
 namespace Autofac.Features.LightweightAdapters
 {
+    /// <summary>
+    /// A registration source for registered adapters.
+    /// </summary>
     internal class LightweightAdapterRegistrationSource : IRegistrationSource
     {
         private readonly RegistrationData _registrationData;
         private readonly LightweightAdapterActivatorData _activatorData;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LightweightAdapterRegistrationSource"/> class.
+        /// </summary>
+        /// <param name="registrationData">The registration data for the adapter.</param>
+        /// <param name="activatorData">The activator data for the adapter.</param>
         public LightweightAdapterRegistrationSource(
             RegistrationData registrationData,
             LightweightAdapterActivatorData activatorData)
@@ -51,6 +59,7 @@ namespace Autofac.Features.LightweightAdapters
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, LightweightAdapterRegistrationSourceResources.FromAndToMustDiffer, activatorData.FromService));
         }
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
@@ -107,8 +116,10 @@ namespace Autofac.Features.LightweightAdapters
             return Enumerable.Empty<IComponentRegistration>();
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format(

--- a/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
@@ -42,6 +42,7 @@ namespace Autofac.Features.Metadata
     {
         private static readonly MethodInfo CreateMetaRegistrationMethod = typeof(MetaRegistrationSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateMetaRegistration));
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (registrationAccessor == null) throw new ArgumentNullException(nameof(registrationAccessor));
@@ -61,8 +62,10 @@ namespace Autofac.Features.Metadata
                 .Cast<IComponentRegistration>();
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return MetaRegistrationSourceResources.MetaRegistrationSourceDescription;

--- a/src/Autofac/Features/Metadata/MetadataViewProvider.cs
+++ b/src/Autofac/Features/Metadata/MetadataViewProvider.cs
@@ -106,5 +106,21 @@ namespace Autofac.Features.Metadata
             throw new DependencyResolutionException(
                 string.Format(CultureInfo.CurrentCulture, MetadataViewProviderResources.InvalidViewImplementation, typeof(TMetadata).Name));
         }
+
+        /// <summary>
+        /// Used via reflection.
+        /// </summary>
+        private static TValue GetMetadataValue<TValue>(IDictionary<string, object> metadata, string name, DefaultValueAttribute defaultValue)
+        {
+            object result;
+            if (metadata.TryGetValue(name, out result))
+                return (TValue)result;
+
+            if (defaultValue != null)
+                return (TValue)defaultValue.Value;
+
+            throw new DependencyResolutionException(
+                string.Format(CultureInfo.CurrentCulture, MetadataViewProviderResources.MissingMetadata, name));
+        }
     }
 }

--- a/src/Autofac/Features/Metadata/MetadataViewProvider.cs
+++ b/src/Autofac/Features/Metadata/MetadataViewProvider.cs
@@ -34,10 +34,18 @@ using Autofac.Core;
 
 namespace Autofac.Features.Metadata
 {
+    /// <summary>
+    /// Helper methods for creating a metadata access function that retrieves typed metdata from a dictionary.
+    /// </summary>
     internal static class MetadataViewProvider
     {
         private static readonly MethodInfo GetMetadataValueMethod = typeof(MetadataViewProvider).GetTypeInfo().GetDeclaredMethod("GetMetadataValue");
 
+        /// <summary>
+        /// Generate a provider function that takes a dictionary of metadata, and outputs a typed metadata object.
+        /// </summary>
+        /// <typeparam name="TMetadata">The metadata type.</typeparam>
+        /// <returns>A provider function.</returns>
         public static Func<IDictionary<string, object?>, TMetadata> GetMetadataViewProvider<TMetadata>()
         {
             if (typeof(TMetadata) == typeof(IDictionary<string, object>))
@@ -97,19 +105,6 @@ namespace Autofac.Features.Metadata
 
             throw new DependencyResolutionException(
                 string.Format(CultureInfo.CurrentCulture, MetadataViewProviderResources.InvalidViewImplementation, typeof(TMetadata).Name));
-        }
-
-        private static TValue GetMetadataValue<TValue>(IDictionary<string, object> metadata, string name, DefaultValueAttribute defaultValue)
-        {
-            object result;
-            if (metadata.TryGetValue(name, out result))
-                return (TValue)result;
-
-            if (defaultValue != null)
-                return (TValue)defaultValue.Value;
-
-            throw new DependencyResolutionException(
-                string.Format(CultureInfo.CurrentCulture, MetadataViewProviderResources.MissingMetadata, name));
         }
     }
 }

--- a/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
@@ -44,6 +44,7 @@ namespace Autofac.Features.Metadata
 
         private delegate IComponentRegistration RegistrationCreator(Service providedService, Service valueService, IComponentRegistration valueRegistration);
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (registrationAccessor == null) throw new ArgumentNullException(nameof(registrationAccessor));
@@ -68,8 +69,10 @@ namespace Autofac.Features.Metadata
                 .Select(v => registrationCreator.Invoke(service, valueService, v));
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return MetaRegistrationSourceResources.StronglyTypedMetaRegistrationSourceDescription;

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -44,6 +44,12 @@ namespace Autofac.Features.OpenGenerics
         private readonly OpenGenericDecoratorActivatorData _activatorData;
         private readonly IResolvePipelineBuilder _existingPipeline;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenGenericDecoratorRegistrationSource"/> class.
+        /// </summary>
+        /// <param name="registrationData">The registration data for the open generic.</param>
+        /// <param name="existingPipelineBuilder">The pipeline for the existing open generic registration.</param>
+        /// <param name="activatorData">The activator data.</param>
         public OpenGenericDecoratorRegistrationSource(
             RegistrationData registrationData,
             IResolvePipelineBuilder existingPipelineBuilder,
@@ -62,6 +68,7 @@ namespace Autofac.Features.OpenGenerics
             _existingPipeline = existingPipelineBuilder;
         }
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
@@ -102,8 +109,10 @@ namespace Autofac.Features.OpenGenerics
             return resultArray;
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format(

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
@@ -31,20 +31,30 @@ using Autofac.Core;
 
 namespace Autofac.Features.OpenGenerics
 {
+    /// <summary>
+    /// Extension methods to support open generic registrations.
+    /// </summary>
     internal static class OpenGenericRegistrationExtensions
     {
+        /// <summary>
+        /// Register an un-parameterised generic type, e.g. Repository&lt;&gt;.
+        /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
+        /// </summary>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="implementer">The open generic implementation type.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>
-            RegisterGeneric(ContainerBuilder builder, Type implementor)
+            RegisterGeneric(ContainerBuilder builder, Type implementer)
         {
             if (builder == null) throw new ArgumentNullException(nameof(builder));
-            if (implementor == null) throw new ArgumentNullException(nameof(implementor));
+            if (implementer == null) throw new ArgumentNullException(nameof(implementer));
 
-            if (!implementor.GetTypeInfo().IsGenericTypeDefinition)
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, OpenGenericRegistrationExtensionsResources.ImplementorMustBeOpenGenericType, implementor));
+            if (!implementer.GetTypeInfo().IsGenericTypeDefinition)
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, OpenGenericRegistrationExtensionsResources.ImplementorMustBeOpenGenericType, implementer));
 
             var rb = new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
-                new TypedService(implementor),
-                new ReflectionActivatorData(implementor),
+                new TypedService(implementer),
+                new ReflectionActivatorData(implementer),
                 new DynamicRegistrationStyle());
 
             rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => cr.AddRegistrationSource(
@@ -53,6 +63,16 @@ namespace Autofac.Features.OpenGenerics
             return rb;
         }
 
+        /// <summary>
+        /// Decorate all components implementing open generic service <paramref name="decoratedServiceType"/>.
+        /// The <paramref name="fromKey"/> and <paramref name="toKey"/> parameters must be different values.
+        /// </summary>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="decoratedServiceType">Service type being decorated. Must be an open generic type.</param>
+        /// <param name="fromKey">Service key or name associated with the components being decorated.</param>
+        /// <param name="toKey">Service key or name given to the decorated components.</param>
+        /// <param name="decoratorType">The type of the decorator. Must be an open generic type, and accept a parameter
+        /// of type <paramref name="decoratedServiceType"/>, which will be set to the instance being decorated.</param>
         public static IRegistrationBuilder<object, OpenGenericDecoratorActivatorData, DynamicRegistrationStyle>
             RegisterGenericDecorator(ContainerBuilder builder, Type decoratorType, Type decoratedServiceType, object fromKey, object? toKey)
         {

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
@@ -43,6 +43,12 @@ namespace Autofac.Features.OpenGenerics
         private readonly IResolvePipelineBuilder _existingPipelineBuilder;
         private readonly ReflectionActivatorData _activatorData;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenGenericRegistrationSource"/> class.
+        /// </summary>
+        /// <param name="registrationData">The registration data for the open generic.</param>
+        /// <param name="existingPipelineBuilder">The pipeline for the existing open generic registration.</param>
+        /// <param name="activatorData">The activator data.</param>
         public OpenGenericRegistrationSource(
             RegistrationData registrationData,
             IResolvePipelineBuilder existingPipelineBuilder,
@@ -58,6 +64,7 @@ namespace Autofac.Features.OpenGenerics
             _activatorData = activatorData;
         }
 
+        /// <inheritdoc/>
         public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
         {
             if (service == null) throw new ArgumentNullException(nameof(service));
@@ -68,7 +75,7 @@ namespace Autofac.Features.OpenGenerics
             if (OpenGenericServiceBinder.TryBindServiceType(service, _registrationData.Services, _activatorData.ImplementationType, out constructedImplementationType, out services))
             {
                 // Pass the pipeline builder from the original registration to the 'CreateRegistration'.
-                // So the original registration will contain all of the pipeline stages originally added, plus anything we want to add due to the lifetim
+                // So the original registration will contain all of the pipeline stages originally added, plus anything we want to add.
                 yield return RegistrationBuilder.CreateRegistration(
                     Guid.NewGuid(),
                     _registrationData,
@@ -78,8 +85,10 @@ namespace Autofac.Features.OpenGenerics
             }
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => false;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return string.Format(

--- a/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -29,14 +29,26 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
-
 using Autofac.Core;
 using Autofac.Util;
 
 namespace Autofac.Features.OpenGenerics
 {
+    /// <summary>
+    /// Helper functions for binding open generic implementations to a known implementation type.
+    /// </summary>
     internal static class OpenGenericServiceBinder
     {
+        /// <summary>
+        /// Given a closed generic service (that is being requested), creates a closed generic implementation type
+        /// and associated services from the open generic implementation and services.
+        /// </summary>
+        /// <param name="service">The closed generic service to bind.</param>
+        /// <param name="configuredOpenGenericServices">The set of configured open generic services.</param>
+        /// <param name="openGenericImplementationType">The implementation type of the open generic.</param>
+        /// <param name="constructedImplementationType">The built closed generic implementation type.</param>
+        /// <param name="constructedServices">The built closed generic services.</param>
+        /// <returns>True if the closed generic service can be bound. False otherwise.</returns>
         public static bool TryBindServiceType(
             Service service,
             IEnumerable<Service> configuredOpenGenericServices,
@@ -134,6 +146,11 @@ namespace Autofac.Features.OpenGenerics
                 .FirstOrDefault(x => x != null);
         }
 
+        /// <summary>
+        /// Throws an exception if an open generic implementation type cannot implement the set of specified open services.
+        /// </summary>
+        /// <param name="implementationType">The open generic implementation type.</param>
+        /// <param name="services">The set of open generic services.</param>
         public static void EnforceBindable(Type implementationType, IEnumerable<Service> services)
         {
             if (implementationType == null) throw new ArgumentNullException(nameof(implementationType));

--- a/src/Autofac/Features/OwnedInstances/InstancePerOwnedKey.cs
+++ b/src/Autofac/Features/OwnedInstances/InstancePerOwnedKey.cs
@@ -3,19 +3,29 @@ using Autofac.Core;
 
 namespace Autofac.Features.OwnedInstances
 {
+    /// <summary>
+    /// Defines a key for a matching lifetime scope used by instance-per-owned.
+    /// </summary>
     internal class InstancePerOwnedKey : IEquatable<IServiceWithType>
     {
         private readonly TypedService _serviceWithType;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InstancePerOwnedKey"/> class.
+        /// </summary>
+        /// <param name="typedService">The encapsulated service.</param>
         public InstancePerOwnedKey(TypedService typedService)
             => _serviceWithType = typedService;
 
+        /// <inheritdoc/>
         public bool Equals(IServiceWithType other)
             => other != null && _serviceWithType.ServiceType == other.ServiceType;
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
             => obj is IServiceWithType serviceWithType && Equals(serviceWithType);
 
+        /// <inheritdoc/>
         public override int GetHashCode()
             => _serviceWithType.ServiceType.GetHashCode();
     }

--- a/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
+++ b/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
@@ -85,8 +85,10 @@ namespace Autofac.Features.OwnedInstances
                 });
         }
 
+        /// <inheritdoc/>
         public bool IsAdapterForIndividualComponents => true;
 
+        /// <inheritdoc/>
         public override string ToString()
         {
             return OwnedInstanceRegistrationSourceResources.OwnedInstanceRegistrationSourceDescription;

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -34,8 +34,17 @@ using Autofac.Util;
 
 namespace Autofac.Features.Scanning
 {
+    /// <summary>
+    /// Helper methods to assist in scanning registration.
+    /// </summary>
     internal static class ScanningRegistrationExtensions
     {
+        /// <summary>
+        /// Register types from the specified assemblies.
+        /// </summary>
+        /// <param name="builder">The container builder.</param>
+        /// <param name="assemblies">The set of assemblies.</param>
+        /// <returns>A registration builder.</returns>
         public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
             RegisterAssemblyTypes(ContainerBuilder builder, params Assembly[] assemblies)
         {
@@ -52,6 +61,12 @@ namespace Autofac.Features.Scanning
             return rb;
         }
 
+        /// <summary>
+        /// Register the specified types.
+        /// </summary>
+        /// <param name="builder">The container builder.</param>
+        /// <param name="types">The set of types.</param>
+        /// <returns>A registration builder.</returns>
         public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
             RegisterTypes(ContainerBuilder builder, params Type[] types)
         {
@@ -111,6 +126,15 @@ namespace Autofac.Features.Scanning
                 postScanningCallback(cr);
         }
 
+        /// <summary>
+        /// Configures the scanning registration builder to register all closed types of the specified open generic.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TScanningActivatorData">The activator data type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="openGenericServiceType">The open generic to register closed types of.</param>
+        /// <returns>The registration builder.</returns>
         public static IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle>
             AsClosedTypesOf<TLimit, TScanningActivatorData, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> registration,
@@ -125,6 +149,16 @@ namespace Autofac.Features.Scanning
                         .Select(t => (Service)new TypedService(t)));
         }
 
+        /// <summary>
+        /// Configures the scanning registration builder to register all closed types of the specified open generic as a keyed service.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TScanningActivatorData">The activator data type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="openGenericServiceType">The open generic to register closed types of.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <returns>The registration builder.</returns>
         public static IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle>
             AsClosedTypesOf<TLimit, TScanningActivatorData, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> registration,
@@ -138,6 +172,16 @@ namespace Autofac.Features.Scanning
             return AsClosedTypesOf(registration, openGenericServiceType, t => serviceKey);
         }
 
+        /// <summary>
+        /// Configures the scanning registration builder to register all closed types of the specified open generic as a keyed service.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TScanningActivatorData">The activator data type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="openGenericServiceType">The open generic to register closed types of.</param>
+        /// <param name="serviceKeyMapping">A function to determine the service key for a given type.</param>
+        /// <returns>The registration builder.</returns>
         public static IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle>
             AsClosedTypesOf<TLimit, TScanningActivatorData, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> registration,
@@ -153,6 +197,16 @@ namespace Autofac.Features.Scanning
                         .Select(t => (Service)new KeyedService(serviceKeyMapping(candidateType), t)));
         }
 
+        /// <summary>
+        /// Filters the scanned types to include only those assignable to the provided
+        /// type.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TScanningActivatorData">Activator data type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to filter types from.</param>
+        /// <param name="type">The type or interface which all classes must be assignable from.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle>
             AssignableTo<TLimit, TScanningActivatorData, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> registration,
@@ -165,6 +219,15 @@ namespace Autofac.Features.Scanning
             return registration;
         }
 
+        /// <summary>
+        /// Specifies how a type from a scanned assembly is mapped to a service.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TScanningActivatorData">Activator data type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="serviceMapping">Function mapping types to services.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle>
             As<TLimit, TScanningActivatorData, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> registration,
@@ -193,6 +256,15 @@ namespace Autofac.Features.Scanning
             return registration;
         }
 
+        /// <summary>
+        /// Specifies that the components being registered should only be made the default for services
+        /// that have not already been registered.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TScanningActivatorData">Activator data type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle>
             PreserveExistingDefaults<TLimit, TScanningActivatorData, TRegistrationStyle>(
             IRegistrationBuilder<TLimit, TScanningActivatorData, TRegistrationStyle> registration)

--- a/src/Autofac/Util/Disposable.cs
+++ b/src/Autofac/Util/Disposable.cs
@@ -72,6 +72,7 @@ namespace Autofac.Util
             }
         }
 
+        /// <inheritdoc/>
         [SuppressMessage(
             "Usage",
             "CA1816:Dispose methods should call SuppressFinalize",
@@ -92,6 +93,10 @@ namespace Autofac.Util
             return default(ValueTask);
         }
 
+        /// <summary>
+        ///  Releases unmanaged and - optionally - managed resources, asynchronously.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         protected virtual ValueTask DisposeAsync(bool disposing)
         {
             // Default implementation does a synchronous dispose.

--- a/src/Autofac/Util/NullableAttributes.cs
+++ b/src/Autofac/Util/NullableAttributes.cs
@@ -41,6 +41,9 @@ namespace System.Diagnostics.CodeAnalysis
         /// </param>
         public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
 
+        /// <summary>
+        /// Gets a value indicating whether the return value is required to be true or false.
+        /// </summary>
         public bool ReturnValue { get; }
     }
 
@@ -55,6 +58,9 @@ namespace System.Diagnostics.CodeAnalysis
         /// </param>
         public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
 
+        /// <summary>
+        /// Gets a value indicating whether the return value is required to be true or false.
+        /// </summary>
         public bool ReturnValue { get; }
     }
 
@@ -69,6 +75,9 @@ namespace System.Diagnostics.CodeAnalysis
         /// </param>
         public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
 
+        /// <summary>
+        /// Gets the name of the parameter.
+        /// </summary>
         public string ParameterName { get; }
     }
 
@@ -90,6 +99,9 @@ namespace System.Diagnostics.CodeAnalysis
         /// </param>
         public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
 
+        /// <summary>
+        /// Gets a value indicating whether the parameter value is expected to be true or false.
+        /// </summary>
         public bool ParameterValue { get; }
     }
 }

--- a/src/Autofac/Util/ReleaseAction.cs
+++ b/src/Autofac/Util/ReleaseAction.cs
@@ -54,6 +54,7 @@ namespace Autofac.Util
             _factory = factory;
         }
 
+        /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             // Value retrieval for the disposal is deferred until

--- a/src/Autofac/Util/SequenceExtensions.cs
+++ b/src/Autofac/Util/SequenceExtensions.cs
@@ -29,6 +29,9 @@ using System.Linq;
 
 namespace Autofac.Util
 {
+    /// <summary>
+    /// Provides extension methods for working with sequences.
+    /// </summary>
     internal static class SequenceExtensions
     {
         /// <summary>
@@ -80,6 +83,12 @@ namespace Autofac.Util
                 yield return t;
         }
 
+        /// <summary>
+        /// Add a set of items to the given collection.
+        /// </summary>
+        /// <typeparam name="T">The set type.</typeparam>
+        /// <param name="collection">The collection to add to.</param>
+        /// <param name="items">The set of items to add.</param>
         public static void AddRange<T>(this ICollection<T> collection, IEnumerable<T> items)
         {
             foreach (var item in items)

--- a/src/Autofac/Util/SequenceGenerator.cs
+++ b/src/Autofac/Util/SequenceGenerator.cs
@@ -28,10 +28,17 @@ using System.Threading;
 
 namespace Autofac.Util
 {
+    /// <summary>
+    /// Provides access to a unique sequenced number.
+    /// </summary>
     internal static class SequenceGenerator
     {
         private static long _lastSequence;
 
+        /// <summary>
+        /// Get the next unique sequence value.
+        /// </summary>
+        /// <returns>A new sequence value.</returns>
         internal static long GetNextUniqueSequence()
         {
             while (true)

--- a/src/Autofac/Util/Traverse.cs
+++ b/src/Autofac/Util/Traverse.cs
@@ -28,8 +28,18 @@ using System.Collections.Generic;
 
 namespace Autofac.Util
 {
+    /// <summary>
+    /// Provides a method to support traversing structures.
+    /// </summary>
     internal static class Traverse
     {
+        /// <summary>
+        /// Traverse across a set, taking the first item in the set, and a function to determine the next item.
+        /// </summary>
+        /// <typeparam name="T">The set type.</typeparam>
+        /// <param name="first">The first item in the set.</param>
+        /// <param name="next">A callback that will take the current item in the set, and output the next one.</param>
+        /// <returns>An enumerable of the set.</returns>
         public static IEnumerable<T> Across<T>(T first, Func<T, T> next)
             where T : class
         {

--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -165,7 +165,7 @@ namespace Autofac.Util
         }
 
         /// <summary>
-        /// Checks whether a given type is a generic enumerable interface type, e.g. <![CDATA[IEnumerable<T>, IList<T>, ICollection<T>]]>, etc.
+        /// Checks whether a given type is a generic enumerable interface type, e.g. <see cref="IEnumerable{T}" />, <see cref="IList{T}"/>, <see cref="ICollection{T}"/>, etc.
         /// </summary>
         /// <param name="type">The type to check.</param>
         /// <returns>True if the type is one of the supported enumerable interface types.</returns>
@@ -177,7 +177,7 @@ namespace Autofac.Util
         }
 
         /// <summary>
-        /// Checks whether a given type is a generic list of colleciton interface type, e.g. <![CDATA[IList<T>, ICollection<T>]]> and the read-only variants.
+        /// Checks whether a given type is a generic list of colleciton interface type, e.g. <see cref="IList{T}"/>, <see cref="ICollection{T}"/> and the read-only variants.
         /// </summary>
         /// <param name="type">The type to check.</param>
         /// <returns>True if the type is one of the supported list/collection types.</returns>

--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -33,6 +33,9 @@ using System.Runtime.CompilerServices;
 
 namespace Autofac.Util
 {
+    /// <summary>
+    /// Provides helper methods for manipulating and inspecting types.
+    /// </summary>
     internal static class TypeExtensions
     {
         private static readonly ConcurrentDictionary<Type, bool> IsGenericEnumerableInterfaceCache = new ConcurrentDictionary<Type, bool>();
@@ -41,6 +44,11 @@ namespace Autofac.Util
 
         private static readonly ConcurrentDictionary<(Type, Type), bool> IsGenericTypeDefinedByCache = new ConcurrentDictionary<(Type, Type), bool>();
 
+        /// <summary>
+        /// For a delegate type, outputs the return type of the delegate.
+        /// </summary>
+        /// <param name="type">The delegate type.</param>
+        /// <returns>The delegate return type.</returns>
         public static Type FunctionReturnType(this Type type)
         {
             var invoke = type.GetTypeInfo().GetDeclaredMethod("Invoke");
@@ -48,6 +56,11 @@ namespace Autofac.Util
             return invoke.ReturnType;
         }
 
+        /// <summary>
+        /// Determine whether a given type is an open generic.
+        /// </summary>
+        /// <param name="type">The input type.</param>
+        /// <returns>True if the type is an open generic; false otherwise.</returns>
         public static bool IsOpenGeneric(this Type type)
         {
             return type.GetTypeInfo().IsGenericTypeDefinition || type.GetTypeInfo().ContainsGenericParameters;
@@ -63,11 +76,23 @@ namespace Autofac.Util
             return FindAssignableTypesThatClose(@this, openGeneric);
         }
 
+        /// <summary>
+        /// Checks whether this type is a closed type of a given generic type.
+        /// </summary>
+        /// <param name="this">The type we are checking.</param>
+        /// <param name="openGeneric">The open generic type to validate against.</param>
+        /// <returns>True if <paramref name="this"/> is a closed type of <paramref name="openGeneric"/>. False otherwise.</returns>
         public static bool IsClosedTypeOf(this Type @this, Type openGeneric)
         {
             return TypesAssignableFrom(@this).Any(t => t.GetTypeInfo().IsGenericType && !@this.GetTypeInfo().ContainsGenericParameters && t.GetGenericTypeDefinition() == openGeneric);
         }
 
+        /// <summary>
+        /// Determines whether a given generic type definition is compatible with the specified type parameters (i.e. is it possible to create a closed generic type from those parameters).
+        /// </summary>
+        /// <param name="genericTypeDefinition">The generic type definition.</param>
+        /// <param name="parameters">The set of parameters to check against.</param>
+        /// <returns>True if the parameters match the generic parameter constraints.</returns>
         public static bool IsCompatibleWithGenericParameterConstraints(this Type genericTypeDefinition, Type[] parameters)
         {
             var genericArgumentDefinitions = genericTypeDefinition.GetTypeInfo().GenericTypeParameters;
@@ -119,16 +144,31 @@ namespace Autofac.Util
             return true;
         }
 
+        /// <summary>
+        /// Checks whether a type is compiler generated.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is compiler generated; false otherwise.</returns>
         public static bool IsCompilerGenerated(this Type type)
         {
             return type.GetTypeInfo().GetCustomAttributes<CompilerGeneratedAttribute>().Any();
         }
 
+        /// <summary>
+        /// Checks whether a given type is a delegate type.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is a delegate; false otherwise.</returns>
         public static bool IsDelegate(this Type type)
         {
             return type.GetTypeInfo().IsSubclassOf(typeof(Delegate));
         }
 
+        /// <summary>
+        /// Checks whether a given type is a generic enumerable interface type, e.g. <![CDATA[IEnumerable<T>, IList<T>, ICollection<T>]]>, etc.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is one of the supported enumerable interface types.</returns>
         public static bool IsGenericEnumerableInterfaceType(this Type type)
         {
             return IsGenericEnumerableInterfaceCache.GetOrAdd(
@@ -136,6 +176,11 @@ namespace Autofac.Util
                            || type.IsGenericListOrCollectionInterfaceType());
         }
 
+        /// <summary>
+        /// Checks whether a given type is a generic list of colleciton interface type, e.g. <![CDATA[IList<T>, ICollection<T>]]> and the read-only variants.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>True if the type is one of the supported list/collection types.</returns>
         public static bool IsGenericListOrCollectionInterfaceType(this Type type)
         {
             return IsGenericListOrCollectionInterfaceTypeCache.GetOrAdd(
@@ -145,6 +190,12 @@ namespace Autofac.Util
                            || t.IsGenericTypeDefinedBy(typeof(IReadOnlyList<>)));
         }
 
+        /// <summary>
+        /// Checks whether a given type is a closed generic defined by the specifed open generic.
+        /// </summary>
+        /// <param name="this">The type to check.</param>
+        /// <param name="openGeneric">The open generic to check against.</param>
+        /// <returns>True if the type is defined by the specified open generic; false otherwise.</returns>
         public static bool IsGenericTypeDefinedBy(this Type @this, Type openGeneric)
         {
             return IsGenericTypeDefinedByCache.GetOrAdd(

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -17,10 +17,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
-  </ItemGroup>
   
   <ItemGroup>
     <Compile Remove="TestResults\**" />

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -17,6 +17,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.ComponentModel.Composition" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <Compile Remove="TestResults\**" />

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
+++ b/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <Compile Remove="TestResults\**" />
     <EmbeddedResource Remove="TestResults\**" />
     <None Remove="TestResults\**" />

--- a/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
+++ b/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
@@ -16,10 +16,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Autofac\Autofac.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
-  </ItemGroup>
   
   <ItemGroup>
     <Compile Remove="TestResults\**" />

--- a/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
+++ b/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
@@ -14,10 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.113">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/Autofac.Test.Scenarios.ScannedAssembly.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -17,6 +17,10 @@
     <ProjectReference Include="..\..\src\Autofac\Autofac.csproj" />
     <ProjectReference Include="..\Autofac.Test.Scenarios.ScannedAssembly\Autofac.Test.Scenarios.ScannedAssembly.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="TestResults\**" />

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -17,10 +17,6 @@
     <ProjectReference Include="..\..\src\Autofac\Autofac.csproj" />
     <ProjectReference Include="..\Autofac.Test.Scenarios.ScannedAssembly\Autofac.Test.Scenarios.ScannedAssembly.csproj" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="TestResults\**" />

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />
+    <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <NoWarn>SA1600</NoWarn>
+  </PropertyGroup>
+</Project>

--- a/test/GlobalSuppressions.cs
+++ b/test/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test projects don't need docs.")]

--- a/test/GlobalSuppressions.cs
+++ b/test/GlobalSuppressions.cs
@@ -1,8 +1,0 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test projects don't need docs.")]

--- a/test/TestSuppressions.cs
+++ b/test/TestSuppressions.cs
@@ -1,5 +1,0 @@
-﻿// Suppressions file for test projects.
-
-using System.Diagnostics.CodeAnalysis;
-
-[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test projects don't need docs.")]

--- a/test/TestSuppressions.cs
+++ b/test/TestSuppressions.cs
@@ -1,0 +1,5 @@
+﻿// Suppressions file for test projects.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Test projects don't need docs.")]


### PR DESCRIPTION
I've turned on S1600 in the analyzer ruleset and added the missing comments. There were only about 200 of them...

I've also added a suppression file for the test projects so they don't need docs, because the ruleset can't vary between projects.