### PR TITLE
Add support for Func<TArgs, Task> handlers for Core Autofac Events

### DIFF
--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -44,10 +44,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0-beta1.final">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0-beta2.final">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Condition="Exists('$(MSBuildThisFileDirectory)../../.git')">

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -264,7 +264,7 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="handler">An event handler; the resolve process will not continue until the returned task completes.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
-        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Func<PreparingEventArgs, Task> handler);
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Func<PreparingEventArgs, ValueTask> handler);
 
         /// <summary>
         /// Add a handler for the Activating event.
@@ -278,7 +278,7 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="handler">An event handler; the resolve process will not continue until the returned task completes.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
-        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Func<IActivatingEventArgs<TLimit>, Task> handler);
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Func<IActivatingEventArgs<TLimit>, ValueTask> handler);
 
         /// <summary>
         /// Add a handler for the Activated event.
@@ -292,7 +292,7 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="handler">An event handler; the resolve process will not continue until the returned task completes.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
-        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Func<IActivatedEventArgs<TLimit>, Task> handler);
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Func<IActivatedEventArgs<TLimit>, ValueTask> handler);
 
         /// <summary>
         /// Configure the component so that any properties whose types are registered in the

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Threading.Tasks;
 using Autofac.Core;
 using Autofac.Core.Resolving.Pipeline;
 
@@ -258,6 +259,14 @@ namespace Autofac.Builder
         IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Action<PreparingEventArgs> handler);
 
         /// <summary>
+        /// Add an async handler for the Preparing event. This event allows manipulating of the parameters
+        /// that will be provided to the component.
+        /// </summary>
+        /// <param name="handler">An event handler; the resolve process will not continue until the returned task completes.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Func<PreparingEventArgs, Task> handler);
+
+        /// <summary>
         /// Add a handler for the Activating event.
         /// </summary>
         /// <param name="handler">The event handler.</param>
@@ -265,11 +274,25 @@ namespace Autofac.Builder
         IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Action<IActivatingEventArgs<TLimit>> handler);
 
         /// <summary>
+        /// Add an async handler for the Activating event.
+        /// </summary>
+        /// <param name="handler">An event handler; the resolve process will not continue until the returned task completes.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Func<IActivatingEventArgs<TLimit>, Task> handler);
+
+        /// <summary>
         /// Add a handler for the Activated event.
         /// </summary>
         /// <param name="handler">The event handler.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Action<IActivatedEventArgs<TLimit>> handler);
+
+        /// <summary>
+        /// Add a handler for the Activated event.
+        /// </summary>
+        /// <param name="handler">An event handler; the resolve process will not continue until the returned task completes.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Func<IActivatedEventArgs<TLimit>, Task> handler);
 
         /// <summary>
         /// Configure the component so that any properties whose types are registered in the

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -420,14 +420,22 @@ namespace Autofac.Builder
         }
 
         /// <inheritdoc/>
-        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Func<PreparingEventArgs, Task> handler)
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Func<PreparingEventArgs, ValueTask> handler)
         {
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return OnPreparing(args => handler(args).ConfigureAwait(false).GetAwaiter().GetResult());
+            return OnPreparing(args =>
+            {
+                var vt = handler(args);
+
+                if (!vt.IsCompletedSuccessfully)
+                {
+                    vt.ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+            });
         }
 
         /// <summary>
@@ -457,14 +465,22 @@ namespace Autofac.Builder
         }
 
         /// <inheritdoc/>
-        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Func<IActivatingEventArgs<TLimit>, Task> handler)
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Func<IActivatingEventArgs<TLimit>, ValueTask> handler)
         {
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return OnActivating(args => handler(args).ConfigureAwait(false).GetAwaiter().GetResult());
+            return OnActivating(args =>
+            {
+                var vt = handler(args);
+
+                if (!vt.IsCompletedSuccessfully)
+                {
+                    vt.ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+            });
         }
 
         /// <summary>
@@ -508,14 +524,22 @@ namespace Autofac.Builder
         }
 
         /// <inheritdoc/>
-        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Func<IActivatedEventArgs<TLimit>, Task> handler)
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Func<IActivatedEventArgs<TLimit>, ValueTask> handler)
         {
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return OnActivated(args => handler(args).ConfigureAwait(false).GetAwaiter().GetResult());
+            return OnActivated(args =>
+            {
+                var vt = handler(args);
+
+                if (!vt.IsCompletedSuccessfully)
+                {
+                    vt.ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+            });
         }
 
         /// <summary>

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -27,6 +27,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Core.Lifetime;
@@ -418,6 +419,17 @@ namespace Autofac.Builder
             return this;
         }
 
+        /// <inheritdoc/>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnPreparing(Func<PreparingEventArgs, Task> handler)
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return OnPreparing(args => handler(args).ConfigureAwait(false).GetAwaiter().GetResult());
+        }
+
         /// <summary>
         /// Add a handler for the Activating event.
         /// </summary>
@@ -442,6 +454,17 @@ namespace Autofac.Builder
             ResolvePipeline.Use(middleware, MiddlewareInsertionMode.StartOfPhase);
 
             return this;
+        }
+
+        /// <inheritdoc/>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivating(Func<IActivatingEventArgs<TLimit>, Task> handler)
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return OnActivating(args => handler(args).ConfigureAwait(false).GetAwaiter().GetResult());
         }
 
         /// <summary>
@@ -482,6 +505,17 @@ namespace Autofac.Builder
             ResolvePipeline.Use(middleware, MiddlewareInsertionMode.StartOfPhase);
 
             return this;
