### PR TITLE
Remove calls to GetTypeInfo

### DIFF
--- a/src/Autofac/Builder/RegistrationBuilder.cs
+++ b/src/Autofac/Builder/RegistrationBuilder.cs
@@ -198,7 +198,7 @@ namespace Autofac.Builder
                         continue;
                     }
 
-                    if (!asServiceWithType.ServiceType.GetTypeInfo().IsAssignableFrom(limitType.GetTypeInfo()))
+                    if (!asServiceWithType.ServiceType.IsAssignableFrom(limitType))
                     {
                         throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationBuilderResources.ComponentDoesNotSupportService, limitType, ts));
                     }

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -49,7 +49,7 @@ namespace Autofac.Core.Activators.Reflection
             new ConcurrentDictionary<Type, PropertyInfo[]>();
 
         private static readonly MethodInfo CallPropertySetterOpenGenericMethod =
-            typeof(AutowiringPropertyInjector).GetTypeInfo().GetDeclaredMethod(nameof(CallPropertySetter));
+            typeof(AutowiringPropertyInjector).GetDeclaredMethod(nameof(CallPropertySetter));
 
         /// <summary>
         /// Inject properties onto an instance, filtered by a property selector.
@@ -132,17 +132,17 @@ namespace Autofac.Core.Activators.Reflection
 
                 var propertyType = property.PropertyType;
 
-                if (propertyType.GetTypeInfo().IsValueType && !propertyType.GetTypeInfo().IsEnum)
+                if (propertyType.IsValueType && !propertyType.IsEnum)
                 {
                     continue;
                 }
 
-                if (propertyType.IsArray && propertyType.GetElementType().GetTypeInfo().IsValueType)
+                if (propertyType.IsArray && propertyType.GetElementType().IsValueType)
                 {
                     continue;
                 }
 
-                if (propertyType.IsGenericEnumerableInterfaceType() && propertyType.GetTypeInfo().GenericTypeArguments[0].GetTypeInfo().IsValueType)
+                if (propertyType.IsGenericEnumerableInterfaceType() && propertyType.GenericTypeArguments[0].IsValueType)
                 {
                     continue;
                 }

--- a/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorParameterBinding.cs
@@ -164,11 +164,11 @@ namespace Autofac.Core.Activators.Reflection
                 var parameterType = paramsInfo[paramIndex].ParameterType;
 
                 var parameterIndexExpression = Expression.ArrayIndex(parametersExpression, indexExpression);
-                var convertExpression = parameterType.GetTypeInfo().IsPrimitive
+                var convertExpression = parameterType.IsPrimitive
                     ? Expression.Convert(ConvertPrimitiveType(parameterIndexExpression, parameterType), parameterType)
                     : Expression.Convert(parameterIndexExpression, parameterType);
 
