### PR TITLE
fix: make sure benchmarks can be run everywhere

### DIFF
--- a/bench/Autofac.Benchmarks/BenchmarkConfig.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkConfig.cs
@@ -7,7 +7,7 @@ namespace Autofac.Benchmarks
 {
     internal class BenchmarkConfig : ManualConfig
     {
-        private const string BenchmarkArtificatsFolder = "BenchmarkDotNet.Artifacts";
+        private const string BenchmarkArtifactsFolder = "BenchmarkDotNet.Artifacts";
 
         internal BenchmarkConfig()
         {
@@ -15,7 +15,7 @@ namespace Autofac.Benchmarks
 
             var rootFolder = AppContext.BaseDirectory;
             var runFolder = DateTime.UtcNow.ToString("dd-MM-yyyy_hh-MM-ss");
-            ArtifactsPath = Path.Combine(rootFolder, BenchmarkArtificatsFolder, runFolder);
+            ArtifactsPath = Path.Combine(rootFolder, BenchmarkArtifactsFolder, runFolder);
 
             Add(MemoryDiagnoser.Default);
         }

--- a/bench/Autofac.Benchmarks/BenchmarkConfig.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 
@@ -6,13 +7,15 @@ namespace Autofac.Benchmarks
 {
     internal class BenchmarkConfig : ManualConfig
     {
+        private const string BenchmarkArtificatsFolder = "BenchmarkDotNet.Artifacts";
+
         internal BenchmarkConfig()
         {
             Add(DefaultConfig.Instance);
 
-            var rootFolder = AppContext.BaseDirectory.Substring(0, AppContext.BaseDirectory.LastIndexOf("bin", StringComparison.OrdinalIgnoreCase));
-            var runFolder = DateTime.Now.ToString("u").Replace(' ', '_').Replace(':', '-');
-            ArtifactsPath = $"{rootFolder}\\BenchmarkDotNet.Artifacts\\{runFolder}";
+            var rootFolder = AppContext.BaseDirectory;
+            var runFolder = DateTime.UtcNow.ToString("dd-MM-yyyy_hh-MM-ss");
+            ArtifactsPath = Path.Combine(rootFolder, BenchmarkArtificatsFolder, runFolder);
 
             Add(MemoryDiagnoser.Default);
         }


### PR DESCRIPTION
Previously it was not possible to something like this:
`dotnet publish -c Release Autofac.Benchmarks.csproj`
`cd publish`
`dotnet Autofac.Benchmarks.dll --filter *ChildScopeResolveBenchmark*` // throws an exception because there is no bin directory.

The changes made make sure that the `bin` directory must not be present when executing them.

It also does not use hard-coded path-separators anymore, even though that somehow didn't seem to be a problem on Unix based systems.