### PR TITLE
Decorator Performance Improvements

### DIFF
--- a/src/Autofac/Features/Decorators/DecoratorContext.cs
+++ b/src/Autofac/Features/Decorators/DecoratorContext.cs
@@ -58,8 +58,8 @@ namespace Autofac.Features.Decorators
             ImplementationType = implementationType;
             ServiceType = serviceType;
             CurrentInstance = currentInstance;
-            AppliedDecoratorTypes = appliedDecoratorTypes ?? new List<Type>(0);
-            AppliedDecorators = appliedDecorators ?? new List<object>(0);
+            AppliedDecoratorTypes = appliedDecoratorTypes ?? Array.Empty<Type>();
+            AppliedDecorators = appliedDecorators ?? Array.Empty<object>();
         }
 
         /// <summary>

--- a/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
+++ b/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
@@ -84,7 +84,17 @@ namespace Autofac.Features.Decorators
 
             var serviceType = swt.ServiceType;
 
-            context.DecoratorContext ??= DecoratorContext.Create(context.Instance.GetType(), serviceType, context.Instance);
+            if (context.DecoratorContext is null)
+            {
+                context.DecoratorContext = DecoratorContext.Create(context.Instance.GetType(), serviceType, context.Instance);
+            }
+            else
+            {
+                // Update the context with the previous decorator's output.
+                // Doing this here, rather than in the decorator middleware that resulted in the instance
+                // means we do not need to needlessly update the decorator context on the final decorator.
+                context.DecoratorContext = context.DecoratorContext.UpdateContext(context.Instance);
+            }
 
             if (!_decoratorService.Condition(context.DecoratorContext))
             {
@@ -131,8 +141,6 @@ namespace Autofac.Features.Decorators
                 var decoratedInstance = context.ResolveComponent(resolveRequest);
 
                 context.Instance = decoratedInstance;
-
-                context.DecoratorContext = context.DecoratorContext.UpdateContext(decoratedInstance);
             }
         }
 


### PR DESCRIPTION
These changes largely bring decorators "back into the fold" performance-wise; most of the improvement is about when we update the decorator context; doing it in the start of the 'next' decorator means we avoid an additional allocation, list copy, etc.