### PR TITLE
Use base type for generic argument matching

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,6 +3,7 @@
     {
       "args": [
         "build",
+        "${workspaceFolder}/Autofac.sln",
         "/property:GenerateFullPaths=true",
         "/consoleloggerparameters:NoSummary"
       ],
@@ -17,6 +18,24 @@
       },
       "problemMatcher": "$msCompile",
       "type": "shell"
+    },
+    {
+      "args": [
+        "test",
+        "${workspaceFolder}/Autofac.sln",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary",
+        "--filter",
+        "FullyQualifiedName!~Benchmark"
+      ],
+      "command": "dotnet",
+      "group": {
+        "isDefault": true,
+        "kind": "test"
+      },
+      "label": "test",
+      "problemMatcher": "$msCompile",
+      "type": "process"
     }
   ],
   "version": "2.0.0"

--- a/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -179,7 +179,12 @@ internal static class OpenGenericServiceBinder
              *
              * If you have a class BaseClass<T1, T2> and a derived class
              * DerivedClass<A1, A2> : BaseClass<A2, A1> then then arguments need
-             * to line up name-wise like A2 -> T1 A1 -> T2
+             * to line up name-wise like...
+             * A2 -> T1
+             * A1 -> T2
+             *
+             * Having those symbols aligned means that, later, we can do a
+             * name-based match to populate the generic arguments.
              *
              * If you do a typeof(BaseClass<,>) then the generic arguments are
              * named T1 and T2, which doesn't help us line up the arguments in
@@ -187,8 +192,7 @@ internal static class OpenGenericServiceBinder
              * However, if you start at the derived class and walk backwards up
              * the inheritance hierarchy then instead of getting the original
              * T1/T2 naming, we get the names A1/A2 - the symbols as lined up by
-             * the compiler. Having those symbols aligned means that, later, we
-             * can do a name-based match to populate the generic arguments.
+             * the compiler.
              *
              * This is the same reason why Type.GetInterfaces() "just works" -
              * it's the generic in relation to the derived/implementing type

--- a/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -173,6 +173,28 @@ internal static class OpenGenericServiceBinder
 
         if (!serviceType.IsInterface)
         {
+            /* Issue #1315: We walk backwards in the inheritance hierarchy to
+             * find the open generic because that's the only way to ensure the
+             * generic argument names match.
+             *
+             * If you have a class BaseClass<T1, T2> and a derived class
+             * DerivedClass<A1, A2> : BaseClass<A2, A1> then then arguments need
+             * to line up name-wise like A2 -> T1 A1 -> T2
+             *
+             * If you do a typeof(BaseClass<,>) then the generic arguments are
+             * named T1 and T2, which doesn't help us line up the arguments in
+             * the derived class because the names and order have changed.
+             * However, if you start at the derived class and walk backwards up
+             * the inheritance hierarchy then instead of getting the original
+             * T1/T2 naming, we get the names A1/A2 - the symbols as lined up by
+             * the compiler. Having those symbols aligned means that, later, we
+             * can do a name-based match to populate the generic arguments.
+             *
+             * This is the same reason why Type.GetInterfaces() "just works" -
+             * it's the generic in relation to the derived/implementing type
+             * rather than just typeof(MyInterface<,>), so the names all line
+             * up.
+             */
             var baseType = GetGenericBaseType(implementationType, serviceTypeDefinition);
             if (baseType == null)
             {

--- a/test/Autofac.Specification.Test/Registration/OpenGenericTests.cs
+++ b/test/Autofac.Specification.Test/Registration/OpenGenericTests.cs
@@ -55,6 +55,19 @@ public class OpenGenericTests
         Assert.IsType<DerivedRepository<int, string>>(resolved);
     }
 
+    // Issue #1315: Class services fail to resolve if the names on the type
+    // arguments are changed. We should be able to handle a deep inheritance chain.
+    [Fact]
+    public void ResolveClassTwoLevelsDownWithRenamedTypeArguments()
+    {
+        var containerBuilder = new ContainerBuilder();
+        containerBuilder.RegisterGeneric(typeof(TwoLevelsDerivedRepository<,>)).As(typeof(BaseRepository<,>));
+
+        var container = containerBuilder.Build();
+        var resolved = container.Resolve<BaseRepository<string, int>>();
+        Assert.IsType<TwoLevelsDerivedRepository<int, string>>(resolved);
+    }
+
     private class SelfComponent<T> : IImplementedInterface<T>
     {
     }
@@ -66,6 +79,10 @@ public class OpenGenericTests
     // Issue #1315: Class services fail to resolve if the names on the type
     // arguments are changed.
     private class DerivedRepository<TSecond, TFirst> : BaseRepository<TFirst, TSecond>
+    {
+    }
+
+    private class TwoLevelsDerivedRepository<TA, TB> : DerivedRepository<TA, TB>
     {
     }
 }

