### PR TITLE
Fix issue 215

### DIFF
--- a/src/Autofac/Features/Scanning/BaseScanningActivatorData.cs
+++ b/src/Autofac/Features/Scanning/BaseScanningActivatorData.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Autofac.Builder;
+using Autofac.Core.Registration;
+
+namespace Autofac.Features.Scanning
+{
+    /// <summary>
+    /// Base activation data for types located by scanning assemblies.
+    /// </summary>
+    public abstract class BaseScanningActivatorData<TActivatorData, TRegistrationStyle> : ReflectionActivatorData
+        where TActivatorData : ReflectionActivatorData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseScanningActivatorData{TActivatorData, TRegistrationStyle}"/> class.
+        /// </summary>
+        /// <param name="configurationActions">Additional actions to be performed on the concrete type registration.</param>
+        protected BaseScanningActivatorData(
+            ICollection<Action<Type, IRegistrationBuilder<object, TActivatorData, TRegistrationStyle>>> configurationActions)
+            : base(typeof(object))
+        {
+            ConfigurationActions = configurationActions;
+        }
+
+        /// <summary>
+        /// Gets the additional actions to be performed on the concrete type registrations.
+        /// </summary>
+        public ICollection<Action<Type, IRegistrationBuilder<object, TActivatorData, TRegistrationStyle>>> ConfigurationActions { get; }
+
+        /// <summary>
+        /// Gets the filters applied to the types from the scanned assembly.
+        /// </summary>
+        public ICollection<Func<Type, bool>> Filters { get; } = new List<Func<Type, bool>>();
+
+        /// <summary>
+        /// Gets the actions to be called once the scanning operation is complete.
+        /// </summary>
+        public ICollection<Action<IComponentRegistryBuilder>> PostScanningCallbacks { get; } = new List<Action<IComponentRegistryBuilder>>();
+    }
+}

--- a/src/Autofac/Features/Scanning/OpenGenericScanningActivatorData.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningActivatorData.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Autofac.Builder;
+using Autofac.Core.Registration;
+
+namespace Autofac.Features.Scanning
+{
+    /// <summary>
+    /// Activation data for open generic types located by scanning assemblies.
+    /// </summary>
+    public class OpenGenericScanningActivatorData : ReflectionActivatorData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenGenericScanningActivatorData"/> class.
+        /// </summary>
+        public OpenGenericScanningActivatorData()
+            : base(typeof(object))
+        {
+        }
+
+        /// <summary>
+        /// Gets the filters applied to the types from the scanned assembly.
+        /// </summary>
+        public ICollection<Func<Type, bool>> Filters { get; } = new List<Func<Type, bool>>();
+
+        /// <summary>
+        /// Gets the additional actions to be performed on the concrete type registrations.
+        /// </summary>
+        public ICollection<Action<Type, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>>> ConfigurationActions { get; }
+            = new List<Action<Type, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>>>();
+
+        /// <summary>
+        /// Gets the actions to be called once the scanning operation is complete.
+        /// </summary>
+        public ICollection<Action<IComponentRegistryBuilder>> PostScanningCallbacks { get; } = new List<Action<IComponentRegistryBuilder>>();
+    }
+}

--- a/src/Autofac/Features/Scanning/OpenGenericScanningActivatorData.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningActivatorData.cs
@@ -4,37 +4,20 @@
 using System;
 using System.Collections.Generic;
 using Autofac.Builder;
