### PR TITLE
Use ephemeral service info blocks for any lookups before the registry is built.

### DIFF
--- a/src/Autofac/Core/Registration/ComponentRegistryBuilder.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistryBuilder.cs
@@ -76,6 +76,9 @@ namespace Autofac.Core.Registration
         /// <returns>A new component registry with the configured component registrations.</returns>
         public IComponentRegistry Build()
         {
+            // Mark our tracker as complete; no more adjustments to the registry will be made after this point.
+            _registeredServicesTracker.Complete();
+
             // Go through all our registrations and build the component pipeline for each one.
             foreach (var registration in _registeredServicesTracker.Registrations)
             {

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -305,6 +305,12 @@ namespace Autofac.Core.Registration
                                 continue;
                             }
 
+                            if (_ephemeralServiceInfo is object)
+                            {
+                                // Use ephemeral info for additional services.
+                                additionalInfo = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
+                            }
+
                             if (!additionalInfo.IsInitializing)
                             {
                                 BeginServiceInfoInitialization(additionalService, additionalInfo, ExcludeSource(_dynamicRegistrationSources, next));

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -39,6 +39,9 @@ namespace Autofac.Core.Registration
 
         private readonly List<IServiceMiddlewareSource> _servicePipelineSources = new List<IServiceMiddlewareSource>();
 
+        private Dictionary<Service, ServiceRegistrationInfo>? _ephemeralServiceInfo;
+        private bool _trackerPopulationComplete;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultRegisteredServicesTracker"/> class.
         /// </summary>
@@ -93,16 +96,30 @@ namespace Autofac.Core.Registration
             foreach (var service in registration.Services)
             {
                 var info = GetServiceInfo(service);
+
+                // We are in an ephemeral initialization; use the ephemeral set.
+                if (_ephemeralServiceInfo is object)
+                {
+                    info = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
+                }
+
                 info.AddImplementation(registration, preserveDefaults, originatedFromDynamicSource);
             }
 
-            _registrations.Add(registration);
-            var handler = Registered;
-            handler?.Invoke(this, registration);
-
-            if (originatedFromDynamicSource)
+            if (_ephemeralServiceInfo is null)
             {
-                registration.BuildResolvePipeline(this);
+                // Only when we are keeping the populated service information will we store registrations and
+                // build pipelines for them.
+                // The Registrations collection is only available to consumers once the tracker is contained with a ContainerRegistry
+                // and the Complete method has been called.
+                _registrations.Add(registration);
+                var handler = Registered;
+                handler?.Invoke(this, registration);
+
+                if (originatedFromDynamicSource)
+                {
+                    registration.BuildResolvePipeline(this);
+                }
             }
         }
 
@@ -213,6 +230,12 @@ namespace Autofac.Core.Registration
             return list;
         }
 
+        /// <inheritdoc/>
+        public void Complete()
+        {
+            _trackerPopulationComplete = true;
+        }
+
         /// <summary>
         /// Releases unmanaged and - optionally - managed resources.
         /// </summary>
@@ -229,10 +252,24 @@ namespace Autofac.Core.Registration
 
         private ServiceRegistrationInfo GetInitializedServiceInfo(Service service)
         {
+            var createdEphemeralSet = false;
+
             var info = GetServiceInfo(service);
             if (info.IsInitialized)
             {
                 return info;
+            }
+
+            if (!_trackerPopulationComplete)
+            {
+                // We need an ephemeral set for this pre-complete intialization.
+                if (_ephemeralServiceInfo is null)
+                {
+                    _ephemeralServiceInfo = new Dictionary<Service, ServiceRegistrationInfo>();
+                    createdEphemeralSet = true;
+                }
+
+                info = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
             }
 
             var succeeded = false;
@@ -278,7 +315,10 @@ namespace Autofac.Core.Registration
                             }
                         }
 
-                        AddRegistration(provided, true, true);
+                        AddRegistration(
+                            provided,
+                            preserveDefaults: true,
+                            originatedFromDynamicSource: true);
                     }
                 }
 
