### PR TITLE
Open generic scanning extensions

### DIFF
--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -169,5 +169,81 @@ namespace Autofac.Features.Scanning
                 action(type, scanned);
             }
         }
+
+        /// <summary>
+        /// Configures the scanning registration builder to register all open types of the specified open generic.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="openGenericServiceType">The open generic to register open types of.</param>
+        /// <returns>The registration builder.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+                IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Type openGenericServiceType)
+        {
+            if (openGenericServiceType == null)
+            {
+                throw new ArgumentNullException(nameof(openGenericServiceType));
+            }
+
+            return registration
+                .Where(candidateType => candidateType.IsOpenGenericTypeOf(openGenericServiceType))
+                .As(candidateType => (Service)new TypedService(candidateType));
+        }
+
+        /// <summary>
+        /// Configures the scanning registration builder to register all open types of the specified open generic as a keyed service.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="openGenericServiceType">The open generic to register open types of.</param>
+        /// <param name="serviceKey">The service key.</param>
+        /// <returns>The registration builder.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+                IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Type openGenericServiceType,
+                object serviceKey)
+        {
+            if (openGenericServiceType == null)
+            {
+                throw new ArgumentNullException(nameof(openGenericServiceType));
+            }
+
+            if (serviceKey == null)
+            {
+                throw new ArgumentNullException(nameof(serviceKey));
+            }
+
+            return AsOpenTypesOf(registration, openGenericServiceType, t => serviceKey);
+        }
+
+        /// <summary>
+        /// Configures the scanning registration builder to register all open types of the specified open generic as a keyed service.
+        /// </summary>
+        /// <typeparam name="TLimit">The limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
+        /// <param name="registration">The registration builder.</param>
+        /// <param name="openGenericServiceType">The open generic to register open types of.</param>
+        /// <param name="serviceKeyMapping">A function to determine the service key for a given type.</param>
+        /// <returns>The registration builder.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+                IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Type openGenericServiceType,
+                Func<Type, object> serviceKeyMapping)
+        {
+            if (openGenericServiceType == null)
+            {
+                throw new ArgumentNullException(nameof(openGenericServiceType));
+            }
+
+            return registration
+                .Where(candidateType => candidateType.IsOpenGenericTypeOf(openGenericServiceType))
+                .As(candidateType => (Service)new KeyedService(serviceKeyMapping(candidateType), candidateType));
+        }
     }
 }

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Autofac.Builder;
@@ -244,6 +245,65 @@ namespace Autofac.Features.Scanning
             return registration
                 .Where(candidateType => candidateType.IsOpenGenericTypeOf(openGenericServiceType))
                 .As(candidateType => (Service)new KeyedService(serviceKeyMapping(candidateType), candidateType));
+        }
+
+        /// <summary>
+        /// Specify how an open generic type from a scanned assembly provides metadata.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set metadata on.</param>
+        /// <param name="metadataMapping">A function mapping the type to a list of metadata items.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            WithMetadata<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                Func<Type, IEnumerable<KeyValuePair<string, object?>>> metadataMapping)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            registration.ActivatorData.ConfigurationActions.Add((t, rb) => rb.WithMetadata(metadataMapping(t)));
+            return registration;
+        }
+
+        /// <summary>
+        /// Use the properties of an attribute (or interface implemented by an attribute) on the scanned type
+        /// to provide metadata values.
+        /// </summary>
+        /// <remarks>Inherited attributes are supported; however, there must be at most one matching attribute
+        /// in the inheritance chain.</remarks>
+        /// <typeparam name="TAttribute">The attribute applied to the scanned type.</typeparam>
+        /// <param name="registration">Registration to set metadata on.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            WithMetadataFrom<TAttribute>(
+                this IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration)
+        {
+            var attrType = typeof(TAttribute);
+            var metadataProperties = attrType
+                .GetRuntimeProperties()
+                .Where(pi => pi.CanRead);
+
+            return registration.WithMetadata(t =>
+            {
+                var attrs = t.GetCustomAttributes(true).OfType<TAttribute>().ToList();
+
+                if (attrs.Count == 0)
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationExtensionsResources.MetadataAttributeNotFound, typeof(TAttribute), t));
+                }
+
+                if (attrs.Count != 1)
+                {
+                    throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RegistrationExtensionsResources.MultipleMetadataAttributesSameType, typeof(TAttribute), t));
+                }
+
+                var attr = attrs[0];
+                return metadataProperties.Select(p => new KeyValuePair<string, object?>(p.Name, p.GetValue(attr, null)));
+            });
         }
     }
 }

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -172,15 +172,15 @@ namespace Autofac.Features.Scanning
         }
 
         /// <summary>