--- a/test/Autofac.Specification.Test/Registration/OpenGenericTests.cs
+++ b/test/Autofac.Specification.Test/Registration/OpenGenericTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Autofac.Test.Scenarios.Graph1.GenericContraints;
+using Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
 namespace Autofac.Specification.Test.Registration;
 

--- a/test/Autofac.Specification.Test/Registration/OpenGenericTests.cs
+++ b/test/Autofac.Specification.Test/Registration/OpenGenericTests.cs
@@ -42,7 +42,30 @@ public class OpenGenericTests
         Assert.NotNull(resolved);
     }
 
+    // Issue #1315: Class services fail to resolve if the names on the type
+    // arguments are changed.
+    [Fact]
+    public void ResolveClassWithRenamedTypeArguments()
+    {
+        var containerBuilder = new ContainerBuilder();
+        containerBuilder.RegisterGeneric(typeof(DerivedRepository<,>)).As(typeof(BaseRepository<,>));
+
+        var container = containerBuilder.Build();
+        var resolved = container.Resolve<BaseRepository<string, int>>();
+        Assert.IsType<DerivedRepository<int, string>>(resolved);
+    }
+
     private class SelfComponent<T> : IImplementedInterface<T>
+    {
+    }
+
+    private class BaseRepository<T1, T2>
+    {
+    }
+
+    // Issue #1315: Class services fail to resolve if the names on the type
+    // arguments are changed.
+    private class DerivedRepository<TSecond, TFirst> : BaseRepository<TFirst, TSecond>
     {
     }
 }

--- a/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/A.cs
+++ b/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/A.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Graph1.GenericContraints;
+namespace Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
 public class A : IA
 {

--- a/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/ClassWithParameterlessButNotPublicConstructor.cs
+++ b/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/ClassWithParameterlessButNotPublicConstructor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Graph1.GenericContraints;
+namespace Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
 public class ClassWithParameterlessButNotPublicConstructor
 {

--- a/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/IA.cs
+++ b/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/IA.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Graph1.GenericContraints;
+namespace Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
-public interface IB<TResult>
+public interface IA
 {
 }

--- a/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/IB.cs
+++ b/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/IB.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Graph1.GenericContraints;
+namespace Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
-public class Required : IB<ClassWithParameterlessButNotPublicConstructor>
+public interface IB<TResult>
 {
 }

--- a/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/Required.cs
+++ b/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/Required.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Graph1.GenericContraints;
+namespace Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
-public class Unrelated<T> : IB<T>
-    where T : class, new()
+public class Required : IB<ClassWithParameterlessButNotPublicConstructor>
 {
 }

--- a/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/Unrelated.cs
+++ b/test/Autofac.Specification.Test/Resolution/Graph1/GenericConstraints/Unrelated.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Graph1.GenericContraints;
+namespace Autofac.Test.Scenarios.Graph1.GenericConstraints;
 
-public interface IA
+public class Unrelated<T> : IB<T>
+    where T : class, new()
 {
 }


### PR DESCRIPTION
Fix #1315.

When you call `GetInterfaces()` on a `Type`, it returns the set of implemented interfaces but has already swapped the generic type argument names in for the ones used on the implementing `Type`. For example, if you have:

```c#
public interface IThing<T1> { }
public class Thing<TFirst> : IThing<TFirst> { }
```

...then when you call `typeof(Thing<>).GetInterfaces()` the result will be `IThing<TFirst>` - the name of the argument matches the implementer's name, not the one in the actual interface definition.

We use this naming to line up the type parameters on generic types and service type interface implementations.

For classes, that's not what we were doing.

```c#
public class BaseClass<T1> { }
public class DerivedClass<TFirst> : BaseClass<TFirst> { }
```

In the class case, we were basically doing `typeof(DervivedClass<>).GetGenericArguments()` and `typeof(BaseClass<>).GetGenericArguments()` and _then_ trying to line up names. The problem is, the name had changed in the implementation so things wouldn't line up.

Instead of doing `typeof(BaseClass<>).GetGenericArguments()`, we need to _walk back in the class hierarchy_ to find where `DerivedClass<TFirst>` actually derives from `BaseClass<>` so we can make use of the compiler having already renamed all the generic arguments for us... _then_ we can match on name.

This PR does exactly that - walks back the inheritance hierarchy until it finds the derived class and then does the argument matching.

I added tests to show it'll work more than just one derived class deep, proving the updated name mapping works all the way down the stack.