-                if (!parameterType.GetTypeInfo().IsValueType)
+                if (!parameterType.IsValueType)
                 {
                     argumentsExpression[paramIndex] = convertExpression;
                     continue;

--- a/src/Autofac/Core/Activators/Reflection/DefaultConstructorFinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/DefaultConstructorFinder.cs
@@ -74,7 +74,7 @@ namespace Autofac.Core.Activators.Reflection
         private static ConstructorInfo[] GetDefaultPublicConstructors(Type type)
         {
             var retval = DefaultPublicConstructorsCache.GetOrAdd(
-                type, t => t.GetTypeInfo().DeclaredConstructors.Where(c => c.IsPublic).ToArray());
+                type, t => t.GetDeclaredPublicConstructors());
 
             if (retval.Length == 0)
             {

--- a/src/Autofac/Core/Activators/Reflection/DefaultValueParameter.cs
+++ b/src/Autofac/Core/Activators/Reflection/DefaultValueParameter.cs
@@ -56,7 +56,7 @@ namespace Autofac.Core.Activators.Reflection
             try
             {
                 // Workaround for https://github.com/dotnet/corefx/issues/17943
-                if (pi.Member.DeclaringType?.GetTypeInfo().Assembly.IsDynamic ?? true)
+                if (pi.Member.DeclaringType?.Assembly.IsDynamic ?? true)
                 {
                     hasDefaultValue = pi.DefaultValue != null && pi.HasDefaultValue;
                 }
@@ -86,7 +86,7 @@ namespace Autofac.Core.Activators.Reflection
                     var defaultValue = pi.DefaultValue;
 
                     // Workaround for https://github.com/dotnet/corefx/issues/11797
-                    if (defaultValue == null && pi.ParameterType.GetTypeInfo().IsValueType)
+                    if (defaultValue == null && pi.ParameterType.IsValueType)
                     {
                         defaultValue = Activator.CreateInstance(pi.ParameterType);
                     }

--- a/src/Autofac/Core/ImplicitRegistrationSource.cs
+++ b/src/Autofac/Core/ImplicitRegistrationSource.cs
@@ -40,7 +40,7 @@ namespace Autofac.Core
     {
         private delegate IComponentRegistration RegistrationCreator(Service providedService, Service valueService, ServiceRegistration valueRegistration);
 
-        private static readonly MethodInfo CreateRegistrationMethod = typeof(ImplicitRegistrationSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateRegistration));
+        private static readonly MethodInfo CreateRegistrationMethod = typeof(ImplicitRegistrationSource).GetDeclaredMethod(nameof(CreateRegistration));
 
         private readonly Type _type;
         private readonly ConcurrentDictionary<Type, RegistrationCreator> _methodCache;
@@ -79,7 +79,7 @@ namespace Autofac.Core
                 return Enumerable.Empty<IComponentRegistration>();
             }
 
-            var valueType = swt.ServiceType.GetTypeInfo().GenericTypeArguments[0];
+            var valueType = swt.ServiceType.GenericTypeArguments[0];
             var valueService = swt.ChangeType(valueType);
             var registrationCreator = _methodCache.GetOrAdd(valueType, t =>
             {
@@ -96,7 +96,7 @@ namespace Autofac.Core
         /// <summary>
         /// Gets the description of the registration source.
         /// </summary>
-        public virtual string Description => GetType().GetTypeInfo().Name;
+        public virtual string Description => GetType().Name;
 
         /// <inheritdoc/>
         public override string ToString() => Description;

--- a/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
+++ b/src/Autofac/Features/AttributeFilters/MetadataFilterAttribute.cs
@@ -101,11 +101,11 @@ namespace Autofac.Features.AttributeFilters
     [SuppressMessage("Microsoft.Design", "CA1018:MarkAttributesWithAttributeUsage", Justification = "Allowing the inherited AttributeUsageAttribute to be used avoids accidental override or conflict at this level.")]
     public sealed class MetadataFilterAttribute : ParameterFilterAttribute
     {
-        private static readonly MethodInfo FilterOneMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(FilterOne));
+        private static readonly MethodInfo FilterOneMethod = typeof(MetadataFilterAttribute).GetDeclaredMethod(nameof(FilterOne));
 
-        private static readonly MethodInfo FilterAllMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(FilterAll));
+        private static readonly MethodInfo FilterAllMethod = typeof(MetadataFilterAttribute).GetDeclaredMethod(nameof(FilterAll));
 
-        private static readonly MethodInfo CanResolveMethod = typeof(MetadataFilterAttribute).GetTypeInfo().GetDeclaredMethod(nameof(CanResolve));
+        private static readonly MethodInfo CanResolveMethod = typeof(MetadataFilterAttribute).GetDeclaredMethod(nameof(CanResolve));
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MetadataFilterAttribute"/> class.
@@ -189,7 +189,7 @@ namespace Autofac.Features.AttributeFilters
 
         private static Type GetElementType(Type type)
         {
-            return type.IsGenericEnumerableInterfaceType() ? type.GetTypeInfo().GenericTypeArguments[0] : type;
+            return type.IsGenericEnumerableInterfaceType() ? type.GenericTypeArguments[0] : type;
         }
 
         private static T FilterOne<T>(IComponentContext context, string metadataKey, object metadataValue)

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -94,7 +94,7 @@ namespace Autofac.Features.Collections
 
             if (serviceType.IsGenericTypeDefinedBy(typeof(IEnumerable<>)))
             {
-                elementType = serviceType.GetTypeInfo().GenericTypeArguments[0];
+                elementType = serviceType.GenericTypeArguments[0];
                 limitType = elementType.MakeArrayType();
                 factory = GenerateArrayFactory(elementType);
             }
@@ -106,7 +106,7 @@ namespace Autofac.Features.Collections
             }
             else if (serviceType.IsGenericListOrCollectionInterfaceType())
             {
-                elementType = serviceType.GetTypeInfo().GenericTypeArguments[0];
+                elementType = serviceType.GenericTypeArguments[0];
                 limitType = typeof(List<>).MakeGenericType(elementType);
                 factory = GenerateListFactory(elementType);
             }

--- a/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
+++ b/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
@@ -136,7 +136,7 @@ namespace Autofac.Features.GeneratedFactories
             var activatorParamsParam = Expression.Parameter(typeof(IEnumerable<Parameter>), "p");
             var activatorParams = new[] { activatorContextParam, activatorParamsParam };
 
-            var invoke = delegateType.GetTypeInfo().GetDeclaredMethod("Invoke");
+            var invoke = delegateType.GetDeclaredMethod("Invoke");
 
             // [dps]*
             var creatorParams = invoke
@@ -150,7 +150,7 @@ namespace Autofac.Features.GeneratedFactories
                 // Issue #269:
                 // If we're resolving a Func<X1...XN>() and there are duplicate input parameter types
                 // and the parameter mapping is by type, we shouldn't be able to resolve it.
-                var arguments = delegateType.GetTypeInfo().GenericTypeArguments;
+                var arguments = delegateType.GenericTypeArguments;
                 var returnType = arguments.Last();
 
                 // Remove the return type to check the list of input types only.

--- a/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyWithMetadataRegistrationSource.cs
@@ -44,7 +44,7 @@ namespace Autofac.Features.LazyDependencies
     /// </summary>
     internal class LazyWithMetadataRegistrationSource : IRegistrationSource
     {
-        private static readonly MethodInfo CreateLazyRegistrationMethod = typeof(LazyWithMetadataRegistrationSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateLazyRegistration));
+        private static readonly MethodInfo CreateLazyRegistrationMethod = typeof(LazyWithMetadataRegistrationSource).GetDeclaredMethod(nameof(CreateLazyRegistration));
 
         private delegate IComponentRegistration RegistrationCreator(Service providedService, Service valueService, ServiceRegistration registrationResolveInfo);
 
@@ -62,11 +62,11 @@ namespace Autofac.Features.LazyDependencies
             if (swt == null || !swt.ServiceType.IsGenericTypeDefinedBy(lazyType))
                 return Enumerable.Empty<IComponentRegistration>();
 
-            var genericTypeArguments = swt.ServiceType.GetTypeInfo().GenericTypeArguments.ToArray();
+            var genericTypeArguments = swt.ServiceType.GenericTypeArguments;
             var valueType = genericTypeArguments[0];
             var metaType = genericTypeArguments[1];
 
-            if (!metaType.GetTypeInfo().IsClass)
+            if (!metaType.IsClass)
                 return Enumerable.Empty<IComponentRegistration>();
 
             var valueService = swt.ChangeType(valueType);

--- a/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/StronglyTypedMetaRegistrationSource.cs
@@ -41,7 +41,7 @@ namespace Autofac.Features.Metadata
     /// </summary>
     internal class StronglyTypedMetaRegistrationSource : IRegistrationSource
     {
-        private static readonly MethodInfo CreateMetaRegistrationMethod = typeof(StronglyTypedMetaRegistrationSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateMetaRegistration));
+        private static readonly MethodInfo CreateMetaRegistrationMethod = typeof(StronglyTypedMetaRegistrationSource).GetDeclaredMethod(nameof(CreateMetaRegistration));
 
         private delegate IComponentRegistration RegistrationCreator(Service providedService, Service valueService, ServiceRegistration valueRegistration);
 
@@ -56,11 +56,11 @@ namespace Autofac.Features.Metadata
             if (swt == null || !swt.ServiceType.IsGenericTypeDefinedBy(typeof(Meta<,>)))
                 return Enumerable.Empty<IComponentRegistration>();
 
-            var genericArguments = swt.ServiceType.GetTypeInfo().GenericTypeArguments.ToArray();
+            var genericArguments = swt.ServiceType.GenericTypeArguments.ToArray();
             var valueType = genericArguments[0];
             var metaType = genericArguments[1];
 
-            if (!metaType.GetTypeInfo().IsClass)
+            if (!metaType.IsClass)
                 return Enumerable.Empty<IComponentRegistration>();
 
             var valueService = swt.ChangeType(valueType);

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorActivatorData.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorActivatorData.cs
@@ -45,7 +45,7 @@ namespace Autofac.Features.OpenGenerics
             : base(implementer)
         {
             if (fromService == null) throw new ArgumentNullException(nameof(fromService));
-            if (!fromService.ServiceType.GetTypeInfo().IsGenericTypeDefinition)
+            if (!fromService.ServiceType.IsGenericTypeDefinition)
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, OpenGenericDecoratorActivatorDataResources.DecoratedServiceIsNotOpenGeneric, fromService));
 
             FromService = fromService;

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
@@ -67,7 +67,7 @@ namespace Autofac.Features.OpenGenerics
         {
             if (implementer == null) throw new ArgumentNullException(nameof(implementer));
 
-            if (!implementer.GetTypeInfo().IsGenericTypeDefinition)
+            if (!implementer.IsGenericTypeDefinition)
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, OpenGenericRegistrationExtensionsResources.ImplementorMustBeOpenGenericType, implementer));
 
             var rb = new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(

--- a/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -83,10 +83,10 @@ namespace Autofac.Features.OpenGenerics
             [NotNullWhen(returnValue: true)] out Type? constructedImplementationType,
             [NotNullWhen(returnValue: true)] out Service[]? constructedServices)
         {
-            if (serviceWithType.ServiceType.GetTypeInfo().IsGenericType && !serviceWithType.ServiceType.IsGenericTypeDefinition)
+            if (serviceWithType.ServiceType.IsGenericType && !serviceWithType.ServiceType.IsGenericTypeDefinition)
             {
                 var definitionService = (IServiceWithType)serviceWithType.ChangeType(serviceWithType.ServiceType.GetGenericTypeDefinition());
-                var serviceGenericArguments = serviceWithType.ServiceType.GetTypeInfo().GenericTypeArguments;
+                var serviceGenericArguments = serviceWithType.ServiceType.GetGenericArguments();
 
                 if (configuredOpenGenericServices.Cast<IServiceWithType>().Any(s => s.Equals(definitionService)))
                 {
@@ -97,13 +97,12 @@ namespace Autofac.Features.OpenGenerics
                         openGenericImplementationType.IsCompatibleWithGenericParameterConstraints(implementorGenericArguments))
                     {
                         var constructedImplementationTypeTmp = openGenericImplementationType.MakeGenericType(implementorGenericArguments);
-                        var constructedImplementationTypeTmpInfo = constructedImplementationTypeTmp.GetTypeInfo();
 
                         var implementedServices = configuredOpenGenericServices
                             .Cast<IServiceWithType>()
-                            .Where(s => s.ServiceType.GetTypeInfo().GenericTypeParameters.Length == serviceGenericArguments.Length)
+                            .Where(s => s.ServiceType.GetGenericArguments().Length == serviceGenericArguments.Length)
                             .Select(s => new { ServiceWithType = s, GenericService = s.ServiceType.MakeGenericType(serviceGenericArguments) })
-                            .Where(p => p.GenericService.GetTypeInfo().IsAssignableFrom(constructedImplementationTypeTmpInfo))
+                            .Where(p => p.GenericService.IsAssignableFrom(constructedImplementationTypeTmp))
                             .Select(p => p.ServiceWithType.ChangeType(p.GenericService))
                             .ToArray();
 
@@ -127,10 +126,10 @@ namespace Autofac.Features.OpenGenerics
             if (serviceTypeDefinition == implementationType)
                 return serviceGenericArguments;
 
-            var implementationGenericArgumentDefinitions = implementationType.GetTypeInfo().GenericTypeParameters;
-            var serviceArgumentDefinitions = serviceType.GetTypeInfo().IsInterface ?
-                    GetInterface(implementationType, serviceType).GetTypeInfo().GenericTypeArguments :
-                    serviceTypeDefinition.GetTypeInfo().GenericTypeParameters;
+            var implementationGenericArgumentDefinitions = implementationType.GetGenericArguments();
+            var serviceArgumentDefinitions = serviceType.IsInterface ?
+                    GetInterface(implementationType, serviceType).GenericTypeArguments :
+                    serviceTypeDefinition.GetGenericArguments();
 
             var serviceArgumentDefinitionToArgumentMapping = serviceArgumentDefinitions.Zip(serviceGenericArguments, (a, b) => new KeyValuePair<Type, Type>(a, b));
 
@@ -144,7 +143,7 @@ namespace Autofac.Features.OpenGenerics
         {
             try
             {
-                return implementationType.GetTypeInfo().ImplementedInterfaces
+                return implementationType.GetInterfaces()
                     .First(i => i.Name == serviceType.Name && i.Namespace == serviceType.Namespace);
             }
             catch (InvalidOperationException)
@@ -157,7 +156,7 @@ namespace Autofac.Features.OpenGenerics
         private static Type TryFindServiceArgumentForImplementationArgumentDefinition(Type implementationGenericArgumentDefinition, IEnumerable<KeyValuePair<Type, Type>> serviceArgumentDefinitionToArgument)
         {
             var matchingRegularType = serviceArgumentDefinitionToArgument
-                .Where(argdef => !argdef.Key.GetTypeInfo().IsGenericType && implementationGenericArgumentDefinition.Name == argdef.Key.Name)
+                .Where(argdef => !argdef.Key.IsGenericType && implementationGenericArgumentDefinition.Name == argdef.Key.Name)
                 .Select(argdef => argdef.Value)
                 .FirstOrDefault();
 
@@ -165,10 +164,10 @@ namespace Autofac.Features.OpenGenerics
                 return matchingRegularType;
 
             return serviceArgumentDefinitionToArgument
-                .Where(argdef => argdef.Key.GetTypeInfo().IsGenericType && argdef.Value.GetTypeInfo().GenericTypeArguments.Length > 0)
+                .Where(argdef => argdef.Key.IsGenericType && argdef.Value.GenericTypeArguments.Length > 0)
                 .Select(argdef => TryFindServiceArgumentForImplementationArgumentDefinition(
-                    implementationGenericArgumentDefinition, argdef.Key.GetTypeInfo().GenericTypeArguments.Zip(
-                        argdef.Value.GetTypeInfo().GenericTypeArguments, (a, b) => new KeyValuePair<Type, Type>(a, b))))
+                    implementationGenericArgumentDefinition, argdef.Key.GenericTypeArguments.Zip(
+                        argdef.Value.GenericTypeArguments, (a, b) => new KeyValuePair<Type, Type>(a, b))))
                 .FirstOrDefault(x => x != null);
         }
 
@@ -182,7 +181,7 @@ namespace Autofac.Features.OpenGenerics
             if (implementationType == null) throw new ArgumentNullException(nameof(implementationType));
             if (services == null) throw new ArgumentNullException(nameof(services));
 
-            if (!implementationType.GetTypeInfo().IsGenericTypeDefinition)
+            if (!implementationType.IsGenericTypeDefinition)
             {
                 throw new ArgumentException(
                     string.Format(CultureInfo.CurrentCulture, OpenGenericServiceBinderResources.ImplementorMustBeOpenGenericTypeDefinition, implementationType));
@@ -190,20 +189,20 @@ namespace Autofac.Features.OpenGenerics
 
             foreach (var service in services.OfType<IServiceWithType>())
             {
-                if (!service.ServiceType.GetTypeInfo().IsGenericTypeDefinition)
+                if (!service.ServiceType.IsGenericTypeDefinition)
                 {
                     throw new ArgumentException(
                         string.Format(CultureInfo.CurrentCulture, OpenGenericServiceBinderResources.ServiceTypeMustBeOpenGenericTypeDefinition, service));
                 }
 
-                if (service.ServiceType.GetTypeInfo().IsInterface)
+                if (service.ServiceType.IsInterface)
                 {
                     if (GetInterface(implementationType, service.ServiceType) == null)
                         throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, OpenGenericServiceBinderResources.InterfaceIsNotImplemented, implementationType, service));
                 }
                 else
                 {
-                    if (!Traverse.Across(implementationType, t => t.GetTypeInfo().BaseType).Any(t => IsCompatibleGenericClassDefinition(t, service.ServiceType)))
+                    if (!Traverse.Across(implementationType, t => t.BaseType).Any(t => IsCompatibleGenericClassDefinition(t, service.ServiceType)))
                         throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, OpenGenericServiceBinderResources.TypesAreNotConvertible, implementationType, service));
                 }
             }
