### PR TITLE
Define distinct 'Core Event' middleware and associated enums.

### DIFF
--- a/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Autofac.Core.Resolving.Pipeline;
+
+namespace Autofac.Core.Resolving.Middleware
+{
+    /// <summary>
+    /// Middleware that invokes one of the built-in resolve events, defined by <see cref="ResolveEventType"/>.
+    /// </summary>
+    public class CoreEventMiddleware : IResolveMiddleware
+    {
+        private readonly Action<ResolveRequestContextBase, Action<ResolveRequestContextBase>> _callback;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CoreEventMiddleware"/> class.
+        /// </summary>
+        /// <param name="eventType">The type of event.</param>
+        /// <param name="phase">The phase of the pipeine at which the event runs.</param>
+        /// <param name="callback">The middleware callback to process the event.</param>
+        internal CoreEventMiddleware(ResolveEventType eventType, PipelinePhase phase, Action<ResolveRequestContextBase, Action<ResolveRequestContextBase>> callback)
+        {
+            Phase = phase;
+            _callback = callback;
+            EventType = eventType;
+        }
+
+        /// <inheritdoc/>
+        public PipelinePhase Phase { get; }
+
+        /// <summary>
+        /// Gets the event type represented by this middleware.
+        /// </summary>
+        public ResolveEventType EventType { get; }
+
+        /// <inheritdoc/>
+        public override string ToString() => EventType.ToString();
+
+        /// <inheritdoc/>
+        public void Execute(ResolveRequestContextBase context, Action<ResolveRequestContextBase> next)
+        {
+            _callback(context, next);
+        }
+    }
+}

--- a/src/Autofac/Core/Resolving/ResolveEventType.cs
+++ b/src/Autofac/Core/Resolving/ResolveEventType.cs
@@ -1,0 +1,30 @@
+﻿using Autofac.Builder;
+
+namespace Autofac.Core.Resolving.Middleware
+{
+    /// <summary>
+    /// Defines the standard set of in-built resolve events, executed by the <see cref="CoreEventMiddleware"/>.
+    /// </summary>
+    public enum ResolveEventType
+    {
+        /// <summary>
+        /// Event type for the OnPreparing event registered by <see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}.OnPreparing"/>.
+        /// </summary>
+        OnPreparing,
+
+        /// <summary>
+        /// Event type for the OnActivating event registered by <see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}.OnActivating(System.Action{IActivatingEventArgs{TLimit}})"/>.
+        /// </summary>
+        OnActivating,
+
+        /// <summary>
+        /// Event type for the OnActivated event registered by <see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}.OnActivated(System.Action{IActivatedEventArgs{TLimit}})"/>.
+        /// </summary>
+        OnActivated,
+
+        /// <summary>
+        /// Event type for the OnRelease event registered by <see cref="RegistrationExtensions.OnRelease"/>
+        /// </summary>
+        OnRelease
+    }
+}


### PR DESCRIPTION
Helps to identify event middleware outside of Autofac without using string comparison.

As discussed in Autofac/Autofac.Pooling#1.

