### PR TITLE
Use singleton instances of the Root and Current lifetime behaviours

### DIFF
--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -116,7 +116,7 @@ namespace Autofac.Builder
         public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> InstancePerDependency()
         {
             RegistrationData.Sharing = InstanceSharing.None;
-            RegistrationData.Lifetime = new CurrentScopeLifetime();
+            RegistrationData.Lifetime = CurrentScopeLifetime.Instance;
             return this;
         }
 
@@ -128,7 +128,7 @@ namespace Autofac.Builder
         public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> SingleInstance()
         {
             RegistrationData.Sharing = InstanceSharing.Shared;
-            RegistrationData.Lifetime = new RootScopeLifetime();
+            RegistrationData.Lifetime = RootScopeLifetime.Instance;
             return this;
         }
 
@@ -141,7 +141,7 @@ namespace Autofac.Builder
         public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> InstancePerLifetimeScope()
         {
             RegistrationData.Sharing = InstanceSharing.Shared;
-            RegistrationData.Lifetime = new CurrentScopeLifetime();
+            RegistrationData.Lifetime = CurrentScopeLifetime.Instance;
             return this;
         }
 

--- a/src/Autofac/Builder/RegistrationData.cs
+++ b/src/Autofac/Builder/RegistrationData.cs
@@ -45,7 +45,7 @@ namespace Autofac.Builder
 
         private readonly ICollection<Service> _services = new HashSet<Service>();
 
-        private IComponentLifetime _lifetime = new CurrentScopeLifetime();
+        private IComponentLifetime _lifetime = CurrentScopeLifetime.Instance;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RegistrationData"/> class.

--- a/src/Autofac/Core/Lifetime/CurrentScopeLifetime.cs
+++ b/src/Autofac/Core/Lifetime/CurrentScopeLifetime.cs
@@ -33,6 +33,11 @@ namespace Autofac.Core.Lifetime
     public class CurrentScopeLifetime : IComponentLifetime
     {
         /// <summary>
+        /// Gets the singleton instance of the <see cref="CurrentScopeLifetime"/> behaviour.
+        /// </summary>
+        public static IComponentLifetime Instance { get; } = new CurrentScopeLifetime();
+
+        /// <summary>
         /// Given the most nested scope visible within the resolve operation, find
         /// the scope for the component.
         /// </summary>

--- a/src/Autofac/Core/Lifetime/RootScopeLifetime.cs
+++ b/src/Autofac/Core/Lifetime/RootScopeLifetime.cs
@@ -33,6 +33,11 @@ namespace Autofac.Core.Lifetime
     public class RootScopeLifetime : IComponentLifetime
     {
         /// <summary>
+        /// Gets the singleton instance of the <see cref="RootScopeLifetime"/> behaviour.
+        /// </summary>
+        public static IComponentLifetime Instance { get; } = new RootScopeLifetime();
+
+        /// <summary>
         /// Given the most nested scope visible within the resolve operation, find
         /// the scope for the component.
         /// </summary>

--- a/src/Autofac/Core/SelfComponentRegistration.cs
+++ b/src/Autofac/Core/SelfComponentRegistration.cs
@@ -20,7 +20,7 @@ namespace Autofac.Core
             : base(
                 LifetimeScope.SelfRegistrationId,
                 new DelegateActivator(typeof(LifetimeScope), (c, p) => { throw new InvalidOperationException(ContainerResources.SelfRegistrationCannotBeActivated); }),
-                new CurrentScopeLifetime(),
+                CurrentScopeLifetime.Instance,
                 InstanceSharing.Shared,
                 InstanceOwnership.ExternallyOwned,
                 new ResolvePipelineBuilder(PipelineType.Registration),

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -146,7 +146,7 @@ namespace Autofac.Features.Collections
             var registration = new ComponentRegistration(
                 Guid.NewGuid(),
                 activator,
-                new CurrentScopeLifetime(),
+                CurrentScopeLifetime.Instance,
                 InstanceSharing.None,
                 InstanceOwnership.ExternallyOwned,
                 new[] { service },

--- a/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
+++ b/test/Autofac.Test/Core/Lifetime/LifetimeScopeTests.cs
@@ -188,7 +188,7 @@ namespace Autofac.Test.Core.Lifetime
                 new ComponentRegistration(
                     Guid.NewGuid(),
                     new DelegateActivator(serviceType, factory),
-                    new CurrentScopeLifetime(),
+                    CurrentScopeLifetime.Instance,
                     InstanceSharing.None,
                     InstanceOwnership.OwnedByLifetimeScope,
                     new[] { service },

--- a/test/Autofac.Test/Core/Registration/ComponentRegistrationLifetimeDecoratorTests.cs
+++ b/test/Autofac.Test/Core/Registration/ComponentRegistrationLifetimeDecoratorTests.cs
@@ -10,7 +10,7 @@ namespace Autofac.Test.Core.Registration
         public void DecoratorCallsDisposeOnInnerInstance()
         {
             var inner = Mocks.GetComponentRegistration();
-            var decorator = new ComponentRegistrationLifetimeDecorator(inner, new CurrentScopeLifetime());
+            var decorator = new ComponentRegistrationLifetimeDecorator(inner, CurrentScopeLifetime.Instance);
 
             decorator.Dispose();
 

--- a/test/Autofac.Test/Factory.cs
+++ b/test/Autofac.Test/Factory.cs
@@ -15,7 +15,7 @@ namespace Autofac.Test
     {
         public static IComponentRegistration CreateSingletonRegistration(IEnumerable<Service> services, IInstanceActivator activator)
         {
-            return CreateRegistration(services, activator, new RootScopeLifetime(), InstanceSharing.Shared);
+            return CreateRegistration(services, activator, RootScopeLifetime.Instance, InstanceSharing.Shared);
         }
 
         public static IComponentRegistration CreateSingletonRegistration(Type implementation)


### PR DESCRIPTION
At the moment, every registration has its own instance of `CurrentScopeLifetime` or `RootScopeLifetime`, but the instances are all identical, and hold no state or parameters.

This set of changes replaces the new instances each time with a static singleton `Instance` on each type.  

The benefits aren't huge (we save 200bytes on each ChildScopeResolveBenchmark), but for very large containers, the overall memory footprint will come down, as will the memory allocation needed for each child scope.