@@ -211,7 +210,7 @@ namespace Autofac.Features.OpenGenerics
 
         private static bool IsCompatibleGenericClassDefinition(Type implementor, Type serviceType)
         {
-            return implementor == serviceType || (implementor.GetTypeInfo().IsGenericType && implementor.GetGenericTypeDefinition() == serviceType);
+            return implementor == serviceType || (implementor.IsGenericType && implementor.GetGenericTypeDefinition() == serviceType);
         }
     }
 }

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -81,23 +81,23 @@ namespace Autofac.Features.ResolveAnything
                 return Enumerable.Empty<IComponentRegistration>();
             }
 
-            var typeInfo = ts.ServiceType.GetTypeInfo();
-            if (!typeInfo.IsClass ||
-                typeInfo.IsSubclassOf(typeof(Delegate)) ||
-                typeInfo.IsAbstract ||
-                typeInfo.IsGenericTypeDefinition ||
+            var serviceType = ts.ServiceType;
+            if (!serviceType.IsClass ||
+                serviceType.IsSubclassOf(typeof(Delegate)) ||
+                serviceType.IsAbstract ||
+                serviceType.IsGenericTypeDefinition ||
                 !_predicate(ts.ServiceType) ||
                 registrationAccessor(service).Any())
             {
                 return Enumerable.Empty<IComponentRegistration>();
             }
 
-            if (typeInfo.IsGenericType && !ShouldRegisterGenericService(typeInfo))
+            if (serviceType.IsGenericType && !ShouldRegisterGenericService(serviceType))
             {
                 return Enumerable.Empty<IComponentRegistration>();
             }
 
-            var builder = RegistrationBuilder.ForType(ts.ServiceType);
+            var builder = RegistrationBuilder.ForType(serviceType);
             RegistrationConfiguration?.Invoke(builder);
             return new[] { builder.CreateRegistration() };
         }