-using Autofac.Core.Registration;
 
 namespace Autofac.Features.Scanning
 {
     /// <summary>
     /// Activation data for open generic types located by scanning assemblies.
     /// </summary>
-    public class OpenGenericScanningActivatorData : ReflectionActivatorData
+    public class OpenGenericScanningActivatorData : BaseScanningActivatorData<ReflectionActivatorData, DynamicRegistrationStyle>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenGenericScanningActivatorData"/> class.
         /// </summary>
         public OpenGenericScanningActivatorData()
-            : base(typeof(object))
+            : base(new List<Action<Type, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>>>())
         {
         }
-
-        /// <summary>
-        /// Gets the filters applied to the types from the scanned assembly.
-        /// </summary>
-        public ICollection<Func<Type, bool>> Filters { get; } = new List<Func<Type, bool>>();
-
-        /// <summary>
-        /// Gets the additional actions to be performed on the concrete type registrations.
-        /// </summary>
-        public ICollection<Action<Type, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>>> ConfigurationActions { get; }
-            = new List<Action<Type, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>>>();
-
-        /// <summary>
-        /// Gets the actions to be called once the scanning operation is complete.
-        /// </summary>
-        public ICollection<Action<IComponentRegistryBuilder>> PostScanningCallbacks { get; } = new List<Action<IComponentRegistryBuilder>>();
     }
 }

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Core.Registration;
+using Autofac.Features.OpenGenerics;
+using Autofac.Util;
+
+namespace Autofac.Features.Scanning
+{
+    /// <summary>
+    /// Helper methods to assist in scanning open generic registration.
+    /// </summary>
+    internal static class OpenGenericScanningRegistrationExtensions
+    {
+        /// <summary>
+        /// Register open generic types from the specified assemblies.
+        /// </summary>
+        /// <param name="builder">The container builder.</param>
+        /// <param name="assemblies">The set of assemblies.</param>
+        /// <returns>A registration builder.</returns>
+        public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            RegisterOpenGenericAssemblyTypes(ContainerBuilder builder, params Assembly[] assemblies)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (assemblies == null)
+            {
+                throw new ArgumentNullException(nameof(assemblies));
+            }
+
+            var rb = new RegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>(
+                new TypedService(typeof(object)),
+                new OpenGenericScanningActivatorData(),
+                new DynamicRegistrationStyle());
+
+            rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => ScanAssemblies(assemblies, cr, rb));
+
+            return rb;
+        }
+
+        private static void ScanAssemblies(IEnumerable<Assembly> assemblies, IComponentRegistryBuilder cr, IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> rb)
+        {
+            ScanTypes(assemblies.SelectMany(a => a.GetLoadableTypes()), cr, rb);
+        }
+
+        private static void ScanTypes(IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> rb)
+        {
+            rb.ActivatorData.Filters.Add(t =>
+                rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
+                    t.IsOpenGenericTypeOf(swt.ServiceType)));
+
+            // Issue #897: For back compat reasons we can't filter out
+            // non-public types here. Folks use assembly scanning on their
+            // own stuff, so encapsulation is a tricky thing to manage.
+            // If people want only public types, a LINQ Where clause can be used.
+            foreach (var t in types
+                .Where(t =>
+                    t.IsClass &&
+                    !t.IsAbstract &&
+                    t.IsGenericTypeDefinition &&
+                    !t.IsDelegate() &&
+                    rb.ActivatorData.Filters.All(p => p(t)) &&
+                    !t.IsCompilerGenerated()))
+            {
+                var scanned = new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
+                    new TypedService(t),
+                    new ReflectionActivatorData(t),
+                    new DynamicRegistrationStyle());
+
+                scanned
+                    .FindConstructorsWith(rb.ActivatorData.ConstructorFinder)
+                    .UsingConstructor(rb.ActivatorData.ConstructorSelector)
+                    .WithParameters(rb.ActivatorData.ConfiguredParameters)
+                    .WithProperties(rb.ActivatorData.ConfiguredProperties);
+
+                // Copy middleware from the scanning registration.
+                scanned.ResolvePipeline.UseRange(rb.ResolvePipeline.Middleware);
+
+                scanned.RegistrationData.CopyFrom(rb.RegistrationData, false);
+
+                foreach (var action in rb.ActivatorData.ConfigurationActions)
+                {
+                    action(t, scanned);
+                }
+
+                if (scanned.RegistrationData.Services.Any())
+                {
+                    cr.AddRegistrationSource(new OpenGenericRegistrationSource(scanned.RegistrationData, scanned.ResolvePipeline, scanned.ActivatorData));
+                }
+            }
+
+            foreach (var postScanningCallback in rb.ActivatorData.PostScanningCallbacks)
+            {
+                postScanningCallback(cr);
+            }
+        }
+
+        /// <summary>
+        /// Specifies how an open generic type from a scanned assembly is mapped to a service.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="serviceMapping">Function mapping types to services.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            As<TLimit, TRegistrationStyle>(
+                IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, IEnumerable<Service>> serviceMapping)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            if (serviceMapping == null)
+            {
+                throw new ArgumentNullException(nameof(serviceMapping));
+            }
+
+            registration.ActivatorData.ConfigurationActions.Add((t, rb) =>
+            {
+                var mapped = serviceMapping(t);
+                var impl = rb.ActivatorData.ImplementationType;
+                var applied = mapped.Where(s =>
+                {
+                    if (s is IServiceWithType c)
+                    {
+                        return impl.IsOpenGenericTypeOf(c.ServiceType);
+                    }
+
+                    return s != null;
+                });
+                rb.As(applied.ToArray());
+            });
+
+            return registration;
+        }
+
+        /// <summary>
+        /// Filters the scanned open generic types to exclude the provided type.
+        /// </summary>
+        /// <param name="registration">Registration to filter types from.</param>
+        /// <param name="openGenericType">The open generic type to exclude.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            Except(this IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration, Type openGenericType)
+        {
+            return registration.Where(t => t != openGenericType);
+        }
+
+        /// <summary>
+        /// Filters the scanned open generic types to exclude the provided type, providing specific configuration for
+        /// the excluded type.
+        /// </summary>
+        /// <param name="registration">Registration to filter types from.</param>
+        /// <param name="openGenericType">The concrete type to exclude.</param>
+        /// <param name="customizedRegistration">Registration for the excepted type.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            Except(
+                this IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration,
+                Type openGenericType,
+                Action<IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>> customizedRegistration)
+        {
+            var result = registration.Except(openGenericType);
+
+            result.ActivatorData.PostScanningCallbacks.Add(cr =>
+            {
+                var rb = new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
+                    new TypedService(openGenericType),
+                    new ReflectionActivatorData(openGenericType),
+                    new DynamicRegistrationStyle());
+
+                customizedRegistration(rb);
+
+                cr.AddRegistrationSource(new OpenGenericRegistrationSource(rb.RegistrationData, rb.ResolvePipeline, rb.ActivatorData));
+            });
+
+            return result;
+        }
+    }
+}