+        }
+
+        /// <inheritdoc/>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> OnActivated(Func<IActivatedEventArgs<TLimit>, Task> handler)
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return OnActivated(args => handler(args).ConfigureAwait(false).GetAwaiter().GetResult());
         }
 
         /// <summary>

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -45,7 +45,7 @@ namespace Autofac.Core.Registration
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "The _service field is useful in debugging and diagnostics.")]
         private readonly Service _service;
 
-        private IComponentRegistration? _fixedRegistration = null;
+        private IComponentRegistration? _fixedRegistration;
 
         /// <summary>
         ///  List of implicit default service implementations. Overriding default implementations are appended to the end,

--- a/src/Autofac/Core/Resolving/ResolveEventType.cs
+++ b/src/Autofac/Core/Resolving/ResolveEventType.cs
@@ -8,7 +8,7 @@ namespace Autofac.Core.Resolving.Middleware
     public enum ResolveEventType
     {
         /// <summary>
-        /// Event type for the OnPreparing event registered by <see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}.OnPreparing"/>.
+        /// Event type for the OnPreparing event registered by <see cref="IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}.OnPreparing(System.Action{PreparingEventArgs})"/>.
         /// </summary>
         OnPreparing,
 
@@ -23,7 +23,7 @@ namespace Autofac.Core.Resolving.Middleware
         OnActivated,
 
         /// <summary>
-        /// Event type for the OnRelease event registered by <see cref="RegistrationExtensions.OnRelease"/>
+        /// Event type for the OnRelease event registered by <see cref="RegistrationExtensions.OnRelease{TLimit, TActivatorData, TRegistrationStyle}(IRegistrationBuilder{TLimit, TActivatorData, TRegistrationStyle}, System.Action{TLimit})"/>
         /// </summary>
         OnRelease
     }

--- a/src/Autofac/Core/Resolving/ResolveOperationBase.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperationBase.cs
@@ -41,8 +41,8 @@ namespace Autofac.Core.Resolving
         private const int SuccessListInitialCapacity = 32;
 
         private bool _ended;
-        private List<ResolveRequestContext> _successfulRequests = new List<ResolveRequestContext>(SuccessListInitialCapacity);
-        private int _nextCompleteSuccessfulRequestStartPos = 0;
+        private readonly List<ResolveRequestContext> _successfulRequests = new List<ResolveRequestContext>(SuccessListInitialCapacity);
+        private int _nextCompleteSuccessfulRequestStartPos;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ResolveOperationBase"/> class.
@@ -179,6 +179,11 @@ namespace Autofac.Core.Resolving
         /// <inheritdoc />
         public object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request)
         {
+            if (request is null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
             if (_ended) throw new ObjectDisposedException(ResolveOperationResources.TemporaryContextDisposed, innerException: null);
 
             // Create a new request context.

--- a/src/Autofac/RegistrationExtensions.EventHandler.cs
+++ b/src/Autofac/RegistrationExtensions.EventHandler.cs
@@ -141,7 +141,7 @@ namespace Autofac
         public static IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle>
             OnRelease<TLimit, TActivatorData, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> registration,
-                Func<TLimit, Task> releaseAction)
+                Func<TLimit, ValueTask> releaseAction)
         {
             if (registration == null) throw new ArgumentNullException(nameof(registration));
             if (releaseAction == null) throw new ArgumentNullException(nameof(releaseAction));

--- a/src/Autofac/Util/AsyncReleaseAction.cs
+++ b/src/Autofac/Util/AsyncReleaseAction.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Autofac.Util
+{
+    /// <summary>
+    /// Adapts an async action to the <see cref="IAsyncDisposable"/> interface.
+    /// </summary>
+    internal class AsyncReleaseAction<TLimit> : Disposable
+    {
+        private readonly Func<TLimit, Task> _action;
+        private readonly Func<TLimit> _factory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncReleaseAction{TLimit}"/> class.
+        /// </summary>
+        /// <param name="action">
+        /// The async action to execute on disposal.
+        /// </param>
+        /// <param name="factory">
+        /// A factory that retrieves the value on which the <paramref name="action" />
+        /// should be executed.
+        /// </param>
+        public AsyncReleaseAction(Func<TLimit, Task> action, Func<TLimit> factory)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+            if (factory == null) throw new ArgumentNullException(nameof(factory));
+
+            _action = action;
+            _factory = factory;
+        }
+
+        /// <inheritdoc/>
+        protected override async ValueTask DisposeAsync(bool disposing)
+        {
+            // Value retrieval for the disposal is deferred until
+            // disposal runs to ensure any calls to, say, .ReplaceInstance()
+            // during .OnActivating() will be accounted for.
+            if (disposing)
+            {
+              await _action(_factory()).ConfigureAwait(false);
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            // Value retrieval for the disposal is deferred until
+            // disposal runs to ensure any calls to, say, .ReplaceInstance()
+            // during .OnActivating() will be accounted for.
+            if (disposing)
+            {
+                _action(_factory()).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1069 

Added overloads for OnPreparing, OnActivating, OnActivated and OnRelease that allow you to provide a `Func<Task>` handler, so you can do async/await inside those methods.

OnPreparing, OnActivating and OnActivated are not 'true' async, because the implementations are basically just a utility wrapper around `handler(args).ConfigureAwait(false).GetAwaiter().GetResult()`.

So they make it more convenient for developers to do some async operations inside these handlers, but there is no `ResolveAsync` method.

OnRelease has a bit more functionality, because if you dispose of the scope/container using `DisposeAsync`, that **will** do a proper await on the task, so it's an actual async flow.