@@ -296,6 +336,14 @@ namespace Autofac.Core.Registration
                 if (lockTaken)
                 {
                     Monitor.Exit(info);
+                }
+
+                // This method was the entry point to an ephemeral service info initialization.
+                // We need to discard it, so the next set of ephemeral service info is done from scratch.
+                if (createdEphemeralSet)
+                {
+                    _ephemeralServiceInfo?.Clear();
+                    _ephemeralServiceInfo = null;
                 }
             }
 
@@ -329,6 +377,20 @@ namespace Autofac.Core.Registration
         private ServiceRegistrationInfo GetServiceInfo(Service service)
         {
             return _serviceInfo.GetOrAdd(service, RegInfoFactory);
+        }
+
+        private static ServiceRegistrationInfo GetEphemeralServiceInfo(Dictionary<Service, ServiceRegistrationInfo> ephemeralSet, Service service, ServiceRegistrationInfo info)
+        {
+            if (ephemeralSet.TryGetValue(service, out var ephemeral))
+            {
+                return ephemeral;
+            }
+
+            var newCopy = info.CloneUninitialized();
+
+            ephemeralSet.Add(service, newCopy);
+
+            return newCopy;
         }
     }
 }

--- a/src/Autofac/Core/Registration/IRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/IRegisteredServicesTracker.cs
@@ -51,6 +51,12 @@ namespace Autofac.Core.Registration
         event EventHandler<IRegistrationSource> RegistrationSourceAdded;
 
         /// <summary>
+        /// Should be called prior to the construction of a <see cref="ComponentRegistry" /> to
+        /// indicate that the tracker is complete, and requested service information should no longer be ephemeral.
+        /// </summary>
+        void Complete();
+
+        /// <summary>
         /// Gets the registered components.
         /// </summary>
         IEnumerable<IComponentRegistration> Registrations { get; }

--- a/src/Autofac/Core/Registration/ScopeRestrictedRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/ScopeRestrictedRegisteredServicesTracker.cs
@@ -23,12 +23,7 @@ namespace Autofac.Core.Registration
             _restrictedRootScopeLifetime = restrictedRootScopeLifetime;
         }
 
-        /// <summary>
-        /// Adds a registration to the list of registered services.
-        /// </summary>
-        /// <param name="registration">The registration to add.</param>
-        /// <param name="preserveDefaults">Indicates whehter the defaults should be preserved.</param>
-        /// <param name="originatedFromSource">Indicates whether this is an explicitly added registration or that it has been added by a different source.</param>
+        /// <inheritdoc/>
         public override void AddRegistration(IComponentRegistration registration, bool preserveDefaults, bool originatedFromSource = false)
         {
             if (registration == null)

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -72,11 +72,6 @@ namespace Autofac.Core.Registration
         }
 
         /// <summary>
-        /// Gets the target registration of a service redirection applied by a particular piece of middleware.
-        /// </summary>
-        public IComponentRegistration? RedirectionTargetRegistration { get; private set; }
-
-        /// <summary>
         /// Gets or sets a value representing the current initialization depth. Will always be zero for initialized service blocks.
         /// </summary>
         public int InitializationDepth { get; set; }

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -166,7 +166,6 @@ namespace Autofac.Core.Registration
         }
 
         private bool Any =>
-            RedirectionTargetRegistration is object ||
             _defaultImplementations.Count > 0 ||
             _sourceImplementations != null ||
             _preserveDefaultImplementations != null;
@@ -364,6 +363,44 @@ namespace Autofac.Core.Registration
                 // Nothing custom, use an empty pipeline.
                 return ServicePipelines.DefaultServicePipeline;
             }