--- a/src/Autofac/Features/Scanning/ScanningActivatorData.cs
+++ b/src/Autofac/Features/Scanning/ScanningActivatorData.cs
@@ -4,37 +4,20 @@
 using System;
 using System.Collections.Generic;
 using Autofac.Builder;
-using Autofac.Core.Registration;
 
 namespace Autofac.Features.Scanning
 {
     /// <summary>
     /// Activation data for types located by scanning assemblies.
     /// </summary>
-    public class ScanningActivatorData : ReflectionActivatorData
+    public class ScanningActivatorData : BaseScanningActivatorData<ConcreteReflectionActivatorData, SingleRegistrationStyle>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ScanningActivatorData"/> class.
         /// </summary>
         public ScanningActivatorData()
-            : base(typeof(object))
+            : base(new List<Action<Type, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>>())
         {
         }
-
-        /// <summary>
-        /// Gets the filters applied to the types from the scanned assembly.
-        /// </summary>
-        public ICollection<Func<Type, bool>> Filters { get; } = new List<Func<Type, bool>>();
-
-        /// <summary>
-        /// Gets the additional actions to be performed on the concrete type registrations.
-        /// </summary>
-        public ICollection<Action<Type, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>> ConfigurationActions { get; }
-            = new List<Action<Type, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>>>();
-
-        /// <summary>
-        /// Gets the actions to be called once the scanning operation is complete.
-        /// </summary>
-        public ICollection<Action<IComponentRegistryBuilder>> PostScanningCallbacks { get; } = new List<Action<IComponentRegistryBuilder>>();
     }
 }

