### PR TITLE
Ignore revs in git blame.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Ignore revisions in git blame - set your git config to use the file by convention:
+# git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Optional additional git config:
+# Mark any lines that have had a commit skipped using --ignore-rev with a `?`
+# git config --global blame.markIgnoredLines true
+# Mark any lines that were added in a skipped commit and can not be attributed with a `*`
+# git config --global blame.markUnblamableLines true
+
+# Convert to file-scoped namespaces.
+48039bd166a76ad7935e3c66eb608fd08b0889fc


### PR DESCRIPTION
Large scale changes that modify trivial things (tab-to-space conversion, file-scoped namespaces, etc.) can be ignored in git blame in git 2.23+. I think this will help with, as noted, the file-scoped namespace conversion, to see the "real" history of lines.

It does require some git client config, which I noted in the file. Community convention seems to be `.git-blame-ignore-revs` as the filename but this isn't a built-in convention like `.gitignore` or `.gitattributes`.

Based on [this blog article](https://akrabat.com/ignoring-revisions-with-git-blame/) and [this blog article](https://michaelheap.com/git-ignore-rev/).