+        }
+
+        /// <summary>
+        /// Creates a copy of an uninitialized <see cref="ServiceRegistrationInfo"/>, preserving existing registrations and custom middleware.
+        /// </summary>
+        /// <returns>A new service registration info block.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if the service registration has been initialized already.</exception>
+        public ServiceRegistrationInfo CloneUninitialized()
+        {
+            if (InitializationDepth != 0 || IsInitializing || IsInitialized)
+            {
+                throw new InvalidOperationException(ServiceRegistrationInfoResources.NotAfterInitialization);
+            }
+
+            var copy = new ServiceRegistrationInfo(_service)
+            {
+                _fixedRegistration = _fixedRegistration,
+                _defaultImplementation = _defaultImplementation,
+            };
+
+            if (_sourceImplementations is object)
+            {
+                copy._sourceImplementations = new List<IComponentRegistration>(_sourceImplementations);
+            }
+
+            if (_preserveDefaultImplementations is object)
+            {
+                copy._preserveDefaultImplementations = new List<IComponentRegistration>(_preserveDefaultImplementations);
+            }
+
+            copy._defaultImplementations.AddRange(_defaultImplementations);
+
+            if (_customPipelineBuilder is object)
+            {
+                copy._customPipelineBuilder = _customPipelineBuilder.Clone();
+            }
+
+            return copy;
         }
 
         /// <inheritdoc/>

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfoResources.Designer.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfoResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Autofac.Core.Registration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The operation is only valid before the object is initialized..
+        /// </summary>
+        internal static string NotAfterInitialization {
+            get {
+                return ResourceManager.GetString("NotAfterInitialization", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The operation is only valid during initialization..
         /// </summary>
         internal static string NotDuringInitialization {

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfoResources.resx
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfoResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="NotAfterInitialization" xml:space="preserve">
+    <value>The operation is only valid before the object is initialized.</value>
+  </data>
   <data name="NotDuringInitialization" xml:space="preserve">
     <value>The operation is only valid during initialization.</value>
   </data>

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -1208,6 +1208,82 @@ namespace Autofac.Specification.Test.Features
             Assert.True(implementation.Started);
         }
 
+        [Fact]
+        public void OpenGenericCanBeDecoratedFromInsideAModuleDecoratorRegisteredFirst()
+        {
+            var activatedInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterModule(new MyModule(b => b.RegisterGenericDecorator(typeof(GenericDecorator<>), typeof(IGenericService<>))));
+
+            builder.RegisterGeneric(typeof(GenericComponent<>)).As(typeof(IGenericService<>));
+
+            var container = builder.Build();
+
+            var instance = container.Resolve<IGenericService<int>>();
+
+            Assert.IsType<GenericDecorator<int>>(instance);
+            Assert.IsType<GenericComponent<int>>(((GenericDecorator<int>)instance).Decorated);
+        }
+
+        [Fact]
+        public void OpenGenericCanBeDecoratedFromInsideAModuleDecoratorRegisteredSecond()
+        {
+            var activatedInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterGeneric(typeof(GenericComponent<>)).As(typeof(IGenericService<>));
+
+            builder.RegisterModule(new MyModule(b => b.RegisterGenericDecorator(typeof(GenericDecorator<>), typeof(IGenericService<>))));
+
+            var container = builder.Build();
+
+            var instance = container.Resolve<IGenericService<int>>();
+
+            Assert.IsType<GenericDecorator<int>>(instance);
+            Assert.IsType<GenericComponent<int>>(((GenericDecorator<int>)instance).Decorated);
+        }
+
+        [Fact]
+        public void OpenGenericInModuleCanBeDecoratoredByDecoratorOutsideModuleWhereModuleRegisteredFirst()
+        {
+            var activatedInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterModule(new MyModule(b => b.RegisterGeneric(typeof(GenericComponent<>)).As(typeof(IGenericService<>))));
+
+            builder.RegisterGenericDecorator(typeof(GenericDecorator<>), typeof(IGenericService<>));
+
+            var container = builder.Build();
+
+            var instance = container.Resolve<IGenericService<int>>();
+
+            Assert.IsType<GenericDecorator<int>>(instance);
+            Assert.IsType<GenericComponent<int>>(((GenericDecorator<int>)instance).Decorated);
+        }
+
+        [Fact]
+        public void OpenGenericInModuleCanBeDecoratoredByDecoratorOutsideModuleWhereModuleRegisteredSecond()
+        {
+            var activatedInstances = new List<object>();
+
+            var builder = new ContainerBuilder();
+
+            builder.RegisterGenericDecorator(typeof(GenericDecorator<>), typeof(IGenericService<>));
+
+            builder.RegisterModule(new MyModule(b => b.RegisterGeneric(typeof(GenericComponent<>)).As(typeof(IGenericService<>))));
+
+            var container = builder.Build();
+
+            var instance = container.Resolve<IGenericService<int>>();
+
+            Assert.IsType<GenericDecorator<int>>(instance);
+            Assert.IsType<GenericComponent<int>>(((GenericDecorator<int>)instance).Decorated);
+        }
+
         private class MyMetadata
         {
             public int A { get; set; }
@@ -1379,6 +1455,39 @@ namespace Autofac.Specification.Test.Features
             {
                 Decorated.Start();
             }
+        }
+
+        private class MyModule : Module
+        {
+            private readonly Action<ContainerBuilder> _callback;
+
+            public MyModule(Action<ContainerBuilder> callback)
+            {
+                _callback = callback;
+            }
+
+            protected override void Load(ContainerBuilder builder)
+            {
+                _callback(builder);
+            }
+        }
+
+        private interface IGenericService<T>
+        {
+        }
+
+        private class GenericComponent<T> : IGenericService<T>
+        {
+        }
+
+        private class GenericDecorator<T> : IGenericService<T>
+        {
+            public GenericDecorator(IGenericService<T> decorated)
+            {
+                Decorated = decorated;
+            }
+
+            public IGenericService<T> Decorated { get; }
         }
     }
 }

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -129,6 +129,78 @@ namespace Autofac.Specification.Test.Registration
         }
 
         [Fact]