--- a/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Features.Scanning;
+using Autofac.Util;
+
+namespace Autofac
+{
+    /// <summary>
+    /// Adds registration syntax to the <see cref="ContainerBuilder"/> type.
+    /// </summary>
+    [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
+    public static partial class RegistrationExtensions
+    {
+        /// <summary>
+        /// Register all open generic types in an assembly.
+        /// </summary>
+        /// <param name="builder">Container builder.</param>
+        /// <param name="assemblies">The assemblies from which to register open generic types.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        [RequiresUnreferencedCode(AssemblyScanningWarning)]
+        public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            RegisterAssemblyOpenGenericTypes(this ContainerBuilder builder, params Assembly[] assemblies)
+        {
+            return OpenGenericScanningRegistrationExtensions.RegisterOpenGenericAssemblyTypes(builder, assemblies);
+        }
+
+        /// <summary>
+        /// Specifies how an open generic type from a scanned assembly is mapped to services.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="serviceMapping">Function mapping types to services.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            As<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, IEnumerable<Service>> serviceMapping)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            if (serviceMapping == null)
+            {
+                throw new ArgumentNullException(nameof(serviceMapping));
+            }
+
+            return OpenGenericScanningRegistrationExtensions.As(registration, serviceMapping);
+        }
+
+        /// <summary>
+        /// Specifies how an open generic type from a scanned assembly is mapped to a service.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="serviceMapping">Function mapping types to services.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            As<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, Service> serviceMapping)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            return registration.As(t => new[] { serviceMapping(t) });
+        }
+
+        /// <summary>
+        /// Specifies how an open generic type from a scanned assembly is mapped to a type.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="serviceMapping">Function mapping types to services.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            As<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, Type> serviceMapping)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            return registration.As(t => new TypedService(serviceMapping(t)));
+        }
+
+        /// <summary>
+        /// Specifies how a type from a scanned assembly is mapped to types.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="serviceMapping">Function mapping types to services.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            As<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, IEnumerable<Type>> serviceMapping)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            return registration.As(t => serviceMapping(t).Select(s => (Service)new TypedService(s)));
+        }
+
+        /// <summary>
+        /// Specifies that an open generic type from a scanned assembly provides its own open generic type as a service.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            AsSelf<TLimit>(this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            return registration.As(t => t);
+        }
+
+        /// <summary>
+        /// Specifies a subset of open generic types to register from a scanned assembly.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to filter types from.</param>
+        /// <param name="predicate">Predicate that returns true for types to register.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            Where<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, bool> predicate)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            registration.ActivatorData.Filters.Add(predicate);
+            return registration;
+        }
+    }
+}

--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -183,6 +183,45 @@ namespace Autofac.Util
         }
 
         /// <summary>
