### PR TITLE
fix: make sure that constructor-binder detects illegal parameter when parameter is by ref

### DIFF
--- a/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
@@ -161,7 +161,8 @@ namespace Autofac.Core.Activators.Reflection
         {
             for (var idx = 0; idx < constructorArgs.Length; idx++)
             {
-                if (constructorArgs[idx].ParameterType.IsPointer)
+                var arg = constructorArgs[idx].ParameterType;
+                if (arg.IsPointer || arg.IsByRef)
                 {
                     // Boo.
                     return constructorArgs[idx];


### PR DESCRIPTION
If I understood correctly, this should fix the issue described in #1226 