### PR TITLE
Check iscompilergenerated last in canberegistered for perf reasons

### DIFF
--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -149,7 +149,7 @@ namespace Autofac.Features.Scanning
                                     !t.IsAbstract &&
                                     !t.IsDelegate() &&
                                     activatorData.Filters.All(p => p(t)) &&
-                                    !t.IsCompilerGenerated()); // run iscompilergenerated check last due to perf
+                                    !t.IsCompilerGenerated()); // run iscompilergenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
         }
 
         private static void ConfigureFrom<TActivatorData, TScanStyle, TRegistrationBuilderStyle>(


### PR DESCRIPTION
Reimplements PR https://github.com/autofac/Autofac/pull/994, please see that PR for more info what/why this fix is for.
We recently upgraded autofac and noticed that the fix was gone. This makes "test" `AssemblyScanningPerformanceTests.MeasurePerformance` perf better again. 


