### PR TITLE
Single constructor reflection optimisation

### DIFF
--- a/src/Autofac/Core/Activators/InstanceActivator.cs
+++ b/src/Autofac/Core/Activators/InstanceActivator.cs
@@ -42,7 +42,14 @@ public abstract class InstanceActivator : Disposable
     {
         if (IsDisposed)
         {
-            throw new ObjectDisposedException(InstanceActivatorResources.InstanceActivatorDisposed, innerException: null);
+            // Call separate throw method to allow inlining of the disposal check.
+            ThrowDisposedException();
         }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowDisposedException()
+    {
+        throw new ObjectDisposedException(InstanceActivatorResources.InstanceActivatorDisposed, innerException: null);
     }
 }

--- a/src/Autofac/Core/Activators/Reflection/BoundConstructor.cs
+++ b/src/Autofac/Core/Activators/Reflection/BoundConstructor.cs
@@ -98,10 +98,19 @@ public class BoundConstructor
             throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, BoundConstructorResources.CannotInstantitate, Description));
         }
 
-        var values = new object?[_valueRetrievers!.Length];
-        for (var i = 0; i < _valueRetrievers.Length; ++i)
+        object?[] values;
+
+        if (_valueRetrievers!.Length != 0)
         {
-            values[i] = _valueRetrievers[i]();
+            values = new object?[_valueRetrievers!.Length];
+            for (var i = 0; i < _valueRetrievers.Length; ++i)
+            {
+                values[i] = _valueRetrievers[i]();
+            }
+        }
+        else
+        {
+            values = Array.Empty<object?>();
         }
 
         try

--- a/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
@@ -36,7 +36,7 @@ public class ConstructorBinder
         if (_illegalParameter is null)
         {
             // Build the invoker.
-            _factory = FactoryCache.GetOrAdd(constructorInfo, FactoryBuilder);
+            _factory = FactoryCache.GetOrAdd(Constructor, FactoryBuilder);
         }
     }
 
@@ -111,6 +111,11 @@ public class ConstructorBinder
         }
 
         return BoundConstructor.ForBindSuccess(this, _factory!, valueRetrievers);
+    }
+
+    internal Func<object?[], object> GetConstructorInvoker()
+    {
+        return FactoryCache.GetOrAdd(Constructor, FactoryBuilder);
     }
 
     private static Func<object?[], object> GetConstructorInvoker(ConstructorInfo constructorInfo)

--- a/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
@@ -116,9 +116,12 @@ public class ConstructorBinder
     /// <summary>
     /// Get the constructor factory delegate.
     /// </summary>
-    internal Func<object?[], object> GetConstructorInvoker()
+    /// <remarks>Will return null if the constructor contains an invalid parameter.</remarks>
+    internal Func<object?[], object>? GetConstructorInvoker()
     {
-        return FactoryCache.GetOrAdd(Constructor, FactoryBuilder);
+        // Method is only used in zero-parameter constructors, so illegal parameters cannot happen.
+        // Adding the null check + throw just in case.
+        return _factory;
     }
 
     private static Func<object?[], object> GetConstructorInvoker(ConstructorInfo constructorInfo)

--- a/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
@@ -113,6 +113,9 @@ public class ConstructorBinder
         return BoundConstructor.ForBindSuccess(this, _factory!, valueRetrievers);
     }
 
