### PR TITLE
Add benchmark for multiple constructors via the reflection activator.

### DIFF
--- a/bench/Autofac.Benchmarks/Benchmarks.cs
+++ b/bench/Autofac.Benchmarks/Benchmarks.cs
@@ -27,7 +27,8 @@ namespace Autofac.Benchmarks
             typeof(EnumerableResolveBenchmark),
             typeof(PropertyInjectionBenchmark),
             typeof(RootContainerResolveBenchmark),
-            typeof(OpenGenericBenchmark)
+            typeof(OpenGenericBenchmark),
+            typeof(MultiConstructorBenchmark)
         };
     }
 }

--- a/bench/Autofac.Benchmarks/Harness.cs
+++ b/bench/Autofac.Benchmarks/Harness.cs
@@ -92,6 +92,9 @@ namespace Autofac.Benchmarks
         [Fact]
         public void OpenGeneric() => RunBenchmark<OpenGenericBenchmark>();
 
+        [Fact]
+        public void MultiConstructor() => RunBenchmark<MultiConstructorBenchmark>();
+
         /// <remarks>
         /// This method is used to enforce that benchmark types are added to <see cref="Benchmarks.All"/>
         /// so that they can be used directly from the command line in <see cref="Program.Main"/> as well.

--- a/bench/Autofac.Benchmarks/MultiConstructorBenchmark.cs
+++ b/bench/Autofac.Benchmarks/MultiConstructorBenchmark.cs
@@ -1,0 +1,120 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Autofac.Benchmarks
+{
+    public class MultiConstructorBenchmark
+    {
+        private IContainer container;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<OneConstructor>();
+            builder.RegisterType<TwoConstructors>();
+            builder.RegisterType<ThreeConstructors>();
+            builder.RegisterType<FourConstructors>();
+            builder.RegisterType<D1>();
+            builder.RegisterType<D2>();
+            builder.RegisterType<D3>();
+            builder.RegisterType<D4>();
+
+            container = builder.Build();
+        }
+
+        [Benchmark(Baseline = true)]
+        public void Single()
+        {
+            container.Resolve<OneConstructor>();
+        }
+
+        [Benchmark]
+        public void Two()
+        {
+            container.Resolve<TwoConstructors>();
+        }
+
+        [Benchmark]
+        public void Three()
+        {
+            container.Resolve<ThreeConstructors>();
+        }
+
+        [Benchmark]
+        public void Four()
+        {
+            container.Resolve<FourConstructors>();
+        }
+
+        private class OneConstructor
+        {
+            public OneConstructor(D1 d1)
+            {
+            }
+        }
+
+        private class TwoConstructors
+        {
+            public TwoConstructors(D1 d1)
+            {
+            }
+
+            public TwoConstructors(D1 d1, D2 d2)
+            {
+            }
+        }
+
+        private class ThreeConstructors
+        {
+            public ThreeConstructors(D1 d1)
+            {
+            }
+
+            public ThreeConstructors(D1 d1, D2 d2)
+            {
+            }
+
+            public ThreeConstructors(D1 d1, D2 d2, D3 d3)
+            {
+            }
+        }
+
+        private class FourConstructors
+        {
+            public FourConstructors(D1 d1)
+            {
+            }
+
+            public FourConstructors(D1 d1, D2 d2)
+            {
+            }
+
+            public FourConstructors(D1 d1, D2 d2, D3 d3)
+            {
+            }
+
+            public FourConstructors(D1 d1, D2 d2, D3 d3, D4 d4)
+            {
+            }
+        }
+
+        private class D1
+        {
+        }
+
+        private class D2
+        {
+        }
+
+        private class D3
+        {
+        }
+
+        private class D4
+        {
+        }
+    }
+}

--- a/bench/Autofac.Benchmarks/MultiConstructorBenchmark.cs
+++ b/bench/Autofac.Benchmarks/MultiConstructorBenchmark.cs
@@ -16,6 +16,7 @@ namespace Autofac.Benchmarks
             builder.RegisterType<OneConstructor>();
             builder.RegisterType<TwoConstructors>();
             builder.RegisterType<ThreeConstructors>();
+            builder.RegisterType<TwoValidConstructorsOneInvalid>();
             builder.RegisterType<FourConstructors>();
             builder.RegisterType<D1>();
             builder.RegisterType<D2>();
@@ -35,6 +36,12 @@ namespace Autofac.Benchmarks
         public void Two()
         {
             container.Resolve<TwoConstructors>();
+        }
+
+        [Benchmark]
+        public void TwoValidOneInvalid()
+        {
+            container.Resolve<TwoValidConstructorsOneInvalid>();
         }
 
         [Benchmark]
@@ -63,6 +70,21 @@ namespace Autofac.Benchmarks
             }
 
             public TwoConstructors(D1 d1, D2 d2)
+            {
+            }
+        }
+
+        private class TwoValidConstructorsOneInvalid
+        {
+            public TwoValidConstructorsOneInvalid(D1 d1)
+            {
+            }
+
+            public TwoValidConstructorsOneInvalid(D1 d1, D2 d2)
+            {
+            }
+
+            public TwoValidConstructorsOneInvalid(D1 d1, D2 d2, object notRegistered)
             {
             }
         }


### PR DESCRIPTION
Example output:

| Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
| Single | 1.041 us | 0.0053 us | 0.0047 us |  1.00 |    0.00 | 0.3071 |     - |     - |   1.26 KB |
|    Two | 2.238 us | 0.0162 us | 0.0143 us |  2.15 |    0.02 | 0.6638 |     - |     - |   2.72 KB |
|  Three | 3.095 us | 0.0227 us | 0.0202 us |  2.97 |    0.03 | 0.9499 |     - |     - |   3.88 KB |
|   Four | 4.185 us | 0.0579 us | 0.0484 us |  4.03 |    0.05 | 1.2970 |     - |     - |   5.32 KB |
