### PR TITLE
Concurrency - Overhaul Registry Locking Mechanism

### DIFF
--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -238,11 +238,11 @@ namespace Autofac.Core.Registration
             }
 
             var succeeded = false;
-
-            Monitor.Enter(info);
-
+            var lockTaken = false;
             try
             {
+                Monitor.Enter(info, ref lockTaken);
+
                 if (info.IsInitialized)
                 {
                     return info;
@@ -292,7 +292,10 @@ namespace Autofac.Core.Registration
                     info.CompleteInitialization();
                 }
 
-                Monitor.Exit(info);
+                if (lockTaken)
+                {
+                    Monitor.Exit(info);
+                }
             }
 
             return info;

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -253,7 +253,7 @@ namespace Autofac.Core.Registration
                     BeginServiceInfoInitialization(service, info, _dynamicRegistrationSources);
                 }
 
-                info.InitialisationDepth++;
+                info.InitializationDepth++;
 
                 while (info.HasSourcesToQuery)
                 {
@@ -285,9 +285,9 @@ namespace Autofac.Core.Registration
             }
             finally
             {
-                info.InitialisationDepth--;
+                info.InitializationDepth--;
 
-                if (info.InitialisationDepth == 0 && succeeded)
+                if (info.InitializationDepth == 0 && succeeded)
                 {
                     info.CompleteInitialization();
                 }

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -40,7 +40,7 @@ namespace Autofac.Core.Registration
     /// </summary>
     internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredServicesTracker
     {
-        private static readonly Func<Service, ServiceRegistrationInfo> regInfoFactory = srv => new ServiceRegistrationInfo(srv);
+        private static readonly Func<Service, ServiceRegistrationInfo> RegInfoFactory = srv => new ServiceRegistrationInfo(srv);
 
         private readonly Func<Service, IEnumerable<ServiceRegistration>> _registrationAccessor;
 
@@ -324,7 +324,7 @@ namespace Autofac.Core.Registration
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ServiceRegistrationInfo GetServiceInfo(Service service)
         {
-            return _serviceInfo.GetOrAdd(service, regInfoFactory);
+            return _serviceInfo.GetOrAdd(service, RegInfoFactory);
         }
     }
 }

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -73,11 +73,6 @@ namespace Autofac.Core.Registration
         /// </summary>
         private Queue<IRegistrationSource>? _sourcesToQuery;
 
-        /// <summary>
-        /// The combined list of registered implementations. The value will be calculated lazily by <see cref="InitializeComponentRegistrations" />.
-        /// </summary>
-        private Lazy<IList<IComponentRegistration>>? _registeredImplementations;
-
         private IResolvePipeline? _resolvePipeline;
 
         private IResolvePipelineBuilder? _customPipelineBuilder;
@@ -104,6 +99,9 @@ namespace Autofac.Core.Registration
         /// </summary>
         public IComponentRegistration? RedirectionTargetRegistration { get; private set; }
 
+        /// <summary>
+        /// Gets or sets a value representing the current initialisation depth. Will always be zero for initialised service blocks.
+        /// </summary>
         public int InitialisationDepth { get; set; }
 
         /// <summary>
