### PR TITLE
Capture prop injection instance when the middleware runs

### DIFF
--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -584,11 +584,13 @@ namespace Autofac.Builder
 
                 if (allowCircularDependencies)
                 {
+                    var capturedInstance = ctxt.Instance;
+
                     // If we are allowing circular deps, then we need to run when all requests have completed (similar to Activated).
                     ctxt.RequestCompleting += (o, args) =>
                     {
                         var evCtxt = args.RequestContext;
-                        AutowiringPropertyInjector.InjectProperties(evCtxt, evCtxt.Instance!, propertySelector, evCtxt.Parameters);
+                        AutowiringPropertyInjector.InjectProperties(evCtxt, capturedInstance!, propertySelector, evCtxt.Parameters);
                     };
                 }
                 else


### PR DESCRIPTION
This fixes #1204; we capture the activated instance in the middleware now, and while we do populate it later, we're populating the right instance.