### PR TITLE
Fix #1275: Filter out 'value' named parameters during property injection

### DIFF
--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -75,7 +75,12 @@ namespace Autofac.Core.Activators.Reflection
                 // SetMethod will be non-null if GetInjectableProperties included it.
                 var setParameter = property.SetMethod!.GetParameters()[0];
                 var valueProvider = (Func<object?>?)null;
-                var parameter = resolveParameters.FirstOrDefault(p => p.CanSupplyValue(setParameter, context, out valueProvider));
+
+                // Issue #1275: If a delegate factory has a named parameter 'value' it will try to
+                // inject into any property being autowired.
+                var parameter = resolveParameters.FirstOrDefault(p =>
+                    p.CanSupplyValue(setParameter, context, out valueProvider) &&
+                    !(p is NamedParameter n && n.Name.Equals("value", StringComparison.Ordinal)));
                 if (parameter != null)
                 {
                     var setter = PropertySetters.GetOrAdd(property, MakeFastPropertySetter);

--- a/src/Autofac/Features/Metadata/MetadataViewProvider.cs
+++ b/src/Autofac/Features/Metadata/MetadataViewProvider.cs
@@ -98,7 +98,7 @@ namespace Autofac.Features.Metadata
 
             if (defaultValue is object)
             {
-                return (TValue)defaultValue.Value;
+                return (TValue?)defaultValue.Value;
             }
 
             throw new DependencyResolutionException(

--- a/src/Autofac/Util/FallbackDictionary.cs
+++ b/src/Autofac/Util/FallbackDictionary.cs
@@ -136,7 +136,7 @@ namespace Autofac.Util
         {
             get
             {
-                if (_localValues.TryGetValue(key, out TValue value))
+                if (_localValues.TryGetValue(key, out TValue? value))
                 {
                     return value;
                 }

--- a/test/Autofac.Specification.Test/Features/PropertyInjection/CtorWithValueParameter.cs
+++ b/test/Autofac.Specification.Test/Features/PropertyInjection/CtorWithValueParameter.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Specification.Test.Features.PropertyInjection
+{
+    public class CtorWithValueParameter
+    {
+        public delegate CtorWithValueParameter Factory(string value);
+
+        // The testing with this class has to do with a constructor
+        // parameter that is named `value` - this property doesn't
+        // need to be filled in, it just needs to exist and not be
+        // a simple `object` or `string` or something.
+        public HasMixedVisibilityProperties Dummy { get; set; }
+
+        public CtorWithValueParameter(string value)
+        {
+        }
+    }
+}

--- a/test/Autofac.Specification.Test/Features/PropertyInjectionTests.cs
+++ b/test/Autofac.Specification.Test/Features/PropertyInjectionTests.cs
@@ -298,6 +298,18 @@ namespace Autofac.Specification.Test.Features
         }
 
         [Fact]
+        public void PropertiesAutowiredWithDelegateFactory()
+        {
+            // Issue #1275: A constructor parameter with the name 'value' messes
+            // up property injection when used in conjunction with delegate factories.
+            var cb = new ContainerBuilder();
+            cb.RegisterType<CtorWithValueParameter>().PropertiesAutowired();
+            var c = cb.Build();
+            var factory = c.Resolve<CtorWithValueParameter.Factory>();
+            Assert.NotNull(factory("test"));
+        }
+
+        [Fact]
         public void PropertiesNotSetIfNotSpecified()
         {
             var builder = new ContainerBuilder();


### PR DESCRIPTION
Resolves #1275. When doing property injection, the set of parameters provided to the resolve operation are all considered for properties. A special edge case occurs when a named parameter is provided where the name is `value` - this overlaps with the reserved word `value` in a property setter method and it's seen to be a "match" for the property.

This change removes this very specific edge case from the considered list of parameters when doing property injection.