@@ -312,7 +310,6 @@ namespace Autofac.Core.Registration
         public void BeginInitialization(IEnumerable<IRegistrationSource> sources)
         {
             IsInitialized = false;
-            _registeredImplementations = new Lazy<IList<IComponentRegistration>>(InitializeComponentRegistrations);
             _sourcesToQuery = new Queue<IRegistrationSource>(sources);
 
             // Build the pipeline during service info initialisation, so that sources can access it
@@ -363,26 +360,6 @@ namespace Autofac.Core.Registration
             // began it.
             IsInitialized = true;
             _sourcesToQuery = null;
-        }
-
-        private IList<IComponentRegistration> InitializeComponentRegistrations()
-        {
-            // Set an initial larger capacity.
-            var resultList = new List<IComponentRegistration>(8);
-
-            resultList.AddRange(Enumerable.Reverse(_defaultImplementations));
-
-            if (_sourceImplementations != null)
-            {
-                resultList.AddRange(_sourceImplementations);
-            }
-
-            if (_preserveDefaultImplementations != null)
-            {
-                resultList.AddRange(_preserveDefaultImplementations);
-            }
-
-            return resultList;
         }
 
         private IResolvePipeline BuildPipeline()

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -355,9 +355,8 @@ namespace Autofac.Core.Registration
         /// </summary>
         public void CompleteInitialization()
         {
-            // Does not EnforceDuringInitialization() because the recursive algorithm
-            // sometimes completes initialisation at a deeper level than that which
-            // began it.
+            EnforceDuringInitialization();
+
             IsInitialized = true;
             _sourcesToQuery = null;
         }

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -100,9 +100,9 @@ namespace Autofac.Core.Registration
         public IComponentRegistration? RedirectionTargetRegistration { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value representing the current initialisation depth. Will always be zero for initialised service blocks.
+        /// Gets or sets a value representing the current initialization depth. Will always be zero for initialized service blocks.
         /// </summary>
-        public int InitialisationDepth { get; set; }
+        public int InitializationDepth { get; set; }
 
         /// <summary>
         /// Gets the known implementations. The first implementation is a default one.
@@ -170,7 +170,7 @@ namespace Autofac.Core.Registration
             // Implementations can be read by consumers while we are inside an initialisation window,
             // even when the initialisation hasn't finished yet.
             // The InitialisationDepth property is always 0 outside of the lock-protected initialisation block.
-            if (InitialisationDepth == 0 && !IsInitialized)
+            if (InitializationDepth == 0 && !IsInitialized)
             {
                 throw new InvalidOperationException(ServiceRegistrationInfoResources.NotInitialized);
             }


### PR DESCRIPTION
I've been looking how to improve our concurrency performance, and fundamentally it comes down the locks inside `DefaultRegisteredServicesTracker`. 

There's been a number of iterations and attempts to improve this, with varying success. We've also had to roll back some of our more fine-grained locking recently to be more global due to #1073.

This PR is my attempt at improving the concurrency behaviour (which I feel is sort of a rite-of-passage for Autofac contributors).

These changes mean that retrieving an Initialized service's registrations is lock-free.

I know that concurrency like this can be a thorny issue, so it's entirely possible I have missed something, or need additional tests. Please let me know if that is the case.

### Changes Overview

The main design behaviour that caused #1073, and prevents us doing the fine-grained locking, is because we call `CompleteInitialization` on the `ServiceRegistrationInfo` inside recursive calls from registration sources, meaning that an info block indicates it has completed initalisation before the ACTNARS (for example) registration is added to the implementation list.

- Introduced an `InitializationDepth` property to the `ServiceRegistrationInfo`. This value is incremented and decremented manually in `DefaultRegisteredServicesTracker` to capture the knowledge that we are inside a nested registration source call.

- Only when `InitializationDepth` has returned to 0 after processing all the sources will we call `CompleteInitialization`.

- A Monitor.Enter/Exit on the `ServiceRegistrationInfo` protects the section that manipulates InitializationDepth, so only one thread can be recursing through it (or indeed incrementing/decrementing the number). The reason I used Enter/Exit explicitly rather than the lock statement is because I wanted to share the finally block with other code.

- Registration Sources can now access the set of implementations for a service **before** initialization has completed, but **only** if that `InitializationDepth` counter is greater than 0, meaning we are doing initialisation work. Because the counter is protected by the Monitor block, only the current thread can access the implementations in this way. This gives us more safety than just letting anyone access implementations at any time.

- Removed the `Lazy` set of implementations for a `ServiceRegistrationInfo`, and instead use `yield return` in the `Implementations` property to yield the full set of implementations, to ensure that we don't have to regenerate the list if sources need to access implementations during initialization.

### Benchmarks

Concurrency benchmarks are greatly improved:

**develop**
|                          Method | ResolveTaskCount | ResolvesPerTask |     Mean |     Error |    StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------------- |---------------- |---------:|----------:|----------:|---------:|--------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |              100 |             100 | 2.084 ms | 0.0408 ms | 0.0635 ms | 617.1875 | 27.3438 |     - |    4.9 MB |
| NestedScope.MultipleResolvesOnMultipleTasks |                100 |          10 | 1.688 ms | 0.0413 ms | 0.0948 ms | 1101.5625 | 253.9063 |     - |   8.71 MB |

**concurrency**
|                          Method | ResolveTaskCount | ResolvesPerTask |     Mean |    Error |   StdDev |    Gen 0 |   Gen 1 | Gen 2 | Allocated |
|-------------------------------- |----------------- |---------------- |---------:|---------:|---------:|---------:|--------:|------:|----------:|
| MultipleResolvesOnMultipleTasks |              100 |             100 | 593.2 μs | 11.81 μs | 20.68 μs | 977.5391 | 75.1953 |     - |   7.64 MB |
| NestedScope.MultipleResolvesOnMultipleTasks |                100 |          10 | 1.154 ms | 0.0224 ms | 0.0249 ms | 1187.5000 | 267.5781 |     - |   9.44 MB |

