### PR TITLE
chore: allow coverage threshold of 1%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,8 @@
 codecov:
   branch: develop
   require_ci_to_pass: yes
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
As discussed in #1184, a threshold of 1% in difference is now given.