-        /// Configures the scanning registration builder to register all open types of the specified open generic.
+        /// Filters the scanned types to include only those assignable to the provided.
         /// </summary>
         /// <typeparam name="TLimit">The limit type.</typeparam>
         /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
         /// <param name="registration">The registration builder.</param>
-        /// <param name="openGenericServiceType">The open generic to register open types of.</param>
+        /// <param name="openGenericServiceType">The type or interface which all classes must be assignable from.</param>
         /// <returns>The registration builder.</returns>
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
-            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+            AssignableTo<TLimit, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
                 Type openGenericServiceType)
         {

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -195,16 +195,16 @@ namespace Autofac.Features.Scanning
         }
 
         /// <summary>
-        /// Configures the scanning registration builder to register all open types of the specified open generic as a keyed service.
+        /// Filters the scanned types to include only those assignable to the provided.
         /// </summary>
         /// <typeparam name="TLimit">The limit type.</typeparam>
         /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
         /// <param name="registration">The registration builder.</param>
-        /// <param name="openGenericServiceType">The open generic to register open types of.</param>
+        /// <param name="openGenericServiceType">The type or interface which all classes must be assignable from.</param>
         /// <param name="serviceKey">The service key.</param>
         /// <returns>The registration builder.</returns>
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
-            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+            AssignableTo<TLimit, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
                 Type openGenericServiceType,
                 object serviceKey)
@@ -219,20 +219,20 @@ namespace Autofac.Features.Scanning
                 throw new ArgumentNullException(nameof(serviceKey));
             }
 
-            return AsOpenTypesOf(registration, openGenericServiceType, t => serviceKey);
+            return AssignableTo(registration, openGenericServiceType, t => serviceKey);
         }
 
         /// <summary>
-        /// Configures the scanning registration builder to register all open types of the specified open generic as a keyed service.
+        /// Filters the scanned types to include only those assignable to the provided.
         /// </summary>
         /// <typeparam name="TLimit">The limit type.</typeparam>
         /// <typeparam name="TRegistrationStyle">The registration style.</typeparam>
         /// <param name="registration">The registration builder.</param>
-        /// <param name="openGenericServiceType">The open generic to register open types of.</param>
+        /// <param name="openGenericServiceType">The type or interface which all classes must be assignable from.</param>
         /// <param name="serviceKeyMapping">A function to determine the service key for a given type.</param>
         /// <returns>The registration builder.</returns>
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
-            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+            AssignableTo<TLimit, TRegistrationStyle>(
                 IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
                 Type openGenericServiceType,
                 Func<Type, object> serviceKeyMapping)
@@ -260,11 +260,6 @@ namespace Autofac.Features.Scanning
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
                 Func<Type, IEnumerable<KeyValuePair<string, object?>>> metadataMapping)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
             registration.ActivatorData.ConfigurationActions.Add((t, rb) => rb.WithMetadata(metadataMapping(t)));
             return registration;
         }

--- a/src/Autofac/RegistrationExtensions.AssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.AssemblyScanning.cs
@@ -245,6 +245,14 @@ namespace Autofac
             return type.IsInterface ? interfaces.AppendItem(type).ToArray() : interfaces.ToArray();
         }
 
+        private static Type[] GetOpenGenericImplementedInterfaces(this Type @this)
+        {
+            return @this.GetInterfaces()
+                .Where(it => it.IsGenericType)
+                .Select(it => it.GetGenericTypeDefinition())
+                .ToArray();
+        }
+
         /// <summary>
         /// Specifies that the components being registered should only be made the default for services
         /// that have not already been registered.

--- a/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
@@ -252,5 +252,69 @@ namespace Autofac
         {
             return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKeyMapping);
         }
