### PR TITLE
Fix #1238 - Only consider instance constructors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "dotnet-test-explorer.testProjectPath": "test/**/*Test.csproj",
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true
 }

--- a/src/Autofac/TypeExtensions.cs
+++ b/src/Autofac/TypeExtensions.cs
@@ -16,8 +16,9 @@ namespace Autofac
     /// </summary>
     public static class TypeExtensions
     {
-        private const BindingFlags DeclaredOnlyPublicFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly;
-        private const BindingFlags DeclaredOnlyFlags = DeclaredOnlyPublicFlags | BindingFlags.NonPublic;
+        private const BindingFlags DeclaredConstructorPublicFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+        private const BindingFlags DeclaredConstructorFlags = DeclaredConstructorPublicFlags | BindingFlags.NonPublic;
+        private const BindingFlags DeclaredMemberFlags = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.NonPublic;
 
         /// <summary>
         /// Returns true if this type is in the <paramref name="namespace"/> namespace
@@ -123,7 +124,7 @@ namespace Autofac
                 throw new ArgumentNullException(nameof(methodName));
             }
 
-            var foundMethod = @this.GetMethod(methodName, DeclaredOnlyFlags);
+            var foundMethod = @this.GetMethod(methodName, DeclaredMemberFlags);
 
             if (foundMethod is null)
             {
@@ -152,7 +153,7 @@ namespace Autofac
                 throw new ArgumentNullException(nameof(propertyName));
             }
 
-            var foundProperty = @this.GetProperty(propertyName, DeclaredOnlyFlags);
+            var foundProperty = @this.GetProperty(propertyName, DeclaredMemberFlags);
 
             if (foundProperty is null)
             {
@@ -163,11 +164,11 @@ namespace Autofac
         }
 
         /// <summary>
-        /// Returns a collection of constructor infomration that represents the declared constructors
+        /// Returns a collection of instance constructor information that represents the declared constructors
         /// for the type (public and private).
         /// </summary>
         /// <param name="this">The type.</param>
-        /// <returns>A collection of constructors.</returns>
+        /// <returns>A collection of instance constructors.</returns>
         public static ConstructorInfo[] GetDeclaredConstructors(this Type @this)
         {
             if (@this is null)
@@ -175,15 +176,15 @@ namespace Autofac
                 throw new ArgumentNullException(nameof(@this));
             }
 
-            return @this.GetConstructors(DeclaredOnlyFlags);
+            return @this.GetConstructors(DeclaredConstructorFlags);
         }
 
         /// <summary>
-        /// Returns a collection of constructor infomration that represents the declared constructors
+        /// Returns a collection of instance constructor information that represents the declared constructors
         /// for the type (public only).
         /// </summary>
         /// <param name="this">The type.</param>
-        /// <returns>A collection of constructors.</returns>
+        /// <returns>A collection of instance constructors.</returns>
         public static ConstructorInfo[] GetDeclaredPublicConstructors(this Type @this)
         {
             if (@this is null)
@@ -191,11 +192,11 @@ namespace Autofac
                 throw new ArgumentNullException(nameof(@this));
             }
 
-            return @this.GetConstructors(DeclaredOnlyPublicFlags);
+            return @this.GetConstructors(DeclaredConstructorPublicFlags);
         }
 
         /// <summary>
-        /// Finds a constructor with the matching type parameters.
+        /// Finds an instance constructor with the matching type parameters.
         /// </summary>
         /// <param name="type">The type being tested.</param>
         /// <param name="constructorParameterTypes">The types of the contractor to find.</param>

--- a/test/Autofac.Test/TypeExtensionsTests.cs
+++ b/test/Autofac.Test/TypeExtensionsTests.cs
@@ -62,7 +62,7 @@ namespace Autofac.Test
         [Fact]
         public void IsInNamespaceOf_DifferentNamespace()
         {
-            Assert.False(typeof(TypeExtensionsTests).IsInNamespaceOf<ContainerBuilder>());
+            Assert.False(typeof(ContainerBuilder).IsInNamespaceOf<TypeExtensionsTests>());
         }
 
         [Theory]
@@ -99,6 +99,73 @@ namespace Autofac.Test
         public void GetDeclaredProperty_MissingProperty()
         {
             Assert.Throws<ArgumentException>(() => typeof(DeclaredPropertyType).GetDeclaredProperty("NoSuchProperty"));
+        }
+
+        [Fact]
+        public void GetDeclaredConstructors_OnlyFindsInstanceConstructors()
+        {
+            // Issue #1238 - Don't consider static constructors during DI.
+            Assert.Equal(4, typeof(DeclaredConstructorType).GetDeclaredConstructors().Length);
+        }
+
+        [Fact]
+        public void GetDeclaredConstructors_FindsDefaultInstanceConstructors()
+        {
+            Assert.Single(typeof(DefaultConstructorType).GetDeclaredConstructors());
+        }
+
+        [Fact]
+        public void GetDeclaredPublicConstructors_OnlyFindsInstanceConstructors()
+        {
+            // Issue #1238 - Don't consider static constructors during DI.
+            Assert.Equal(2, typeof(DeclaredConstructorType).GetDeclaredPublicConstructors().Length);
+        }
+
+        [Fact]
+        public void GetDeclaredPublicConstructors_FindsDefaultInstanceConstructors()
+        {
+            Assert.Single(typeof(DefaultConstructorType).GetDeclaredPublicConstructors());
+        }
+
+        private class DefaultConstructorType
+        {
+            // No constructor declared - allows tests for default constructor detection.
+        }
+
+        [SuppressMessage("IDE0051", "IDE0051", Justification = "Constructors with unused parameters required for testing reflection against different visibilities.")]
+        [SuppressMessage("IDE0052", "IDE0052", Justification = "Constructors with unused parameters required for testing reflection against different visibilities.")]
+        [SuppressMessage("IDE0060", "IDE0060", Justification = "Constructors with unused parameters required for testing reflection against different visibilities.")]
+        private class DeclaredConstructorType
+        {
+            // Values here to ensure constructors get used and not
+            // optimized out by the compiler.
+            private static readonly Guid StaticValue;
+
+            private readonly Guid _instanceValue;
+
+            static DeclaredConstructorType()
+            {
+                StaticValue = Guid.NewGuid();
+            }
+
+            public DeclaredConstructorType()
+            {
+                _instanceValue = Guid.NewGuid();
+            }
+
+            public DeclaredConstructorType(string parameter)
+            {
+                _instanceValue = Guid.NewGuid();
+            }
+
+            protected DeclaredConstructorType(int parameter)
+            {
+                _instanceValue = Guid.NewGuid();
+            }
+
+            private DeclaredConstructorType(bool parameter)
+            {
+            }
         }
 
         private class DeclaredMethodType

