### PR TITLE
Improve scan perf

### DIFF
--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -92,7 +92,7 @@ internal static partial class ScanningRegistrationExtensions
             rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
                 t.IsOpenGenericTypeOf(swt.ServiceType)));
 
-        var types = assemblies.SelectMany(a => a.GetLoadableTypes())
+        var types = assemblies.SelectMany(a => a.PossibleScanTypes())
             .Where(t => t.IsGenericTypeDefinition)
             .CanBeRegistered(rb.ActivatorData);
 
@@ -141,10 +141,7 @@ internal static partial class ScanningRegistrationExtensions
         // non-public types here. Folks use assembly scanning on their
         // own stuff, so encapsulation is a tricky thing to manage.
         // If people want only public types, a LINQ Where clause can be used.
-        return types.Where(t => t.IsClass &&
-                                !t.IsAbstract &&
-                                !t.IsDelegate() &&
-                                activatorData.Filters.All(p => p(t)) &&
+        return types.Where(t => activatorData.Filters.All(p => p(t)) &&
                                 !t.IsCompilerGenerated()); // run iscompilergenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
     }
 

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -74,7 +74,7 @@ internal static partial class ScanningRegistrationExtensions
 
     private static void ScanAssemblies(IEnumerable<Assembly> assemblies, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
     {
-        ScanTypes(assemblies.SelectMany(a => a.GetLoadableTypes()), cr, rb);
+        ScanTypes(assemblies.SelectMany(a => a.PossibleScanTypes()), cr, rb);
     }
 
     private static void ScanTypes(IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)

--- a/test/Autofac.Specification.Test/Registration/AssemblyScanningPerformanceTests.cs
+++ b/test/Autofac.Specification.Test/Registration/AssemblyScanningPerformanceTests.cs
@@ -17,7 +17,7 @@ public class AssemblyScanningPerformanceTests
     public void MeasurePerformance()
     {
         var builder = new ContainerBuilder();
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < 10_000; i++)
         {
             // Just to simulate a lot of "scanning" with few (in this case zero) "hits"
             builder.RegisterAssemblyTypes(GetType().Assembly).Where(x => false);
@@ -26,7 +26,7 @@ public class AssemblyScanningPerformanceTests
         var stopwatch = Stopwatch.StartNew();
         builder.Build().Dispose();
 
-        // After fix drops from ~500ms to ~100ms
+        // Should take no more than ~500ms
         _output.WriteLine(stopwatch.Elapsed.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
     }
 }


### PR DESCRIPTION
When, like us, have multiple RegisterAssemblyTypes (and large assemblies) and creating loads of container when running our test suites, the "general type checks" IsClass, IsAbstract and IsDelegate that is called over and over again on the very same type takes noticeable time.

I used old test AssemblyScanningPerformanceTests.MeasurePerformance as a benchmark. It now runs "too fast" so fyi increased the loop with *10 as part of this PR.

Note! Everything should work as before except...
In `ScanningRegistrationExtensions.RegisterTypes(RegisterTypes, params Type[])`, it's different behavior now. the "general type checks" mentioned above is no longer called, as that method calls `ScanTypes` directly. Not sure if these "general type checks" needs to be added explicitly here? I didn't change it in this PR as all tests are green, better listen with you first.