### PR TITLE
chore: update coverlage packages to stable 3.0.0 version

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,7 +4,6 @@
     <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Xunit MyGet" value="https://myget.org/F/xunit/api/v3/index.json" protocolVersion="3" />
-    <add key="Coverlet Nightly" value="https://f.feedz.io/marcorossignoli/coverletunofficial/nuget/index.json" protocolVersion="3" />
   </packageSources>
   <disabledPackageSources>
     <add key="Microsoft and .NET" value="true" />

--- a/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
+++ b/test/Autofac.Specification.Test/Autofac.Specification.Test.csproj
@@ -34,11 +34,11 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.0-preview.9">
+    <PackageReference Include="coverlet.collector" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.0-preview.9">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
+++ b/test/Autofac.Test.Compilation/Autofac.Test.Compilation.csproj
@@ -37,11 +37,11 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.0-preview.9">
+    <PackageReference Include="coverlet.collector" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.0-preview.9">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -38,11 +38,11 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.0-preview.9">
+    <PackageReference Include="coverlet.collector" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.0-preview.9">
+    <PackageReference Include="coverlet.msbuild" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
As per #1241, updating coverlet* to stable 3.0.0 release.