### PR TITLE
Remove some assemblyinfo attributes and replace with project properties

### DIFF
--- a/src/Autofac/Autofac.csproj
+++ b/src/Autofac/Autofac.csproj
@@ -20,10 +20,9 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/autofac/Autofac</RepositoryUrl>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <AssemblyTitle>Autofac</AssemblyTitle>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <Copyright>Copyright © 2015 Autofac Contributors</Copyright>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedAllSources>true</EmbedAllSources>

--- a/src/Autofac/Properties/AssemblyInfo.cs
+++ b/src/Autofac/Properties/AssemblyInfo.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Reflection;
-using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("Autofac")]
 [assembly: InternalsVisibleTo("Autofac.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001008728425885ef385e049261b18878327dfaaf0d666dea3bd2b0e4f18b33929ad4e5fbc9087e7eda3c1291d2de579206d9b4292456abffbe8be6c7060b36da0c33b883e3878eaf7c89fddf29e6e27d24588e81e86f3a22dd7b1a296b5f06fbfb500bbd7410faa7213ef4e2ce7622aefc03169b0324bcd30ccfe9ac8204e4960be6")]
 [assembly: CLSCompliant(false)]
 [assembly: ComVisible(false)]
-[assembly: NeutralResourcesLanguage("en-US")]
-[assembly: AssemblyCopyright("Copyright © 2015 Autofac Contributors")]
-[assembly: AssemblyDescription("Autofac Inversion of Control container for .NET applications.")]


### PR DESCRIPTION
As discussed in the MVC integration. 

The AssemblyDescription has no project property, so will just use the Description property normally allocated for the NuGet package.