### PR TITLE
Ensure that middleware added to a scanning registration is copied to all found types.

### DIFF
--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -127,6 +127,9 @@ namespace Autofac.Features.Scanning
                     .WithParameters(rb.ActivatorData.ConfiguredParameters)
                     .WithProperties(rb.ActivatorData.ConfiguredProperties);
 
+                // Copy middleware from the scanning registration.
+                scanned.ResolvePipeline.UseRange(rb.ResolvePipeline.Middleware);
+
                 scanned.RegistrationData.CopyFrom(rb.RegistrationData, false);
 
                 foreach (var action in rb.ActivatorData.ConfigurationActions)

--- a/test/Autofac.Test/Features/Scanning/ScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/ScanningRegistrationTests.cs
@@ -491,5 +491,53 @@ namespace Autofac.Test.Features.Scanning
             var c = RegisterScenarioAssembly();
             c.AssertRegistered<NestedComponent.PublicComponent>();
         }
+
+        [Fact]
+        public void ScannedAssembliesPreparingEventFires()
+        {
+            var preparingCalled = false;
+
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyTypes(typeof(AComponent).GetTypeInfo().Assembly)
+                .OnPreparing(args => preparingCalled = true);
+
+            var c = cb.Build();
+
+            var a = c.Resolve<AComponent>();
+
+            Assert.True(preparingCalled);
+        }
+
+        [Fact]
+        public void ScannedAssembliesActivatedEventFires()
+        {
+            var activatedCalled = false;
+
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyTypes(typeof(AComponent).GetTypeInfo().Assembly)
+                .OnActivated(args => activatedCalled = true);
+
+            var c = cb.Build();
+
+            var a = c.Resolve<AComponent>();
+
+            Assert.True(activatedCalled);
+        }
+
+        [Fact]
+        public void ScannedAssembliesActivatingEventFires()
+        {
+            var activatingCalled = false;
+
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyTypes(typeof(AComponent).GetTypeInfo().Assembly)
+                .OnActivating(args => activatingCalled = true);
+
+            var c = cb.Build();
+
+            var a = c.Resolve<AComponent>();
+
+            Assert.True(activatingCalled);
+        }
     }
 }


### PR DESCRIPTION
This was almost a doozy! Found this while testing one of the integrations; middleware added to a scanning registration (via OnActivating, for example), wasn't getting copied to the actual created registration.

Added the code to add the middleware to the generated registration.