+    /// <summary>
+    /// Get the constructor factory delegate.
+    /// </summary>
     internal Func<object?[], object> GetConstructorInvoker()
     {
         return FactoryCache.GetOrAdd(Constructor, FactoryBuilder);

--- a/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
+++ b/src/Autofac/Core/Activators/Reflection/ConstructorBinder.cs
@@ -119,8 +119,6 @@ public class ConstructorBinder
     /// <remarks>Will return null if the constructor contains an invalid parameter.</remarks>
     internal Func<object?[], object>? GetConstructorInvoker()
     {
-        // Method is only used in zero-parameter constructors, so illegal parameters cannot happen.
-        // Adding the null check + throw just in case.
         return _factory;
     }
 

--- a/src/Autofac/Core/Activators/Reflection/IConstructorSelectorWithEarlyBinding.cs
+++ b/src/Autofac/Core/Activators/Reflection/IConstructorSelectorWithEarlyBinding.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Core.Activators.Reflection;
+
+/// <summary>
+/// Defines an interface that indicates a constructor selector can attempt to
+/// determine the correct constructor early, as the container is built,
+/// without needing to understand the set of parameters in each resolve.
+/// </summary>
+public interface IConstructorSelectorWithEarlyBinding : IConstructorSelector
+{
+    /// <summary>
+    /// Given the set of all found constructors for a registration, try and
+    /// select the correct single <see cref="ConstructorBinder"/> to use.
+    /// </summary>
+    /// <param name="constructorBinders">
+    /// The set of binders for all constructors found by
+    /// <see cref="IConstructorFinder"/> on the registration.
+    /// </param>
+    /// <returns>
+    /// The single, correct binder to use. If the method returns null, this
+    /// indicates the selector requires resolve-time parameters, and the default
+    /// <see cref="IConstructorSelector.SelectConstructorBinding"/> method will
+    /// be invoked.
+    /// </returns>
+    ConstructorBinder? SelectConstructorBinder(ConstructorBinder[] constructorBinders);
+}

--- a/src/Autofac/Core/Activators/Reflection/MatchingSignatureConstructorSelector.cs
+++ b/src/Autofac/Core/Activators/Reflection/MatchingSignatureConstructorSelector.cs
@@ -8,7 +8,7 @@ namespace Autofac.Core.Activators.Reflection;
 /// <summary>
 /// Selects a constructor based on its signature.
 /// </summary>
-public class MatchingSignatureConstructorSelector : IConstructorSelector
+public class MatchingSignatureConstructorSelector : IConstructorSelector, IConstructorSelectorWithEarlyBinding
 {
     private readonly Type[] _signature;
 
@@ -81,21 +81,21 @@ public class MatchingSignatureConstructorSelector : IConstructorSelector
     /// <summary>
     /// Selects the best constructor from the available constructor bindings.
     /// </summary>
-    /// <param name="constructorBindings">Available constructors.</param>
+    /// <param name="constructorBinders">Available constructors.</param>
     /// <returns>The best constructor.</returns>
-    public ConstructorBinder SelectConstructorBinding(ConstructorBinder[] constructorBindings)
+    public ConstructorBinder SelectConstructorBinder(ConstructorBinder[] constructorBinders)
     {
-        if (constructorBindings == null)
+        if (constructorBinders == null)
         {
-            throw new ArgumentNullException(nameof(constructorBindings));
+            throw new ArgumentNullException(nameof(constructorBinders));
         }
 
         var matchingCount = 0;
         ConstructorBinder? chosen = null;
 
-        for (var idx = 0; idx < constructorBindings.Length; idx++)
+        for (var idx = 0; idx < constructorBinders.Length; idx++)
         {
-            var binding = constructorBindings[idx];
+            var binding = constructorBinders[idx];
 
             // Concievably could store the set of parameter types in the binder as well, but
             // that's yet more memory up-front, for a less used constructor selector.
@@ -112,7 +112,7 @@ public class MatchingSignatureConstructorSelector : IConstructorSelector
         }
 
         // DeclaringType will be non-null for constructors.
-        var targetTypeName = constructorBindings[0].Constructor.DeclaringType!.Name;
+        var targetTypeName = constructorBinders[0].Constructor.DeclaringType!.Name;
         var signature = string.Join(", ", _signature.Select(t => t.Name).ToArray());
 
         if (matchingCount == 0)

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -98,13 +98,16 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
             UseSingleConstructorActivation(pipelineBuilder, binders[0]);
             return;
         }
-        else if (ConstructorSelector is MatchingSignatureConstructorSelector matchingSelector)
+        else if (ConstructorSelector is IConstructorSelectorWithEarlyBinding earlyBindingSelector)
         {
-            var matchedConstructor = matchingSelector.SelectConstructorBinding(binders);
+            var matchedConstructor = earlyBindingSelector.SelectConstructorBinder(binders);
 
-            UseSingleConstructorActivation(pipelineBuilder, matchedConstructor);
+            if (matchedConstructor is not null)
+            {
+                UseSingleConstructorActivation(pipelineBuilder, matchedConstructor);
 
-            return;
+                return;
+            }
         }
 
         _constructorBinders = binders;
@@ -121,10 +124,20 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
     {
         if (singleConstructor.ParameterCount == 0)
         {
+            var constructorInvoker = singleConstructor.GetConstructorInvoker();
+
+            if (constructorInvoker is null)
+            {
+                // This is not going to happen, because there is only 1 constructor, that constructor has no parameters,
+                // so there are no conditions under which GetConstructorInvoker will return null in this path.
+                // Throw an error here just in case (and to satisfy nullability checks).
+                throw new NoConstructorsFoundException(_implementationType, string.Format(CultureInfo.CurrentCulture, ReflectionActivatorResources.NoConstructorsAvailable, _implementationType, ConstructorFinder));
+            }
+
             // If there are no arguments to the constructor, bypass all argument binding and pre-bind the constructor.
             var boundConstructor = BoundConstructor.ForBindSuccess(
                 singleConstructor,
-                singleConstructor.GetConstructorInvoker(),
+                constructorInvoker,
                 Array.Empty<Func<object?>>());
 
             // Fast-path to just create an instance.
@@ -212,8 +225,6 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
     private BoundConstructor[] GetAllBindings(ConstructorBinder[] availableConstructors, IComponentContext context, IEnumerable<Parameter> parameters)
     {
-        // Most often, there will be no `parameters` and/or no `_defaultParameters`; in both of those cases we can avoid allocating.
-        // Do a reference compare with the NoParameters constant; faster than an Any() check for the common case.
         var prioritisedParameters = GetAllParameters(parameters);
 
         var boundConstructors = new BoundConstructor[availableConstructors.Length];
@@ -241,6 +252,8 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
     private IEnumerable<Parameter> GetAllParameters(IEnumerable<Parameter> parameters)
     {
+        // Most often, there will be no `parameters` and/or no `_defaultParameters`; in both of those cases we can avoid allocating.
+        // Do a reference compare with the NoParameters constant; faster than an Any() check for the common case.
         if (ReferenceEquals(ResolveRequest.NoParameters, parameters))
         {
             return _defaultParameters;

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -3,7 +3,9 @@
 
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
+using Autofac.Core.Resolving;
 using Autofac.Core.Resolving.Pipeline;
 
 namespace Autofac.Core.Activators.Reflection;
@@ -91,6 +93,20 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
             binders[idx] = new ConstructorBinder(availableConstructors[idx]);
         }
 
+        if (binders.Length == 1)
+        {
+            UseSingleConstructorActivation(pipelineBuilder, binders[0]);
+            return;
+        }
+        else if (ConstructorSelector is MatchingSignatureConstructorSelector matchingSelector)
+        {
+            var matchedConstructor = matchingSelector.SelectConstructorBinding(binders);
+
+            UseSingleConstructorActivation(pipelineBuilder, matchedConstructor);
+
+            return;
+        }
+
         _constructorBinders = binders;
 
         pipelineBuilder.Use(ToString(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
@@ -99,6 +115,52 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
             next(ctxt);
         });
+    }
+
+    private void UseSingleConstructorActivation(IResolvePipelineBuilder pipelineBuilder, ConstructorBinder singleConstructor)
+    {
+        if (singleConstructor.ParameterCount == 0)
+        {
+            // If there are no arguments to the constructor, bypass all argument binding and pre-bind the constructor.
+            var boundConstructor = BoundConstructor.ForBindSuccess(
+                singleConstructor,
+                singleConstructor.GetConstructorInvoker(),
+                Array.Empty<Func<object?>>());
+
+            // Fast-path to just create an instance.
+            pipelineBuilder.Use(ToString(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
+            {
+                var instance = boundConstructor.Instantiate();
+
+                InjectProperties(instance, ctxt);
+
+                ctxt.Instance = instance;
+
+                next(ctxt);
+            });
+        }
+        else
+        {
+            pipelineBuilder.Use(ToString(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
+            {
+                var prioritisedParameters = GetAllParameters(ctxt.Parameters);
+
+                var bound = singleConstructor.Bind(prioritisedParameters, ctxt);
+
+                if (!bound.CanInstantiate)
+                {
+                    throw new DependencyResolutionException(GetBindingFailureMessage(new[] { bound }));
+                }
+
+                var instance = bound.Instantiate();
+
+                InjectProperties(instance, ctxt);
+
+                ctxt.Instance = instance;
+
+                next(ctxt);
+            });
+        }
     }
 
     /// <summary>
@@ -147,7 +209,8 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
     private BoundConstructor[] GetAllBindings(ConstructorBinder[] availableConstructors, IComponentContext context, IEnumerable<Parameter> parameters)
     {
         // Most often, there will be no `parameters` and/or no `_defaultParameters`; in both of those cases we can avoid allocating.
-        var prioritisedParameters = parameters.Any() ? EnumerateParameters(parameters) : _defaultParameters;
+        // Do a reference compare with the NoParameters constant; faster than an Any() check for the common case.
+        var prioritisedParameters = GetAllParameters(parameters);
 
         var boundConstructors = new BoundConstructor[availableConstructors.Length];
         var validBindings = availableConstructors.Length;
@@ -170,6 +233,21 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
         }
 
         return boundConstructors;
+    }
+
+    private IEnumerable<Parameter> GetAllParameters(IEnumerable<Parameter> parameters)
+    {
+        if (ReferenceEquals(ResolveRequest.NoParameters, parameters))
+        {
+            return _defaultParameters;
+        }
+
+        if (parameters.Any())
+        {
+            return EnumerateParameters(parameters);
+        }
+
+        return _defaultParameters;
     }
 
     private IEnumerable<Parameter> EnumerateParameters(IEnumerable<Parameter> parameters)

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -130,6 +130,8 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
             // Fast-path to just create an instance.
             pipelineBuilder.Use(ToString(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
             {
+                CheckNotDisposed();
+
                 var instance = boundConstructor.Instantiate();
 
                 InjectProperties(instance, ctxt);
@@ -143,6 +145,8 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
         {
             pipelineBuilder.Use(ToString(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
             {
+                CheckNotDisposed();
+
                 var prioritisedParameters = GetAllParameters(ctxt.Parameters);
 
                 var bound = singleConstructor.Bind(prioritisedParameters, ctxt);

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivatorResources.Designer.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivatorResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Autofac.Core.Activators.Reflection {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ReflectionActivatorResources {

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -443,7 +443,8 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
     {
         if (IsTreeDisposed())
         {
-            throw new ObjectDisposedException(LifetimeScopeResources.ScopeIsDisposed, innerException: null);
+            // Throw in a separate method to allow this check to be inlined.
+            ThrowDisposedException();
         }
     }
 
@@ -490,4 +491,10 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
     /// Fired when a resolve operation is beginning in this scope.
     /// </summary>
     public event EventHandler<ResolveOperationBeginningEventArgs>? ResolveOperationBeginning;
+
+    [DoesNotReturn]
+    private static void ThrowDisposedException()
+    {
+        throw new ObjectDisposedException(LifetimeScopeResources.ScopeIsDisposed, innerException: null);
+    }
 }

--- a/test/Autofac.Test/Core/Activators/Reflection/MatchingSignatureConstructorSelectorTests.cs
+++ b/test/Autofac.Test/Core/Activators/Reflection/MatchingSignatureConstructorSelectorTests.cs
@@ -67,7 +67,7 @@ public class MatchingSignatureConstructorSelectorTests
     public void SelectsConstructorInEarlyBinding()
     {
         var target0 = new MatchingSignatureConstructorSelector();
-        var c0 = target0.SelectConstructorBinding(GetConstructorBinders());
+        var c0 = target0.SelectConstructorBinder(GetConstructorBinders());
         Assert.Empty(c0.Constructor.GetParameters());
     }
 
@@ -75,7 +75,7 @@ public class MatchingSignatureConstructorSelectorTests
     public void SelectsConstructorWithParametersInEarlyBinding()
     {
         var target2 = new MatchingSignatureConstructorSelector(typeof(int), typeof(string));
-        var c2 = target2.SelectConstructorBinding(GetConstructorBinders());
+        var c2 = target2.SelectConstructorBinder(GetConstructorBinders());
         Assert.Equal(2, c2.Constructor.GetParameters().Length);
     }
 
@@ -85,7 +85,7 @@ public class MatchingSignatureConstructorSelectorTests
         var target = new MatchingSignatureConstructorSelector(typeof(string));
 
         var dx = Assert.Throws<DependencyResolutionException>(() =>
-            target.SelectConstructorBinding(GetConstructorBinders()));
+            target.SelectConstructorBinder(GetConstructorBinders()));
 
         Assert.Contains(typeof(FourConstructors).Name, dx.Message);
         Assert.Contains(typeof(string).Name, dx.Message);

--- a/test/Autofac.Test/Core/Activators/Reflection/MatchingSignatureConstructorSelectorTests.cs
+++ b/test/Autofac.Test/Core/Activators/Reflection/MatchingSignatureConstructorSelectorTests.cs
@@ -28,13 +28,11 @@ public class MatchingSignatureConstructorSelectorTests
         }
     }
 
-    private readonly BoundConstructor[] _ctors = GetConstructors();
-
     [Fact]
     public void SelectsEmptyConstructor()
     {
         var target0 = new MatchingSignatureConstructorSelector();
-        var c0 = target0.SelectConstructorBinding(_ctors, Enumerable.Empty<Parameter>());
+        var c0 = target0.SelectConstructorBinding(GetConstructors(), Enumerable.Empty<Parameter>());
         Assert.Empty(c0.TargetConstructor.GetParameters());
     }
 
@@ -42,7 +40,7 @@ public class MatchingSignatureConstructorSelectorTests
     public void SelectsConstructorWithParameters()
     {
         var target2 = new MatchingSignatureConstructorSelector(typeof(int), typeof(string));
-        var c2 = target2.SelectConstructorBinding(_ctors, Enumerable.Empty<Parameter>());
+        var c2 = target2.SelectConstructorBinding(GetConstructors(), Enumerable.Empty<Parameter>());
         Assert.Equal(2, c2.TargetConstructor.GetParameters().Length);
     }
 
@@ -50,7 +48,7 @@ public class MatchingSignatureConstructorSelectorTests
     public void IgnoresInvalidBindings()
     {
         var target2 = new MatchingSignatureConstructorSelector(typeof(int), typeof(string), typeof(double));
-        Assert.Throws<DependencyResolutionException>(() => target2.SelectConstructorBinding(_ctors, Enumerable.Empty<Parameter>()));
+        Assert.Throws<DependencyResolutionException>(() => target2.SelectConstructorBinding(GetConstructors(), Enumerable.Empty<Parameter>()));
     }
 
     [Fact]
@@ -59,7 +57,35 @@ public class MatchingSignatureConstructorSelectorTests
         var target = new MatchingSignatureConstructorSelector(typeof(string));
 
         var dx = Assert.Throws<DependencyResolutionException>(() =>
-            target.SelectConstructorBinding(_ctors, Enumerable.Empty<Parameter>()));
+            target.SelectConstructorBinding(GetConstructors(), Enumerable.Empty<Parameter>()));
+
+        Assert.Contains(typeof(FourConstructors).Name, dx.Message);
+        Assert.Contains(typeof(string).Name, dx.Message);
+    }
+
+    [Fact]
+    public void SelectsConstructorInEarlyBinding()
+    {
+        var target0 = new MatchingSignatureConstructorSelector();
+        var c0 = target0.SelectConstructorBinding(GetConstructorBinders());
+        Assert.Empty(c0.Constructor.GetParameters());
+    }
+
+    [Fact]
+    public void SelectsConstructorWithParametersInEarlyBinding()
+    {
+        var target2 = new MatchingSignatureConstructorSelector(typeof(int), typeof(string));
+        var c2 = target2.SelectConstructorBinding(GetConstructorBinders());
+        Assert.Equal(2, c2.Constructor.GetParameters().Length);
+    }
+
+    [Fact]
+    public void WhenNoMatchingConstructorsAvailable_ExceptionDescribesTargetTypeAndSignature_InEarlyBinding()
+    {
+        var target = new MatchingSignatureConstructorSelector(typeof(string));
+
+        var dx = Assert.Throws<DependencyResolutionException>(() =>
+            target.SelectConstructorBinding(GetConstructorBinders()));
 
         Assert.Contains(typeof(FourConstructors).Name, dx.Message);
         Assert.Contains(typeof(string).Name, dx.Message);
@@ -72,9 +98,16 @@ public class MatchingSignatureConstructorSelectorTests
         builder.Register(ctx => "test");
         var container = builder.Build();
 
+        return GetConstructorBinders()
+            .Select(cb => cb.Bind(new[] { new AutowiringParameter() }, container))
+            .ToArray();
+    }
+
+    private static ConstructorBinder[] GetConstructorBinders()
+    {
         return typeof(FourConstructors)
        .GetTypeInfo().DeclaredConstructors
-       .Select(ci => new ConstructorBinder(ci).Bind(new[] { new AutowiringParameter() }, container))
+       .Select(ci => new ConstructorBinder(ci))
        .ToArray();
     }
 }


### PR DESCRIPTION
We didn't actually need to generate extra delegates using the mechanism added in #1321, I've added fast-paths through the reflection activator for single-constructor and matched-sig-constructor selection that does "early binding" of sorts on the constructors where possible.

The approach taken actually means I don't need to change the binding exception handling at all, and the existing resolve check behaviour stays.

We get noticeable perf and memory usage improvements across the board. 

Some examples:

#### DeepGraphResolveBenchmark
```markdown
# develop
|  Method |     Mean |    Error |   StdDev |  Gen 0 | Allocated |
|-------- |---------:|---------:|---------:|-------:|----------:|
| Resolve | 13.97 μs | 0.061 μs | 0.054 μs | 4.1351 |     17 KB |

# optimised
|  Method |     Mean |    Error |   StdDev |   Median |  Gen 0 | Allocated |
|-------- |---------:|---------:|---------:|---------:|-------:|----------:|
| Resolve | 12.82 μs | 0.254 μs | 0.451 μs | 12.45 μs | 3.5553 |     15 KB |
```

#### ChildScopeResolveBenchmark
```markdown
# develop
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|----------:|
| Resolve | 32.08 μs | 0.195 μs | 0.173 μs | 7.4463 | 1.4648 |     31 KB |

# optimised 
|  Method |     Mean |    Error |   StdDev |  Gen 0 |  Gen 1 | Allocated |
|-------- |---------:|---------:|---------:|-------:|-------:|----------:|
| Resolve | 31.47 μs | 0.084 μs | 0.070 μs | 7.3853 | 1.4648 |     30 KB |
```

#### EnumerableResolveBenchmark
```markdown
# develop
|               Method |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|-------:|----------:|
|   ResolveIEnumerable | 3.066 μs | 0.0223 μs | 0.0186 μs | 0.9727 |      4 KB |
| ResolveIReadOnlyList | 3.070 μs | 0.0072 μs | 0.0064 μs | 0.9804 |      4 KB |
|         ResolveArray | 3.114 μs | 0.0106 μs | 0.0094 μs | 0.9727 |      4 KB |

# optimised
|               Method |     Mean |     Error |    StdDev |   Median |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|---------:|-------:|----------:|
|   ResolveIEnumerable | 2.747 μs | 0.0122 μs | 0.0114 μs | 2.749 μs | 0.8125 |      3 KB |
| ResolveIReadOnlyList | 2.795 μs | 0.0189 μs | 0.0167 μs | 2.791 μs | 0.8202 |      3 KB |
|         ResolveArray | 2.787 μs | 0.0557 μs | 0.1175 μs | 2.704 μs | 0.8125 |      3 KB |
```

#### Multi-Constructor Benchmarks
```markdown
# develop
|             Method |       Mean |   Error |  StdDev | Ratio |  Gen 0 | Allocated |
|------------------- |-----------:|--------:|--------:|------:|-------:|----------:|
|             Single |   813.9 ns | 2.08 ns | 1.84 ns |  1.00 | 0.3557 |      1 KB |
|                Two | 1,345.0 ns | 3.56 ns | 3.33 ns |  1.65 | 0.5455 |      2 KB |
| TwoValidOneInvalid | 1,684.5 ns | 6.15 ns | 5.75 ns |  2.07 | 0.6866 |      3 KB |
|              Three | 1,944.2 ns | 6.86 ns | 6.08 ns |  2.39 | 0.7782 |      3 KB |
|               Four | 2,568.4 ns | 8.19 ns | 7.66 ns |  3.16 | 1.0529 |      4 KB |

# optimised
|             Method |       Mean |    Error |  StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
|------------------- |-----------:|---------:|--------:|------:|--------:|-------:|----------:|
|             Single |   735.8 ns |  2.58 ns | 2.16 ns |  1.00 |    0.00 | 0.3204 |      1 KB |
|                Two | 1,220.8 ns |  8.80 ns | 6.87 ns |  1.66 |    0.01 | 0.4921 |      2 KB |
| TwoValidOneInvalid | 1,555.0 ns |  4.23 ns | 3.96 ns |  2.11 |    0.01 | 0.6313 |      3 KB |
|              Three | 1,769.7 ns |  6.51 ns | 6.09 ns |  2.40 |    0.01 | 0.7000 |      3 KB |
|               Four | 2,359.6 ns | 10.00 ns | 8.86 ns |  3.21 |    0.02 | 0.9460 |      4 KB |
```

Improvements on the multi-constructor benchmarks (which use the old path) may be down to the use of the `ReferenceEquals` check against the `NoParameters` constant, rather than `Any()`.