+        public void IfNotRegistered_CanBeDecoratedByModuleWhenModuleRegistered1st()
+        {
+            var builder = new ContainerBuilder();
+
+            var module = new MyModule(build =>
+            {
+                build.RegisterDecorator<Decorator, IService>();
+            });
+
+            builder.RegisterModule(module);
+            builder.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
+
+            var container = builder.Build();
+            var result = container.Resolve<IService>();
+            Assert.IsType<Decorator>(result);
+        }
+
+        [Fact]
+        public void IfNotRegistered_CanBeDecoratedByModuleWhenModuleRegistered2nd()
+        {
+            var builder = new ContainerBuilder();
+
+            var module = new MyModule(build =>
+            {
+                build.RegisterDecorator<Decorator, IService>();
+            });
+
+            builder.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
+            builder.RegisterModule(module);
+
+            var container = builder.Build();
+            var result = container.Resolve<IService>();
+            Assert.IsType<Decorator>(result);
+        }
+
+        [Fact]
+        public void IfNotRegistered_ConditionalInModuleIsDecoratedWhenModuleRegistered1st()
+        {
+            var builder = new ContainerBuilder();
+
+            var module = new MyModule(build =>
+            {
+                build.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
+            });
+
+            builder.RegisterModule(module);
+            builder.RegisterDecorator<Decorator, IService>();
+
+            var container = builder.Build();
+            var result = container.Resolve<IService>();
+            Assert.IsType<Decorator>(result);
+        }
+
+        [Fact]
+        public void IfNotRegistered_ConditionalInModuleIsDecoratedWhenModuleRegistered2nd()
+        {
+            var builder = new ContainerBuilder();
+
+            var module = new MyModule(build =>
+            {
+                build.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
+            });
+
+            builder.RegisterDecorator<Decorator, IService>();
+            builder.RegisterModule(module);
+
+            var container = builder.Build();
+            var result = container.Resolve<IService>();
+            Assert.IsType<Decorator>(result);
+        }
+
+        [Fact]
         public void OnlyIf_CanFilterEnumerableServices()
         {
             var builder = new ContainerBuilder();
@@ -252,6 +324,21 @@ namespace Autofac.Specification.Test.Registration
 
         public class MultiServiceGeneric<T> : IService<T>, IService2<T>
         {
+        }
+
+        public class MyModule : Module
+        {
+            private readonly Action<ContainerBuilder> _callback;
+
+            public MyModule(Action<ContainerBuilder> callback)
+            {
+                _callback = callback;
+            }
+
+            protected override void Load(ContainerBuilder builder)
+            {
+                _callback(builder);
+            }
         }
     }
 }

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -99,7 +99,7 @@ namespace Autofac.Specification.Test.Registration
         {
             var builder = new ContainerBuilder();
             builder.RegisterGeneric(typeof(MultiServiceGeneric<>)).As(typeof(IService<>)).As(typeof(IService2<>));
-            builder.RegisterGeneric(typeof(MultiServiceGeneric<>)).As(typeof(IService<>)).IfNotRegistered(typeof(IService2<int>));
+            builder.RegisterGeneric(typeof(MultiServiceGeneric2<>)).As(typeof(IService<>)).IfNotRegistered(typeof(IService2<int>));
             var container = builder.Build();
 
             var result = container.Resolve<IService<int>>();
@@ -323,6 +323,10 @@ namespace Autofac.Specification.Test.Registration
         }
 
         public class MultiServiceGeneric<T> : IService<T>, IService2<T>