--- a/test/Autofac.Test/TypeExtensionsTests.cs
+++ b/test/Autofac.Test/TypeExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Autofac.Test.Scenarios.ScannedAssembly;
 using Xunit;
 
@@ -40,6 +41,110 @@ namespace Autofac.Test
         public void AnOpenGenericTypeIsNotAClosedTypeOfAnything()
         {
             Assert.False(typeof(CommandBase<>).IsClosedTypeOf(typeof(CommandBase<>)));
+        }
+
+        [Theory]
+        [InlineData(typeof(TypeExtensionsTests), "Autofac", true)]
+        [InlineData(typeof(TypeExtensionsTests), "Autofac.Test", true)]
+        [InlineData(typeof(TypeExtensionsTests), "Auto", false)]
+        [InlineData(typeof(TypeExtensionsTests), "", false)]
+        public void IsInNamespace_DetectsNamespace(Type t, string ns, bool expected)
+        {
+            Assert.Equal(expected, t.IsInNamespace(ns));
+        }
+
+        [Fact]
+        public void IsInNamespaceOf_SameNamespace()
+        {
+            Assert.True(typeof(TypeExtensionsTests).IsInNamespaceOf<TypedParameterTests>());
+        }
+
+        [Fact]
+        public void IsInNamespaceOf_DifferentNamespace()
+        {
+            Assert.False(typeof(TypeExtensionsTests).IsInNamespaceOf<ContainerBuilder>());
+        }
+
+        [Theory]
+        [InlineData("PublicInstanceMethod")]
+        [InlineData("PublicStaticMethod")]
+        [InlineData("ProtectedInstanceMethod")]
+        [InlineData("ProtectedStaticMethod")]
+        [InlineData("PrivateInstanceMethod")]
+        [InlineData("PrivateStaticMethod")]
+        public void GetDeclaredMethod_FindsMethods(string method)
+        {
+            Assert.NotNull(typeof(DeclaredMethodType).GetDeclaredMethod(method));
+        }
+
+        [Fact]
+        public void GetDeclaredMethod_MissingMethod()
+        {
+            Assert.Throws<ArgumentException>(() => typeof(DeclaredMethodType).GetDeclaredMethod("NoSuchMethod"));
+        }
+
+        [Theory]
+        [InlineData("PublicInstanceProperty")]
+        [InlineData("PublicStaticProperty")]
+        [InlineData("ProtectedInstanceProperty")]
+        [InlineData("ProtectedStaticProperty")]
+        [InlineData("PrivateInstanceProperty")]
+        [InlineData("PrivateStaticProperty")]
+        public void GetDeclaredProperty_FindsProperties(string property)
+        {
+            Assert.NotNull(typeof(DeclaredPropertyType).GetDeclaredProperty(property));
+        }
+
+        [Fact]
+        public void GetDeclaredProperty_MissingProperty()
+        {
+            Assert.Throws<ArgumentException>(() => typeof(DeclaredPropertyType).GetDeclaredProperty("NoSuchProperty"));
+        }
+
+        private class DeclaredMethodType
+        {
+            public void PublicInstanceMethod()
+            {
+            }
+
+            protected void ProtectedInstanceMethod()
+            {
+            }
+
+            [SuppressMessage("IDE0051", "IDE0051", Justification = "Method used by reflection in tests.")]
+            private void PrivateInstanceMethod()
+            {
+            }
+
+            public static void PublicStaticMethod()
+            {
+            }
+
+            protected static void ProtectedStaticMethod()
+            {
+            }
+
+            [SuppressMessage("IDE0051", "IDE0051", Justification = "Method used by reflection in tests.")]
+            private static void PrivateStaticMethod()
+            {
+            }
+        }
+
+        private class DeclaredPropertyType
+        {
+            public string PublicInstanceProperty { get; set; }
+
+            protected string ProtectedInstanceProperty { get; set; }
+
+            [SuppressMessage("IDE0051", "IDE0051", Justification = "Property used by reflection in tests.")]
+            private string PrivateInstanceProperty { get; set; }
+
+            public static string PublicStaticProperty { get; set; }
+
+            protected static string ProtectedStaticProperty { get; set; }
+
+            [SuppressMessage("IDE0051", "IDE0051", Justification = "Property used by reflection in tests.")]
+            private static string PrivateStaticProperty { get; set; }
         }
     }
 }


### PR DESCRIPTION
#1238 shows that when we query types for constructors, usually when building reflection activators, we're inadvertently getting static constructors along with instance constructors. Since we can't create an instance of a type based on a static constructor, this PR removes the `BindingFlags.Static` when searching for constructors.