+
+        /// <summary>
+        /// Filters the scanned open generic types to include only those in the namespace of the provided type
+        /// or one of its sub-namespaces.
+        /// </summary>
+        /// <param name="registration">Registration to filter types from.</param>
+        /// <typeparam name="T">A type in the target namespace.</typeparam>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            InNamespaceOf<T>(this IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            // Namespace is always non-null for concrete type parameters.
+            return registration.InNamespace(typeof(T).Namespace!);
+        }
+
+        /// <summary>
+        /// Filters the scanned types to include only those in the provided namespace
+        /// or one of its sub-namespaces.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to filter types from.</param>
+        /// <param name="ns">The namespace from which types will be selected.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            InNamespace<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
+                string ns)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            if (ns == null)
+            {
+                throw new ArgumentNullException(nameof(ns));
+            }
+
+            return registration.Where(t => t.IsInNamespace(ns));
+        }
+
+        /// <summary>
+        /// Specifies that an open generic type from a scanned assembly is registered as providing all of its
+        /// implemented interfaces.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
+            AsImplementedInterfaces<TLimit>(this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration)
+        {
+            if (registration == null)
+            {
+                throw new ArgumentNullException(nameof(registration));
+            }
+
+            return registration.As(t => t.GetOpenGenericImplementedInterfaces());
+        }
     }
 }

--- a/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
@@ -202,5 +202,55 @@ namespace Autofac
             registration.ActivatorData.Filters.Add(predicate);
             return registration;
         }
+
+        /// <summary>
+        /// Specifies that an open generic type from a scanned assembly is registered if it implements an interface
+        /// that opens the provided open generic interface type.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="openGenericServiceType">The open generic interface or base class type for which implementations will be found.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType)
+        {
+            return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType);
+        }
+
+        /// <summary>
+        /// Specifies that an open generic type from a scanned assembly is registered if it implements an interface
+        /// that opens the provided open generic interface type.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="openGenericServiceType">The open generic interface or base class type for which implementations will be found.</param>
+        /// <param name="serviceKey">Key of the service.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, object serviceKey)
+        {
+            return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKey);
+        }
+
+        /// <summary>
+        /// Specifies that an open generic type from a scanned assembly is registered if it implements an interface
+        /// that opens the provided open generic interface type.
+        /// </summary>
+        /// <typeparam name="TLimit">Registration limit type.</typeparam>
+        /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
+        /// <param name="registration">Registration to set service mapping on.</param>
+        /// <param name="openGenericServiceType">The open generic interface or base class type for which implementations will be found.</param>
+        /// <param name="serviceKeyMapping">Function mapping types to service keys.</param>
+        /// <returns>Registration builder allowing the registration to be configured.</returns>
+        public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
+            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+                this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, Func<Type, object> serviceKeyMapping)
+        {
+            return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKeyMapping);
+        }
     }
 }

--- a/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
@@ -204,50 +204,47 @@ namespace Autofac
         }
 
         /// <summary>
-        /// Specifies that an open generic type from a scanned assembly is registered if it implements an interface
-        /// that opens the provided open generic interface type.
+        /// Filters the scanned types to include only those assignable to the provided.
         /// </summary>
         /// <typeparam name="TLimit">Registration limit type.</typeparam>
         /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
         /// <param name="registration">Registration to set service mapping on.</param>
-        /// <param name="openGenericServiceType">The open generic interface or base class type for which implementations will be found.</param>
+        /// <param name="openGenericServiceType">The type or interface which all classes must be assignable from.</param>
         /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
-            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+            AssignableTo<TLimit, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType)
         {
-            return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType);
+            return ScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType);
         }
 
         /// <summary>
-        /// Specifies that an open generic type from a scanned assembly is registered if it implements an interface
-        /// that opens the provided open generic interface type.
+        /// Filters the scanned types to include only those assignable to the provided.
         /// </summary>
         /// <typeparam name="TLimit">Registration limit type.</typeparam>
         /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
         /// <param name="registration">Registration to set service mapping on.</param>
-        /// <param name="openGenericServiceType">The open generic interface or base class type for which implementations will be found.</param>
+        /// <param name="openGenericServiceType">The type or interface which all classes must be assignable from.</param>
         /// <param name="serviceKey">Key of the service.</param>
         /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
-            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+            AssignableTo<TLimit, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, object serviceKey)
         {
             return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKey);
         }
 
         /// <summary>
