### PR TITLE
Add support for OnlyIf and IfNotRegistered on module registration

### DIFF
--- a/src/Autofac/Core/Registration/IModuleRegistrar.cs
+++ b/src/Autofac/Core/Registration/IModuleRegistrar.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System;
+using System.ComponentModel;
+
 namespace Autofac.Core.Registration
 {
     /// <summary>
@@ -8,6 +11,12 @@ namespace Autofac.Core.Registration
     /// </summary>
     public interface IModuleRegistrar
     {
+        /// <summary>
+        /// Gets the registrar data.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ModuleRegistrarData RegistrarData { get; }
+
         /// <summary>
         /// Add a module to the container.
         /// </summary>

--- a/src/Autofac/Core/Registration/IModuleRegistrar.cs
+++ b/src/Autofac/Core/Registration/IModuleRegistrar.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using System.ComponentModel;
 
 namespace Autofac.Core.Registration

--- a/src/Autofac/Core/Registration/ModuleRegistrarData.cs
+++ b/src/Autofac/Core/Registration/ModuleRegistrarData.cs
@@ -20,7 +20,7 @@ namespace Autofac.Core.Registration
         }
 
         /// <summary>
-        /// Gets or sets the callback invoked when the collection of modules attached to this registrar are registered.
+        /// Gets the callback invoked when the collection of modules attached to this registrar are registered.
         /// </summary>
         public DeferredCallback Callback { get; }
     }

--- a/src/Autofac/Core/Registration/ModuleRegistrarData.cs
+++ b/src/Autofac/Core/Registration/ModuleRegistrarData.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using Autofac.Builder;
+
+namespace Autofac.Core.Registration
+{
+    /// <summary>
+    /// Data used by <see cref="IModuleRegistrar"/> to support customisations to the module registration process.
+    /// </summary>
+    public class ModuleRegistrarData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ModuleRegistrarData"/> class.
+        /// </summary>
+        /// <param name="callback">The callback for the registrar.</param>
+        public ModuleRegistrarData(DeferredCallback callback)
+        {
+            Callback = callback;
+        }
+
+        /// <summary>
+        /// Gets or sets the callback invoked when the collection of modules attached to this registrar are registered.
+        /// </summary>
+        public DeferredCallback Callback { get; }
+    }
+}

--- a/src/Autofac/Core/Registration/ModuleRegistrarData.cs
+++ b/src/Autofac/Core/Registration/ModuleRegistrarData.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System;
 using Autofac.Builder;
 
 namespace Autofac.Core.Registration

--- a/test/Autofac.Specification.Test/Registration/ModuleRegistrationTests.cs
+++ b/test/Autofac.Specification.Test/Registration/ModuleRegistrationTests.cs
@@ -129,6 +129,22 @@ namespace Autofac.Specification.Test.Registration
         }
 
         [Fact]
+        public void OnlyIf_RequiresPredicate()
+        {
+            var mod = new ObjectModule();
+            var builder = new ContainerBuilder();
+            Assert.Throws<ArgumentNullException>(() => builder.RegisterModule(mod).OnlyIf(null));
+        }
+
+        [Fact]
+        public void OnlyIf_RequiresRegistrar()
+        {
+            var mod = new ObjectModule();
+            var builder = new ContainerBuilder();
+            Assert.Throws<ArgumentNullException>(() => ModuleRegistrationExtensions.OnlyIf(null, reg => true));
+        }
+
+        [Fact]
         public void OnlyIf_PreventsModuleRegistration()
         {
             var mod = new ObjectModule();
@@ -194,6 +210,22 @@ namespace Autofac.Specification.Test.Registration
             var container = builder.Build();
             Assert.NotNull(container.Resolve<object>());
             Assert.Equal("foo", container.Resolve<string>());
+        }
+
+        [Fact]
+        public void IfNotRegistered_RequiresRegistrar()
+        {
+            var mod = new ObjectModule();
+            var builder = new ContainerBuilder();
+            Assert.Throws<ArgumentNullException>(() => ModuleRegistrationExtensions.IfNotRegistered(null, typeof(object)));
+        }
+
+        [Fact]
+        public void IfNotRegistered_RequiresType()
+        {
+            var mod = new ObjectModule();
+            var builder = new ContainerBuilder();
+            Assert.Throws<ArgumentNullException>(() => builder.RegisterModule(mod).IfNotRegistered(null));
         }
 
         [Fact]

--- a/test/Autofac.Specification.Test/Registration/ModuleRegistrationTests.cs
+++ b/test/Autofac.Specification.Test/Registration/ModuleRegistrationTests.cs
@@ -173,6 +173,7 @@ namespace Autofac.Specification.Test.Registration
             var objModule1 = new ObjectModule();
             var objModule2 = new ObjectModule();
             builder.RegisterModule(objModule1)
+
                    // Shouldn't run because last OnlyIf fails
                    .OnlyIf(regBuilder => counter++ != 1)
                    .RegisterModule(objModule2)


### PR DESCRIPTION
This PR is a partial fix for #1235, by adding OnlyIf support for Module Registrations.

This change is _technically_ breaking, through the addition of a new `RegistrarData` property on `IModuleRegistrar`, however if someone has implemented a custom `IModuleRegistrar`, I will be quite surprised.

This change allows you to do this:

```csharp
var builder = new ContainerBuilder();

builder.RegisterModule(new MyModule())
       .OnlyIf(regBuilder => someCondition);
```

or this:

```csharp
var builder = new ContainerBuilder();

builder.RegisterModule(new MyModule())
       .IfNotRegistered(typeof(string));
```

You can stack `OnlyIf` calls in the same way you can do it on normal registrations:

```csharp
var builder = new ContainerBuilder();

builder.RegisterModule(new MyModule())
       .OnlyIf(regBuilder => someCondition)
       .OnlyIf(regBuilder => somethingElse);
```

The way I've laid out the evaluation of the conditions and the module registrations is as follows (after some thought):

- Evaluate any predicates (in reverse definition order, same as normal registrations), stopping if one fails.
- If all predicates pass, then run all module registrations.

This means that any `OnlyIf` statements used against a single `IModuleRegistrar` instance will be applied to the state of the registry **before** any modules got registered.

This behaviour seemed like the most predicatable/logical, rather than (for example), evaluating the predicate per-module.