### PR TITLE
chore: small code optimizations

### DIFF
--- a/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContextBase.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContextBase.cs
@@ -162,10 +162,8 @@ namespace Autofac.Core.Resolving.Pipeline
         }
 
         /// <inheritdoc />
-        public virtual object ResolveComponent(ResolveRequest request)
-        {
-            return Operation.GetOrCreateInstance(ActivationScope, request);
-        }
+        public virtual object ResolveComponent(ResolveRequest request) =>
+            Operation.GetOrCreateInstance(ActivationScope, request);
 
         /// <summary>
         /// Complete the request, raising any appropriate events.


### PR DESCRIPTION
* Remove redundant constructor in `ResolveOperationBase` and make `IPipelineTracer` default to `null` 
* Mark some fields as readonly in `ResolveOperationBase`
* Make setters of some properties private, since they are not set from outside
* Make some public properties private, since they are not set from outside
* Use new pattern matching method `x is { }` rather than `x is object`