@@ -128,7 +128,7 @@ namespace Autofac.Features.ResolveAnything
             return AnyConcreteTypeNotAlreadyRegisteredSourceResources.AnyConcreteTypeNotAlreadyRegisteredSourceDescription;
         }
 
-        private static bool ShouldRegisterGenericService(TypeInfo type)
+        private static bool ShouldRegisterGenericService(Type type)
         {
             var genericType = type.GetGenericTypeDefinition();
 

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -92,7 +92,7 @@ namespace Autofac.Features.Scanning
         {
             rb.ActivatorData.Filters.Add(t =>
                 rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
-                    swt.ServiceType.GetTypeInfo().IsAssignableFrom(t.GetTypeInfo())));
+                    swt.ServiceType.IsAssignableFrom(t)));
 
             // Issue #897: For back compat reasons we can't filter out
             // non-public types here. Folks use assembly scanning on their
@@ -100,9 +100,9 @@ namespace Autofac.Features.Scanning
             // If people want only public types, a LINQ Where clause can be used.
             foreach (var t in types
                 .Where(t =>
-                    t.GetTypeInfo().IsClass &&
-                    !t.GetTypeInfo().IsAbstract &&
-                    !t.GetTypeInfo().IsGenericTypeDefinition &&
+                    t.IsClass &&
+                    !t.IsAbstract &&
+                    !t.IsGenericTypeDefinition &&
                     !t.IsDelegate() &&
                     rb.ActivatorData.Filters.All(p => p(t)) &&
                     !t.IsCompilerGenerated()))
