### PR TITLE
More stable null check when accessing the parent scope to check disposal

### DIFF
--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -449,7 +449,7 @@ namespace Autofac.Core.Lifetime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsTreeDisposed()
         {
-            return IsDisposed || (_parentScope is object && _parentScope.IsTreeDisposed());
+            return IsDisposed || (_parentScope?.IsTreeDisposed() ?? false);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1175 (maybe?).

As listed in the issue, I can't see any reason that the original code would actually cause the displayed error, but this line seems like the only viable culprit. 

So I've just updated the null check to guarantee that the line cannot throw a null check.

Sadly though, I can't recreate this locally (or on CI now).