+        {
+        }
+
+        public class MultiServiceGeneric2<T> : IService<T>, IService2<T>
         {
         }
 

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -61,6 +61,16 @@ namespace Autofac.Specification.Test.Registration
         }
 
         [Fact]
+        public void IfNotRegistered_CanFilterAndRegisterMultipleServices()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ServiceMulti>().As<IService>().As<IService2>().IfNotRegistered(typeof(IService));
+            var container = builder.Build();
+            Assert.IsType<ServiceMulti>(container.Resolve<IService>());
+            Assert.IsType<ServiceMulti>(container.Resolve<IService2>());
+        }
+
+        [Fact]
         public void IfNotRegistered_CanBeDecorated()
         {
             // Order here is important - the IfNotRegistered needs to happen
@@ -82,6 +92,20 @@ namespace Autofac.Specification.Test.Registration
 
             var result = container.Resolve<SimpleGeneric<int>>();
             Assert.IsType<SimpleGeneric<int>>(result);
+        }
+
+        [Fact]
+        public void IfNotRegistered_CanConditionGenericServiceWithMultipleInterfaces()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterGeneric(typeof(MultiServiceGeneric<>)).As(typeof(IService<>)).As(typeof(IService2<>)).IfNotRegistered(typeof(SimpleGeneric<int>));
+            var container = builder.Build();
+
+            var result = container.Resolve<IService<int>>();
+            Assert.IsType<MultiServiceGeneric<int>>(result);
+
+            var result2 = container.Resolve<IService2<int>>();
+            Assert.IsType<MultiServiceGeneric<int>>(result);
         }
 
         [Fact]
@@ -209,7 +233,23 @@ namespace Autofac.Specification.Test.Registration
         {
         }
 
+        public interface IService2
+        {
+        }
+
+        public class ServiceMulti : IService, IService2
+        {
+        }
+
         public class SimpleGeneric<T>
+        {
+        }
+
+        public interface IService2<T>
+        {
+        }
+
+        public class MultiServiceGeneric<T> : IService<T>, IService2<T>
         {
         }
     }

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -98,14 +98,15 @@ namespace Autofac.Specification.Test.Registration
         public void IfNotRegistered_CanConditionGenericServiceWithMultipleInterfaces()
         {
             var builder = new ContainerBuilder();
-            builder.RegisterGeneric(typeof(MultiServiceGeneric<>)).As(typeof(IService<>)).As(typeof(IService2<>)).IfNotRegistered(typeof(SimpleGeneric<int>));
+            builder.RegisterGeneric(typeof(MultiServiceGeneric<>)).As(typeof(IService<>)).As(typeof(IService2<>));
+            builder.RegisterGeneric(typeof(MultiServiceGeneric<>)).As(typeof(IService<>)).IfNotRegistered(typeof(IService2<int>));
             var container = builder.Build();
 
             var result = container.Resolve<IService<int>>();
             Assert.IsType<MultiServiceGeneric<int>>(result);
 
             var result2 = container.Resolve<IService2<int>>();
-            Assert.IsType<MultiServiceGeneric<int>>(result);
+            Assert.IsType<MultiServiceGeneric<int>>(result2);
         }
 
         [Fact]


### PR DESCRIPTION
This change constructs a temporary set of `ServiceRegistrationInfo` for calls to `GetInitializedServiceInfo` that take place during the build callbacks that populate the `DefaultRegisteredServicesTracker`.

Marginal extra performance cost to `IfNotRegistered` calls at container build time to allocate a new set, and the overhead of evaluating sources multiple times, but once the tracker is marked as `Complete`, the only extra cost is a single boolean flag check the first time we initialize a `ServiceRegistrationInfo`. No concurrency issues expected, because the Container Build process is always a single-threaded operation anyway.

Fixes #1217.  Also added a test for conditional registrations based on dynamic sources, and on service middleware.

Any suggestions of additional test cases would be most welcome.