+        /// Checks whether this type is an open generic type of a given type.
+        /// </summary>
+        /// <param name="this">The type we are checking.</param>
+        /// <param name="type">The open generic type to validate against.</param>
+        /// <returns>True if <paramref name="this"/> is a closed type of <paramref name="type"/>. False otherwise.</returns>
+        public static bool IsOpenGenericTypeOf(this Type @this, Type type)
+        {
+            if (@this == null || type == null)
+            {
+                return false;
+            }
+
+            if (@this == type)
+            {
+                return true;
+            }
+
+            return @this == type
+              || @this.CheckBaseTypeIsOpenGenericTypeOf(type)
+              || @this
+                  .GetInterfaces()
+                  .Any(it => it.IsGenericType
+                    ? it.GetGenericTypeDefinition().IsOpenGenericTypeOf(type)
+                    : it.IsOpenGenericTypeOf(type));
+        }
+
+        private static bool CheckBaseTypeIsOpenGenericTypeOf(this Type @this, Type type)
+        {
+            if (@this.BaseType == null)
+            {
+                return false;
+            }
+
+            return @this.BaseType.IsGenericType
+                ? @this.BaseType.GetGenericTypeDefinition().IsOpenGenericTypeOf(type)
+                : @this.BaseType.IsOpenGenericTypeOf(type);
+        }
+
+        /// <summary>
         /// Looks for an interface on the candidate type that closes the provided open generic interface type.
         /// </summary>
         /// <param name="candidateType">The type that is being checked for the interface.</param>

--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -186,11 +186,16 @@ namespace Autofac.Util
         /// Checks whether this type is an open generic type of a given type.
         /// </summary>
         /// <param name="this">The type we are checking.</param>
-        /// <param name="type">The open generic type to validate against.</param>
-        /// <returns>True if <paramref name="this"/> is a closed type of <paramref name="type"/>. False otherwise.</returns>
+        /// <param name="type">The type to validate against.</param>
+        /// <returns>True if <paramref name="this"/> is a open generic type of <paramref name="type"/>. False otherwise.</returns>
         public static bool IsOpenGenericTypeOf(this Type @this, Type type)
         {
             if (@this == null || type == null)
+            {
+                return false;
+            }
+
+            if (!@this.IsGenericTypeDefinition)
             {
                 return false;
             }
@@ -200,13 +205,8 @@ namespace Autofac.Util
                 return true;
             }
 
-            return @this == type
-              || @this.CheckBaseTypeIsOpenGenericTypeOf(type)
-              || @this
-                  .GetInterfaces()
-                  .Any(it => it.IsGenericType
-                    ? it.GetGenericTypeDefinition().IsOpenGenericTypeOf(type)
-                    : it.IsOpenGenericTypeOf(type));
+            return @this.CheckBaseTypeIsOpenGenericTypeOf(type)
+              || @this.CheckInterfacesAreOpenGenericTypeOf(type);
         }
 
         private static bool CheckBaseTypeIsOpenGenericTypeOf(this Type @this, Type type)
@@ -218,7 +218,16 @@ namespace Autofac.Util
 
             return @this.BaseType.IsGenericType
                 ? @this.BaseType.GetGenericTypeDefinition().IsOpenGenericTypeOf(type)