-        /// Specifies that an open generic type from a scanned assembly is registered if it implements an interface
-        /// that opens the provided open generic interface type.
+        /// Filters the scanned types to include only those assignable to the provided.
         /// </summary>
         /// <typeparam name="TLimit">Registration limit type.</typeparam>
         /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
         /// <param name="registration">Registration to set service mapping on.</param>
-        /// <param name="openGenericServiceType">The open generic interface or base class type for which implementations will be found.</param>
+        /// <param name="openGenericServiceType">The type or interface which all classes must be assignable from.</param>
         /// <param name="serviceKeyMapping">Function mapping types to service keys.</param>
         /// <returns>Registration builder allowing the registration to be configured.</returns>
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle>
-            AsOpenTypesOf<TLimit, TRegistrationStyle>(
+            AssignableTo<TLimit, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, Func<Type, object> serviceKeyMapping)
         {
             return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKeyMapping);

--- a/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
@@ -231,7 +231,7 @@ namespace Autofac
             AssignableTo<TLimit, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, object serviceKey)
         {
-            return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKey);
+            return ScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType, serviceKey);
         }
 
         /// <summary>
@@ -247,7 +247,7 @@ namespace Autofac
             AssignableTo<TLimit, TRegistrationStyle>(
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, Func<Type, object> serviceKeyMapping)
         {
-            return ScanningRegistrationExtensions.AsOpenTypesOf(registration, openGenericServiceType, serviceKeyMapping);
+            return ScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType, serviceKeyMapping);
         }
 
         /// <summary>
@@ -260,11 +260,6 @@ namespace Autofac
         public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
             InNamespaceOf<T>(this IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
             // Namespace is always non-null for concrete type parameters.
             return registration.InNamespace(typeof(T).Namespace!);
         }
@@ -283,12 +278,7 @@ namespace Autofac
                 this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration,
                 string ns)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
-            if (ns == null)
+            if (string.IsNullOrEmpty(ns))
             {
                 throw new ArgumentNullException(nameof(ns));
             }
@@ -306,11 +296,6 @@ namespace Autofac
         public static IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
             AsImplementedInterfaces<TLimit>(this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, DynamicRegistrationStyle> registration)
         {
-            if (registration == null)
-            {
-                throw new ArgumentNullException(nameof(registration));
-            }
-
             return registration.As(t => t.GetOpenGenericImplementedInterfaces());
         }
     }