@@ -215,7 +215,7 @@ namespace Autofac.Features.Scanning
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
 
-            registration.ActivatorData.Filters.Add(t => type.GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()));
+            registration.ActivatorData.Filters.Add(t => type.IsAssignableFrom(t));
             return registration;
         }
 
@@ -245,7 +245,7 @@ namespace Autofac.Features.Scanning
                     {
                         if (s is IServiceWithType c)
                         {
-                            return c.ServiceType.GetTypeInfo().IsAssignableFrom(impl.GetTypeInfo());
+                            return c.ServiceType.IsAssignableFrom(impl);
                         }
 
                         return s != null;

--- a/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
+++ b/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
@@ -90,10 +90,10 @@ namespace Autofac.Features.Variance
                 || !IsCompatibleInterfaceType(swt.ServiceType, out var contravariantParameterIndex))
                 return Enumerable.Empty<IComponentRegistration>();
 
-            var args = swt.ServiceType.GetTypeInfo().GenericTypeArguments;
+            var args = swt.ServiceType.GenericTypeArguments;
             var definition = swt.ServiceType.GetGenericTypeDefinition();
             var contravariantParameter = args[contravariantParameterIndex];
-            if (contravariantParameter.GetTypeInfo().IsValueType)
+            if (contravariantParameter.IsValueType)
                 return Enumerable.Empty<IComponentRegistration>();
 
             var possibleSubstitutions = GetTypesAssignableFrom(contravariantParameter);
