### PR TITLE
Add generic overloads for TryResolveNamed and TryResolveKeyed

### DIFF
--- a/src/Autofac/ResolutionExtensions.cs
+++ b/src/Autofac/ResolutionExtensions.cs
@@ -954,6 +954,39 @@ namespace Autofac
         /// <summary>
         /// Try to retrieve a service from the context.
         /// </summary>
+        /// <typeparam name="T">The service type to resolve.</typeparam>
+        /// <param name="context">The context from which to resolve the service.</param>
+        /// <param name="serviceKey">The key of the service to resolve.</param>
+        /// <param name="instance">The resulting component instance providing the service, or null.</param>
+        /// <returns>
+        /// True if a component providing the service is available.
+        /// </returns>
+        /// <exception cref="DependencyResolutionException"/>
+        public static bool TryResolveKeyed<T>(this IComponentContext context, object serviceKey, [NotNullWhen(returnValue: true)] out T? instance)
+            where T : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.TryResolveKeyed(serviceKey, typeof(T), out object? component))
+            {
+                instance = CastInstance<T>(component);
+
+                return true;
+            }
+            else
+            {
+                instance = default;
+
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Try to retrieve a service from the context.
+        /// </summary>
         /// <param name="context">The context from which to resolve the service.</param>
         /// <param name="serviceKey">The key of the service to resolve.</param>
         /// <param name="serviceType">The type of the service to resolve.</param>
@@ -971,6 +1004,39 @@ namespace Autofac
             }
 
             return context.TryResolveService(new KeyedService(serviceKey, serviceType), NoParameters, out instance);
+        }
+
+        /// <summary>
+        /// Try to retrieve a service from the context.
+        /// </summary>
+        /// <typeparam name="T">The service type to resolve.</typeparam>
+        /// <param name="context">The context from which to resolve the service.</param>
+        /// <param name="serviceName">The name of the service to resolve.</param>
+        /// <param name="instance">The resulting component instance providing the service, or null.</param>
+        /// <returns>
+        /// True if a component providing the service is available.
+        /// </returns>
+        /// <exception cref="DependencyResolutionException"/>
+        public static bool TryResolveNamed<T>(this IComponentContext context, string serviceName, [NotNullWhen(returnValue: true)] out T? instance)
+            where T : class
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (context.TryResolveNamed(serviceName, typeof(T), out object? component))
+            {
+                instance = CastInstance<T>(component);
+
+                return true;
+            }
+            else
+            {
+                instance = default;
+
+                return false;
+            }
         }
 
         /// <summary>

--- a/test/Autofac.Test/ResolutionExtensionsTests.cs
+++ b/test/Autofac.Test/ResolutionExtensionsTests.cs
@@ -124,5 +124,51 @@ namespace Autofac.Test
             Assert.Throws<ArgumentOutOfRangeException>(() =>
                 builder.RegisterType<WithProps>().WithProperty(x => x._field, a));
         }
+
+        [Fact]
+        public void WhenServiceIsRegistered_TryResolveNamedReturnsTrue()
+        {
+            const string name = "name";
+
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>().Named<object>(name);
+
+            var container = cb.Build();
+
+            Assert.True(container.TryResolveNamed<object>(name, out var o));
+            Assert.NotNull(o);
+        }
+
+        [Fact]
+        public void WhenServiceIsNotRegistered_TryResolveNamedReturnsFalse()
+        {
+            var container = Factory.CreateEmptyContainer();
+
+            Assert.False(container.TryResolveNamed<object>("name", out var o));
+            Assert.Null(o);
+        }
+
+        [Fact]
+        public void WhenServiceIsRegistered_TryResolveKeyedReturnsTrue()
+        {
+            var key = new object();
+
+            var cb = new ContainerBuilder();
+            cb.RegisterType<object>().Keyed<object>(key);
+
+            var container = cb.Build();
+
+            Assert.True(container.TryResolveKeyed<object>(key, out var o));
+            Assert.NotNull(o);
+        }
+
+        [Fact]
+        public void WhenServiceIsNotRegistered_TryResolveKeyedReturnsFalse()
+        {
+            var container = Factory.CreateEmptyContainer();
+
+            Assert.False(container.TryResolveKeyed<object>("name", out var o));
+            Assert.Null(o);
+        }
     }
 }


### PR DESCRIPTION
This adds generic counterparts for `TryResolveNamed` and `TryResolveKeyed` extensions.

Closes #1263 