--- a/src/Autofac/Util/TypeExtensions.cs
+++ b/src/Autofac/Util/TypeExtensions.cs
@@ -223,7 +223,6 @@ namespace Autofac.Util
 
         private static bool CheckInterfacesAreOpenGenericTypeOf(this Type @this, Type type)
         {
-            var interfaces = @this.GetInterfaces().ToList();
             return @this.GetInterfaces()
                 .Any(it => it.IsGenericType
                     ? it.GetGenericTypeDefinition().IsOpenGenericTypeOf(type)

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/MetadataAttributeScanningScenario/DuplicatedNameAttribute.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/MetadataAttributeScanningScenario/DuplicatedNameAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+
+namespace Autofac.Test.Scenarios.ScannedAssembly.MetadataAttributeScanningScenario
+{
+    public class DuplicatedNameAttribute : Attribute, IHaveName
+    {
+        public DuplicatedNameAttribute(string name)
+        {
+            Name = name ?? throw new ArgumentNullException("name");
+        }
+
+        public string Name { get; }
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/MetadataAttributeScanningScenario/OpenGenericScannedComponentWithMultipleNames.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/MetadataAttributeScanningScenario/OpenGenericScannedComponentWithMultipleNames.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly.MetadataAttributeScanningScenario
+{
+    [Name("My Name")]
+    [DuplicatedName("My Name 2")]
+    public class OpenGenericScannedComponentWithMultipleNames<T>
+    {
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/MetadataAttributeScanningScenario/OpenGenericScannedComponentWithName.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/MetadataAttributeScanningScenario/OpenGenericScannedComponentWithName.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly.MetadataAttributeScanningScenario
+{
+    [Name("My Name")]
+    public class OpenGenericScannedComponentWithName<T>
+    {
+    }
+}

--- a/test/Autofac.Test.Scenarios.ScannedAssembly/OpenGenericAComponent.cs
+++ b/test/Autofac.Test.Scenarios.ScannedAssembly/OpenGenericAComponent.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test.Scenarios.ScannedAssembly
+{
+    public class OpenGenericAComponent<T>
+    {
+    }
+}

--- a/test/Autofac.Test/Assertions.cs
+++ b/test/Autofac.Test/Assertions.cs
@@ -4,7 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Features.Indexed;
+using Autofac.Features.OpenGenerics;
 using Xunit;
 
 namespace Autofac.Test
@@ -90,6 +94,24 @@ namespace Autofac.Test
 
             Assert.True(foundFirst);
             Assert.True(foundLast);
+        }
+
+        public static bool RegisteredAnyOpenGenericTypeFromScanningAssembly(this IComponentContext context)
+        {
+            return context.ComponentRegistry.Sources.Any(source =>
+            {
+                if (source is OpenGenericRegistrationSource)
+                {
+                    var activatorData = typeof(OpenGenericRegistrationSource)
+                        .GetField("_activatorData", BindingFlags.NonPublic | BindingFlags.Instance)
+                        .GetValue(source) as ReflectionActivatorData;
+                    return activatorData.ImplementationType != typeof(KeyedServiceIndex<,>);
+                }
+                else
+                {
+                    return false;
+                }
+            });
         }
 
         private static IEnumerable<Type> LookForComponents(this IEnumerable<IComponentRegistration> registrations, IEnumerable<Type> types)

--- a/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
@@ -10,6 +10,7 @@ using Autofac.Core;
 using Autofac.Core.Lifetime;
 using Autofac.Core.Registration;
 using Autofac.Features.Metadata;
+using Autofac.Features.OpenGenerics;
 using Autofac.Features.Scanning;
 using Autofac.Test.Scenarios.ScannedAssembly;
 using Autofac.Test.Scenarios.ScannedAssembly.MetadataAttributeScanningScenario;
@@ -117,6 +118,30 @@ namespace Autofac.Test.Features.Scanning
 
             Assert.Throws<ArgumentNullException>(() => cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
                 .AssignableTo(null, t => t));
+        }
+
+        [Theory]
+        [InlineData(typeof(ICloseCommand))]
+        [InlineData(typeof(CloseCommand))]
+        public void AssignableToClosedTypeProvidedNoneOpenGenericSourceRegistered(Type closedType)
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AssignableTo(closedType);
+            var c = cb.Build();
+
+            Assert.False(c.RegisteredAnyOpenGenericTypeFromScanningAssembly());
+        }
+
+        [Fact]
+        public void ServiceIsNotAssignableToIsNotRegistered()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AssignableTo(typeof(RedoOpenGenericCommand<>));
+            var c = cb.Build();
+
+            Assert.Throws<ComponentNotRegisteredException>(() => c.Resolve<DeleteOpenGenericCommand<int>>());
         }
 
         [Fact]

--- a/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
@@ -102,41 +102,41 @@ namespace Autofac.Test.Features.Scanning
         }
 
         [Fact]
-        public void AsOpenTypesOfNullTypeProvidedThrowsException()
+        public void AssignableToNullTypeProvidedThrowsException()
         {
             var cb = new ContainerBuilder();
-            Assert.Throws<ArgumentNullException>(() => cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly).
-                AsOpenTypesOf(null));
+            Assert.Throws<ArgumentNullException>(() => cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AssignableTo(null));
         }
 
         [Fact]
-        public void AsOpenTypesOfOpenGenericInterfaceTypeProvidedOpenGenericTypesRegistered()
+        public void AssignableToOpenGenericInterfaceTypeProvidedOpenGenericTypesRegistered()
         {
             var cb = new ContainerBuilder();
             cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
-                .AsOpenTypesOf(typeof(ICommand<>));
+                .AssignableTo(typeof(ICommand<>));
             var c = cb.Build();
 
             Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
         }
 
         [Fact]
-        public void AsOpenTypesOfOpenGenericAbstractClassTypeProvidedOpenGenericTypesRegistered()
+        public void AssignableToOpenGenericAbstractClassTypeProvidedOpenGenericTypesRegistered()
         {
             var cb = new ContainerBuilder();
             cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
-                .AsOpenTypesOf(typeof(CommandBase<>));
+                .AssignableTo(typeof(CommandBase<>));
             var c = cb.Build();
 
             Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
         }
 
         [Fact]