-                : @this.BaseType.IsOpenGenericTypeOf(type);
+                : type.IsAssignableFrom(@this.BaseType);
+        }
+
+        private static bool CheckInterfacesAreOpenGenericTypeOf(this Type @this, Type type)
+        {
+            var interfaces = @this.GetInterfaces().ToList();
+            return @this.GetInterfaces()
+                .Any(it => it.IsGenericType
+                    ? it.GetGenericTypeDefinition().IsOpenGenericTypeOf(type)
+                    : type.IsAssignableFrom(it));
         }
 
         /// <summary>

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/DeleteOpenGenericCommand.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/DeleteOpenGenericCommand.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public class DeleteOpenGenericCommand<T> : CommandBase<T>
+    {
+        public override void Execute(T data)
+        {
+        }
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/IOpenGenericAService.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/IOpenGenericAService.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public interface IOpenGenericAService<T>
+    {
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/IOpenGenericBService.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/IOpenGenericBService.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public interface IOpenGenericBService<T>
+    {
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/OpenGenericA2Component.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/OpenGenericA2Component.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public class OpenGenericA2Component<T> : IOpenGenericAService<T>, IOpenGenericBService<T>
+    {
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/RedoOpenGenericCommand.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/RedoOpenGenericCommand.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public class RedoOpenGenericCommand<T> : CommandBase<T>
+    {
+        public override void Execute(T data)
+        {
+        }
+    }
+}

--- a/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
@@ -50,7 +50,6 @@ namespace Autofac.Test.Features.Scanning
         {
             var cb = new ContainerBuilder();
             cb.RegisterAssemblyOpenGenericTypes(typeof(AComponent).GetTypeInfo().Assembly)
-                .Where(t => t.Name.StartsWith("Re"))
                 .Where(t => t.Name.StartsWith("Redo"));
             var c = cb.Build();
 

--- a/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Autofac.Core;
+using Autofac.Core.Lifetime;
+using Autofac.Core.Registration;
+using Autofac.Features.Scanning;
+using Autofac.Test.Scenarios.ScannedAssembly;
+using Xunit;
+
+namespace Autofac.Test.Features.Scanning
+{
+    public class OpenGenericScanningRegistrationTests
+    {
+        private static readonly Assembly ScenarioAssembly = typeof(AComponent).GetTypeInfo().Assembly;
+
+        [Fact]
+        public void WhenAssemblyIsScannedOpenGenericTypesCanBeResolved()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(AComponent).GetTypeInfo().Assembly);
+            var c = cb.Build();
+
+            Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
+
+            c.AssertRegistered<RedoOpenGenericCommand<int>>();
+            c.AssertSharing<RedoOpenGenericCommand<int>>(InstanceSharing.None);
+            c.AssertLifetime<RedoOpenGenericCommand<int>, CurrentScopeLifetime>();
+            c.AssertOwnership<RedoOpenGenericCommand<int>>(InstanceOwnership.OwnedByLifetimeScope);
+        }
+
+        [Fact]
+        public void WhenOpenGenericTypesRegisteredAsSelfConcreteTypeIsService()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(AComponent).GetTypeInfo().Assembly)
+                .AsSelf();
+            var c = cb.Build();
+
+            Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
+
+            c.AssertRegistered<RedoOpenGenericCommand<int>>();
+        }
+
+        [Fact]
+        public void WhenFiltersAppliedNonMatchingOpenGenericTypesExcluded()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(AComponent).GetTypeInfo().Assembly)
+                .Where(t => t.Name.StartsWith("Re"))
+                .Where(t => t.Name.StartsWith("Redo"));
+            var c = cb.Build();
+
+            Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
+            Assert.Throws<ComponentNotRegisteredException>(() => c.Resolve<DeleteOpenGenericCommand<int>>());
+
+            c.AssertRegistered<RedoOpenGenericCommand<int>>();
+            c.AssertNotRegistered<DeleteOpenGenericCommand<int>>();
+        }
+
+        [Fact]
+        public void WhenTypedServicesAreSpecifiedImplicitFilterApplied()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(A2Component).GetTypeInfo().Assembly)
+                .As(typeof(IOpenGenericAService<>));
+            var c = cb.Build();
+
+            // Without the filter this line would throw anyway
+            var a = c.Resolve<IEnumerable<IOpenGenericAService<int>>>();
+            Assert.Single(a);
+        }
+
+        [Fact]
+        public void WhenMappingToMultipleTypedServicesEachExposedAsService()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(A2Component).GetTypeInfo().Assembly)
+                .As(t => t.GetInterfaces().Where(i => i.IsGenericType).Select(i => i.GetGenericTypeDefinition()));
+            var c = cb.Build();
+
+            Assert.NotNull(c.Resolve<IOpenGenericAService<int>>());
+            Assert.NotNull(c.Resolve<IOpenGenericBService<int>>());
+        }
+
+        [Fact]
+        public void WhenExceptionsProvideConfigurationComponentConfiguredAppropriately()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(ScenarioAssembly)
+                .Except(typeof(RedoOpenGenericCommand<>), ac => ac.SingleInstance());
+            var c = cb.Build();
+
+            var a1 = c.Resolve<RedoOpenGenericCommand<int>>();
+            var a2 = c.Resolve<RedoOpenGenericCommand<int>>();
+            Assert.Same(a1, a2);
+        }
+    }
+}

