### PR TITLE
Fix memory leak due to use of ConcurrentBag

### DIFF
--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -247,6 +247,18 @@ namespace Autofac.Core.Registration
                 registration.Dispose();
             }
 
+            // If we do not explicitly empty the ConcurrentBag that stores our registrations,
+            // this will cause a memory leak due to threads holding a reference to the bag.
+            // In netstandard2.0 the faster 'Clear' method is not available,
+            // so we have do this manually. We'll use the faster method if it's available though.
+#if NETSTANDARD2_0
+            while (_registrations.TryTake(out _))
+            {
+            }
+#else
+            _registrations.Clear();
+#endif
+
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
Ensure we empty the `_registrations` bag in `DefaultRegisteredServicesTracker` when we dispose the tracker; this ensures any `ThreadLocal` references are cleared up and memory is not leaked.

Fixes #1252 