-        public void AsOpenTypesOfWithServiceKeyShouldAssignKeyToAllRegistrations()
+        public void AssignableToWithServiceKeyShouldAssignKeyToAllRegistrations()
         {
             var cb = new ContainerBuilder();
             cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
-                .AsOpenTypesOf(typeof(ICommand<>), "command");
+                .AssignableTo(typeof(ICommand<>), "command");
             var c = cb.Build();
 
             Assert.Throws<ComponentNotRegisteredException>(() => c.Resolve<DeleteOpenGenericCommand<int>>());
@@ -144,11 +144,11 @@ namespace Autofac.Test.Features.Scanning
         }
 
         [Fact]
-        public void AsOpenTypesOfWithServiceKeyMappingShouldAssignKeyResultToEachRegistration()
+        public void AssignableToWithServiceKeyMappingShouldAssignKeyResultToEachRegistration()
         {
             var cb = new ContainerBuilder();
             cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
-                .AsOpenTypesOf(typeof(ICommand<>), t => t);
+                .AssignableTo(typeof(ICommand<>), t => t);
             var c = cb.Build();
 
             Assert.NotNull(c.ResolveKeyed<RedoOpenGenericCommand<int>>(typeof(RedoOpenGenericCommand<>)));

--- a/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
+++ b/test/Autofac.Test/Features/Scanning/OpenGenericScanningRegistrationTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -96,6 +97,59 @@ namespace Autofac.Test.Features.Scanning
             var a1 = c.Resolve<RedoOpenGenericCommand<int>>();
             var a2 = c.Resolve<RedoOpenGenericCommand<int>>();
             Assert.Same(a1, a2);
+        }
+
+        [Fact]
+        public void AsOpenTypesOfNullTypeProvidedThrowsException()
+        {
+            var cb = new ContainerBuilder();
+            Assert.Throws<ArgumentNullException>(() => cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly).
+                AsOpenTypesOf(null));
+        }
+
+        [Fact]
+        public void AsOpenTypesOfOpenGenericInterfaceTypeProvidedOpenGenericTypesRegistered()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AsOpenTypesOf(typeof(ICommand<>));
+            var c = cb.Build();
+
+            Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
+        }
+
+        [Fact]
+        public void AsOpenTypesOfOpenGenericAbstractClassTypeProvidedOpenGenericTypesRegistered()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AsOpenTypesOf(typeof(CommandBase<>));
+            var c = cb.Build();
+
+            Assert.NotNull(c.Resolve<RedoOpenGenericCommand<int>>());
+        }
+
+        [Fact]
+        public void AsOpenTypesOfWithServiceKeyShouldAssignKeyToAllRegistrations()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AsOpenTypesOf(typeof(ICommand<>), "command");
+            var c = cb.Build();
+
+            Assert.Throws<ComponentNotRegisteredException>(() => c.Resolve<DeleteOpenGenericCommand<int>>());
+            Assert.NotNull(c.ResolveKeyed<RedoOpenGenericCommand<int>>("command"));
+        }
+
+        [Fact]
+        public void AsOpenTypesOfWithServiceKeyMappingShouldAssignKeyResultToEachRegistration()
+        {
+            var cb = new ContainerBuilder();
+            cb.RegisterAssemblyOpenGenericTypes(typeof(ICommand<>).GetTypeInfo().Assembly)
+                .AsOpenTypesOf(typeof(ICommand<>), t => t);
+            var c = cb.Build();
+
+            Assert.NotNull(c.ResolveKeyed<RedoOpenGenericCommand<int>>(typeof(RedoOpenGenericCommand<>)));
         }
     }
 }


### PR DESCRIPTION
Add remaining methods as discussed in https://github.com/autofac/Autofac/pull/1232.
Some notes:
- `AsClosedTypesOf` is renamed to `AsOpenTypesOf`
- I think we shouldn't support `AssignableTo` because https://stackoverflow.com/questions/5461295/using-isassignablefrom-with-open-generic-types#:~:text=The%20difference%20is%20that%20open,%22assignable%22%20to%20the%20other.