--- a/test/Autofac.Test/Util/InternalTypeExtensionsTests.cs
+++ b/test/Autofac.Test/Util/InternalTypeExtensionsTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Xunit;
+
+using InternalTypeExtensions = Autofac.Util.TypeExtensions;
+
+namespace Autofac.Test.Util
+{
+    public class InternalTypeExtensionsTests
+    {
+        [Theory]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(Derived<>))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(Base<>))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(IChildInterface<>))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(IChildInterface))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(IParentsInterface<>))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(IParentsInterface))]
+        [InlineData(typeof(OpenGenericInheritNonGenericBase<>), typeof(Derived))]
+        [InlineData(typeof(OpenGenericInheritNonGenericBase<>), typeof(Base))]
+        public void IsOpenGenericTypeOf_Should_Return_True(Type openGenericType, Type typeToValidate)
+        {
+            Assert.True(InternalTypeExtensions.IsOpenGenericTypeOf(openGenericType, typeToValidate));
+        }
+
+        private class Base
+        {
+        }
+
+        private class Base<T>
+        {
+        }
+
+        private class Derived : Base
+        {
+        }
+
+        private class Derived<T> : Base<T>
+        {
+        }
+
+        private interface IParentsInterface
+        {
+        }
+
+        private interface IParentsInterface<T>
+        {
+        }
+
+        private interface IChildInterface : IParentsInterface
+        {
+        }
+
+        private interface IChildInterface<T> : IParentsInterface<T>
+        {
+        }
+
+        private class OpenGenericInheritNonGenericBase<T> : Derived, IChildInterface<int>
+        {
+        }
+
+        private class OpenGenericInheritOpenGenericBase<T> : Derived<T>, IChildInterface<T>, IChildInterface
+        {
+        }
+    }
+}

--- a/test/Autofac.Test/Util/InternalTypeExtensionsTests.cs
+++ b/test/Autofac.Test/Util/InternalTypeExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using Autofac.Test.Scenarios.ScannedAssembly;
 using Xunit;
 
 using InternalTypeExtensions = Autofac.Util.TypeExtensions;
@@ -22,6 +23,19 @@ namespace Autofac.Test.Util
         public void IsOpenGenericTypeOf_Should_Return_True(Type openGenericType, Type typeToValidate)
         {
             Assert.True(InternalTypeExtensions.IsOpenGenericTypeOf(openGenericType, typeToValidate));
+        }
+
+        [Theory]
+        [InlineData(typeof(Derived<>), typeof(OpenGenericInheritOpenGenericBase<>))]
+        [InlineData(typeof(IChildInterface<>), typeof(OpenGenericInheritOpenGenericBase<>))]
+        [InlineData(typeof(IChildInterface), typeof(OpenGenericInheritOpenGenericBase<>))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(int))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(ICommand<>))]
+        [InlineData(typeof(OpenGenericInheritOpenGenericBase<>), typeof(RedoOpenGenericCommand<>))]
+        [InlineData(typeof(Derived), typeof(Base))]
+        public void IsOpenGenericTypeOf_Should_Return_False(Type openGenericType, Type typeToValidate)
+        {
+            Assert.False(InternalTypeExtensions.IsOpenGenericTypeOf(openGenericType, typeToValidate));
         }
 
         private class Base


### PR DESCRIPTION
Issue https://github.com/autofac/Autofac/issues/215 has been lasted for 6 years so I would like to try my self fixing it. :grin:
My approach is to use a new extension method for registering open generic types when scanning assemblies following @tillig 's suggestion. This PR hasn't been finished yet, there are still some functions I haven't implemented yet like `AsImplementedInterfaces(), Named(), Keyed(), Metadata()`. Adding those functions at this time will make this PR too large to review so I will add them later when we accept this approach and also easily reviewing PR.