### PR TITLE
Expose a Registration's Resolve Pipeline in a Fluent Manner

### DIFF
--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -334,6 +334,6 @@ namespace Autofac.Builder
         /// </summary>
         /// <param name="configurationAction">An action that can configure the registration's pipeline.</param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
-        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> Pipeline(Action<IResolvePipelineBuilder> configurationAction);
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> ConfigurePipeline(Action<IResolvePipelineBuilder> configurationAction);
     }
 }

--- a/src/Autofac/Builder/IRegistrationBuilder.cs
+++ b/src/Autofac/Builder/IRegistrationBuilder.cs
@@ -328,5 +328,12 @@ namespace Autofac.Builder
         /// </param>
         /// <returns>A registration builder allowing further configuration of the component.</returns>
         IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> WithMetadata<TMetadata>(Action<MetadataConfiguration<TMetadata>> configurationAction);
+
+        /// <summary>
+        /// Provides access to the registration's pipeline builder, allowing custom middleware to be added.
+        /// </summary>
+        /// <param name="configurationAction">An action that can configure the registration's pipeline.</param>
+        /// <returns>A registration builder allowing further configuration of the component.</returns>
+        IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> Pipeline(Action<IResolvePipelineBuilder> configurationAction);
     }
 }

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -680,5 +680,18 @@ namespace Autofac.Builder
             configurationAction(epConfiguration);
             return WithMetadata(epConfiguration.Properties);
         }
+
+        /// <inheritdoc/>
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> Pipeline(Action<IResolvePipelineBuilder> configurationAction)
+        {
+            if (configurationAction is null)
+            {
+                throw new ArgumentNullException(nameof(configurationAction));
+            }
+
+            configurationAction(ResolvePipeline);
+
+            return this;
+        }
     }
 }

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -682,7 +682,7 @@ namespace Autofac.Builder
         }
 
         /// <inheritdoc/>
-        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> Pipeline(Action<IResolvePipelineBuilder> configurationAction)
+        public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> ConfigurePipeline(Action<IResolvePipelineBuilder> configurationAction)
         {
             if (configurationAction is null)
             {


### PR DESCRIPTION
I'm working on the docs for the pipelines stuff, and realised that the current way of adding to a registration's resolve pipeline (using a `ResolvePipeline` property that is not displayed in intellisense) is pretty rubbish, and completely goes against the fluent nature of registering something.

With these changes the new usage looks like this:

```csharp
var registration = builder.RegisterType<MyImplementation>().As<IMyService>().Pipeline(p =>
{
    p.Use(PipelinePhase.RegistrationPipelineStart, (ctxt, next) =>
    {
        Console.WriteLine("Yay");
    });
});
```

I'm happy to take suggestions for better method names than `Pipeline`.