### PR TITLE
Update to use the latest Codecov Uploader and SHA validation

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -66,9 +66,19 @@ try {
 
     if ($env:CI -eq "true") {
         # Generate Coverage Report
+        Write-Message "Downloading and verifying Codecov Uploader"
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest -Uri https://keybase.io/codecovsecurity/pgp_keys.asc -OutFile codecov.asc
+        gpg --no-default-keyring --keyring trustedkeys.gpg --import codecov.asc
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/linux/codecov -Outfile codecov
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/linux/codecov.SHA256SUM -Outfile codecov.SHA256SUM
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig -Outfile codecov.SHA256SUM.sig
+        gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+        shasum -a 256 -c codecov.SHA256SUM
+        chmod +x codecov
+
         Write-Message "Generating Codecov Report"
-        Invoke-WebRequest -Uri 'https://codecov.io/bash' -OutFile codecov.sh
-        & bash codecov.sh -f "artifacts/coverage/*/coverage*.info"
+        & ./codecov -f "artifacts/coverage/*/coverage*.info"
     }
 
     # Finished


### PR DESCRIPTION
The bash version of the Codecov Uploader [has been retired and the new version is a binary](https://docs.codecov.com/docs/codecov-uploader) you can download and check SHA hashes to verify integrity.

I've updated the build script to use this new uploader and fail if the checksums aren't correct.