### PR TITLE
Update a few build settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.200"
+    "version": "3.1.200",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -8,7 +8,6 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS1591;IDE0008</NoWarn>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Autofac</AssemblyName>
     <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>

--- a/test/Autofac.Test/Scenarios/WithProperty/WithProps.cs
+++ b/test/Autofac.Test/Scenarios/WithProperty/WithProps.cs
@@ -6,6 +6,8 @@
 
         public bool B { get; set; }
 
+#pragma warning disable SA1401 // Fields should be private
         public string _field;
+#pragma warning restore SA1401 // Fields should be private
     }
 }


### PR DESCRIPTION
- Allow rolling forward for global.json so later features versions are allowed
- Add Directory.Build.[props|targets] for solution level settings
- Moved compile as warning to error to solution level but only turned on for release builds. This helps so that while prototyping stuff, it does not fail to build on style stuff that can be cleaned up before the final commit.