@@ -129,10 +129,10 @@ namespace Autofac.Features.Variance
 
         private static IEnumerable<Type> GetBagOfTypesAssignableFrom(Type type)
         {
-            if (type.GetTypeInfo().BaseType != null)
+            if (type.BaseType != null)
             {
-                yield return type.GetTypeInfo().BaseType;
-                foreach (var fromBase in GetBagOfTypesAssignableFrom(type.GetTypeInfo().BaseType))
+                yield return type.BaseType;
+                foreach (var fromBase in GetBagOfTypesAssignableFrom(type.BaseType))
                     yield return fromBase;
             }
             else
@@ -141,7 +141,7 @@ namespace Autofac.Features.Variance
                     yield return typeof(object);
             }
 
-            foreach (var ifce in type.GetTypeInfo().ImplementedInterfaces)
+            foreach (var ifce in type.GetInterfaces())
             {
                 if (ifce != type)
                 {
@@ -154,14 +154,14 @@ namespace Autofac.Features.Variance
 
         private static bool IsCompatibleInterfaceType(Type type, out int contravariantParameterIndex)
         {
-            if (type.GetTypeInfo().IsGenericType && type.GetTypeInfo().IsInterface)
+            if (type.IsGenericType && type.IsInterface)
             {
                 var contravariantWithIndex = type
                     .GetGenericTypeDefinition()
-                    .GetTypeInfo().GenericTypeParameters
+                    .GetGenericArguments()
                     .Select((c, i) => new
                     {
-                        IsContravariant = (c.GetTypeInfo().GenericParameterAttributes & GenericParameterAttributes.Contravariant) !=
+                        IsContravariant = (c.GenericParameterAttributes & GenericParameterAttributes.Contravariant) !=
                         GenericParameterAttributes.None,
                         Index = i,
                     })

--- a/src/Autofac/Module.cs
+++ b/src/Autofac/Module.cs
@@ -150,11 +150,11 @@ namespace Autofac
             get
             {
                 var thisType = GetType();
-                var baseType = thisType.GetTypeInfo().BaseType;
+                var baseType = thisType.BaseType;
                 if (baseType != typeof(Module))
                     throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, ModuleResources.ThisAssemblyUnavailable, thisType, baseType));
 
-                return thisType.GetTypeInfo().Assembly;
+                return thisType.Assembly;
             }
         }
     }

