### PR TITLE
Fix enum range in exception message raised when an invalid phase is used for registration middleware.

### DIFF
--- a/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
@@ -341,7 +341,7 @@ namespace Autofac.Core.Resolving.Pipeline
                             CultureInfo.CurrentCulture,
                             ResolvePipelineBuilderMessages.CannotAddServiceMiddlewareToRegistrationPipeline,
                             middlewarePhase,
-                            DescribeValidEnumRange(PipelinePhase.ResolveRequestStart, PipelinePhase.ServicePipelineEnd)));
+                            DescribeValidEnumRange(PipelinePhase.RegistrationPipelineStart, PipelinePhase.Activation)));
             }
         }
 

--- a/test/Autofac.Test/Core/Pipeline/PipelineBuilderTests.cs
+++ b/test/Autofac.Test/Core/Pipeline/PipelineBuilderTests.cs
@@ -404,6 +404,19 @@ namespace Autofac.Test.Core.Pipeline
         }
 
         [Fact]
+        public void ExceptionForAddingServiceMiddlewareToRegistrationPipelineContainsCorrectPhases()
+        {
+            var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Registration);
+            var order = new List<string>();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => pipelineBuilder.Use(
+                            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) => { })));
+
+            // Confirm phase content.
+            Assert.Contains("[RegistrationPipelineStart, ParameterSelection, Activation]", ex.Message);
+        }
+
+        [Fact]
         public void CannotAddBadPhaseToPipelineInUseRangeExistingMiddleware()
         {
             var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);


### PR DESCRIPTION
Fixes #1301 by making sure the right message is raised