--- a/src/Autofac/ModuleRegistrationExtensions.cs
+++ b/src/Autofac/ModuleRegistrationExtensions.cs
@@ -161,7 +161,7 @@ namespace Autofac
             var moduleFinder = new ContainerBuilder();
 
             moduleFinder.RegisterAssemblyTypes(assemblies)
-                .Where(t => moduleType.GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()))
+                .Where(t => moduleType.IsAssignableFrom(t))
                 .As<IModule>();
 
             using (var moduleContainer = moduleFinder.Build())

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -458,11 +458,11 @@ namespace Autofac
 
             return registration.WithMetadata(t =>
             {
-                var attrs = t.GetTypeInfo().GetCustomAttributes(true).OfType<TAttribute>().ToArray();
+                var attrs = t.GetCustomAttributes(true).OfType<TAttribute>().ToList();
 
-                if (attrs.Length == 0)
+                if (attrs.Count == 0)
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationExtensionsResources.MetadataAttributeNotFound, typeof(TAttribute), t));
-                if (attrs.Length != 1)
+                if (attrs.Count != 1)
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationExtensionsResources.MultipleMetadataAttributesSameType, typeof(TAttribute), t));
                 var attr = attrs[0];
                 return metadataProperties.Select(p => new KeyValuePair<string, object?>(p.Name, p.GetValue(attr, null)));
@@ -620,8 +620,8 @@ namespace Autofac
 
         private static Type[] GetImplementedInterfaces(Type type)
         {
-            var interfaces = type.GetTypeInfo().ImplementedInterfaces.Where(i => i != typeof(IDisposable));
-            return type.GetTypeInfo().IsInterface ? interfaces.AppendItem(type).ToArray() : interfaces.ToArray();
+            var interfaces = type.GetInterfaces().Where(i => i != typeof(IDisposable));
+            return type.IsInterface ? interfaces.AppendItem(type).ToArray() : interfaces.ToArray();
         }
 
         /// <summary>

--- a/src/Autofac/ScanningFilterExtensions.cs
+++ b/src/Autofac/ScanningFilterExtensions.cs
@@ -53,7 +53,7 @@ namespace Autofac
             // from being found by default, but this convenience method will allow
             // people to opt in.
             if (registration == null) throw new ArgumentNullException(nameof(registration));
-            return registration.Where(t => t.GetTypeInfo().IsPublic || t.GetTypeInfo().IsNestedPublic);
+            return registration.Where(t => t.IsPublic || t.IsNestedPublic);
         }
     }
 }

--- a/src/Autofac/TypeExtensions.cs
+++ b/src/Autofac/TypeExtensions.cs
@@ -24,6 +24,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -37,6 +38,9 @@ namespace Autofac
     /// </summary>
     public static class TypeExtensions
     {
+        private const BindingFlags DeclaredOnlyPublicFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
+        private const BindingFlags DeclaredOnlyFlags = DeclaredOnlyPublicFlags | BindingFlags.NonPublic;
+
         /// <summary>
         /// Returns true if this type is in the <paramref name="namespace"/> namespace
         /// or one of its sub-namespaces.
@@ -96,7 +100,83 @@ namespace Autofac
         {
             if (@this == null) throw new ArgumentNullException(nameof(@this));
 
-            return typeof(T).GetTypeInfo().IsAssignableFrom(@this.GetTypeInfo());
+            return typeof(T).IsAssignableFrom(@this);
+        }
+
+        /// <summary>
+        /// Returns an object that represents the specified method declared by the
+        /// current type.
+        /// </summary>
+        /// <param name="this">The type.</param>
+        /// <param name="methodName">The name of the method.</param>
+        /// <returns>An object that represents the specified method, if found; otherwise, null.</returns>
+        public static MethodInfo GetDeclaredMethod(this Type @this, string methodName)
+        {
+            if (@this is null)
+            {
+                throw new ArgumentNullException(nameof(@this));
+            }
+
+            if (methodName is null)
+            {
+                throw new ArgumentNullException(nameof(methodName));
+            }
+
+            return @this.GetMethod(methodName, DeclaredOnlyFlags);
+        }
+
+        /// <summary>
+        /// Returns an object that represents the specified property declared by the
+        /// current type.
+        /// </summary>
+        /// <param name="this">The type.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <returns>An object that represents the specified property, if found; otherwise, null.</returns>
+        public static PropertyInfo GetDeclaredProperty(this Type @this, string propertyName)
+        {
+            if (@this is null)
+            {
+                throw new ArgumentNullException(nameof(@this));
+            }
+
+            if (propertyName is null)
+            {
+                throw new ArgumentNullException(nameof(propertyName));
+            }
+
+            return @this.GetProperty(propertyName, DeclaredOnlyFlags);
+        }
+
+        /// <summary>
+        /// Returns a collection of constructor infomration that represents the declared constructors
+        /// for the type (public and private).
+        /// </summary>
+        /// <param name="this">The type.</param>
+        /// <returns>A collection of constructors.</returns>
+        public static ConstructorInfo[] GetDeclaredConstructors(this Type @this)
+        {
+            if (@this is null)
+            {
+                throw new ArgumentNullException(nameof(@this));
+            }
+
+            return @this.GetConstructors(DeclaredOnlyFlags);
+        }
+
+        /// <summary>
+        /// Returns a collection of constructor infomration that represents the declared constructors
+        /// for the type (public only).
+        /// </summary>
+        /// <param name="this">The type.</param>
+        /// <returns>A collection of constructors.</returns>
+        public static ConstructorInfo[] GetDeclaredPublicConstructors(this Type @this)
+        {
+            if (@this is null)
+            {
+                throw new ArgumentNullException(nameof(@this));
+            }
+
+            return @this.GetConstructors(DeclaredOnlyPublicFlags);
         }
 
         /// <summary>
@@ -107,7 +187,7 @@ namespace Autofac
         /// <returns>The <see cref="ConstructorInfo"/> is a match is found; otherwise, <c>null</c>.</returns>
         public static ConstructorInfo GetMatchingConstructor(this Type type, Type[] constructorParameterTypes)
         {
-            return type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(
+            return type.GetDeclaredConstructors().FirstOrDefault(
                 c => c.GetParameters().Select(p => p.ParameterType).SequenceEqual(constructorParameterTypes));
         }
     }

--- a/src/Autofac/Util/Enforce.cs
+++ b/src/Autofac/Util/Enforce.cs
@@ -98,7 +98,7 @@ namespace Autofac.Util
         {
             if (delegateType == null) throw new ArgumentNullException(nameof(delegateType));
 
-            MethodInfo invoke = delegateType.GetTypeInfo().GetDeclaredMethod("Invoke");
+            MethodInfo invoke = delegateType.GetDeclaredMethod("Invoke");
 
             if (invoke == null)
                 throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, EnforceResources.NotDelegate, delegateType));

--- a/src/Autofac/Util/ReflectionExtensions.cs
+++ b/src/Autofac/Util/ReflectionExtensions.cs
@@ -58,7 +58,7 @@ namespace Autofac.Util
             var mi = pi.Member as MethodInfo;
             if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", StringComparison.Ordinal) && mi.DeclaringType != null)
             {
-                prop = mi.DeclaringType.GetTypeInfo().GetDeclaredProperty(mi.Name.Substring(4));
+                prop = mi.DeclaringType.GetDeclaredProperty(mi.Name.Substring(4));
                 return true;
             }
 


### PR DESCRIPTION
These changes remove all calls to `GetTypeInfo`, preferring to use the actual methods on `Type`. 

A couple of extension methods on `Type` have been added for consistency with the code that was already there.

The primary motivation around these changes is one of style preference, to conform with the fact that `GetTypeInfo` is a mistake the .net team now regrets, and to eke out a minor performance gain.

There are some very minor performance gains on some of the long benchmarks (like 100ns on DeepGraph and ChildScope), but that's a slight bonus extra only.