### PR TITLE
Remove misleading comment

### DIFF
--- a/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
+++ b/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
@@ -106,6 +106,7 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
                 {
                     return vt;
                 }
+
                 static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
                 return Awaiter(vt);
             }
@@ -113,9 +114,10 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
             {
                 // Call the standard Dispose.
                 disposable.Dispose();
-                return default;
             }
         }
+
+        return default;
 
         // Do not call the base, otherwise the standard Dispose will fire.
     }

--- a/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
+++ b/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
@@ -106,16 +106,14 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
                 {
                     return vt;
                 }
-                else
-                {
-                    static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
-                    return Awaiter(vt);
-                }
+                static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
+                return Awaiter(vt);
             }
             else if (_instance is IDisposable disposable)
             {
                 // Call the standard Dispose.
                 disposable.Dispose();
+                return default;
             }
         }
 

--- a/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
+++ b/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
@@ -101,13 +101,7 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
             // If the item implements IAsyncDisposable we will call its DisposeAsync Method.
             if (_instance is IAsyncDisposable asyncDisposable)
             {
-                var vt = asyncDisposable.DisposeAsync();
-
-                // Don't await if it's already completed (this is a slight gain in performance of using ValueTask).
-                if (!vt.IsCompletedSuccessfully)
-                {
-                    await vt.ConfigureAwait(false);
-                }
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
             }
             else if (_instance is IDisposable disposable)
             {

--- a/src/Autofac/Core/Disposer.cs
+++ b/src/Autofac/Core/Disposer.cs
@@ -87,13 +87,7 @@ internal class Disposer : Disposable, IDisposer
                     // If the item implements IAsyncDisposable we will call its DisposeAsync Method.
                     if (item is IAsyncDisposable asyncDisposable)
                     {
-                        var vt = asyncDisposable.DisposeAsync();
-
-                        // Don't await if it's already completed (this is a slight gain in performance of using ValueTask).
-                        if (!vt.IsCompletedSuccessfully)
-                        {
-                            await vt.ConfigureAwait(false);
-                        }
+                        await asyncDisposable.DisposeAsync().ConfigureAwait(false);
                     }
                     else if (item is IDisposable disposable)
                     {

--- a/src/Autofac/Core/Registration/ComponentRegistration.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistration.cs
@@ -330,15 +330,17 @@ public class ComponentRegistration : Disposable, IComponentRegistration
                 {
                     return vt;
                 }
+
                 static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
                 return Awaiter(vt);
             }
             else
             {
                 Activator.Dispose();
-                return default;
             }
         }
+
+        return default;
 
         // Do not call the base, otherwise the standard Dispose will fire.
     }

--- a/src/Autofac/Core/Registration/ComponentRegistration.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistration.cs
@@ -325,13 +325,7 @@ public class ComponentRegistration : Disposable, IComponentRegistration
             // Check the Activator type so we don't have to force Activators to implement IAsyncDisposable if they don't need it.
             if (Activator is IAsyncDisposable asyncDispose)
             {
-                var vt = asyncDispose.DisposeAsync();
-
-                // Don't await if it's already completed (this is a slight gain in performance of using ValueTask).
-                if (!vt.IsCompletedSuccessfully)
-                {
-                    await vt.ConfigureAwait(false);
-                }
+                await asyncDispose.DisposeAsync().ConfigureAwait(false);
             }
             else
             {

--- a/src/Autofac/Core/Registration/ComponentRegistration.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistration.cs
@@ -330,15 +330,13 @@ public class ComponentRegistration : Disposable, IComponentRegistration
                 {
                     return vt;
                 }
-                else
-                {
-                    static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
-                    return Awaiter(vt);
-                }
+                static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
+                return Awaiter(vt);
             }
             else
             {
                 Activator.Dispose();
+                return default;
             }
         }
 

--- a/src/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistry.cs
@@ -110,13 +110,7 @@ internal class ComponentRegistry : Disposable, IComponentRegistry
     /// <inheritdoc />
     protected override async ValueTask DisposeAsync(bool disposing)
     {
-        var vt = _registeredServicesTracker.DisposeAsync();
-
-        // Don't await if it's already completed (this is a slight gain in performance of using ValueTask).
-        if (!vt.IsCompleted)
-        {
-            await vt.ConfigureAwait(false);
-        }
+        await _registeredServicesTracker.DisposeAsync().ConfigureAwait(false);
 
         // Do not call the base, otherwise the standard Dispose will fire.
     }

--- a/src/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistry.cs
@@ -115,11 +115,9 @@ internal class ComponentRegistry : Disposable, IComponentRegistry
         {
             return vt;
         }
-        else
-        {
-            static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
-            return Awaiter(vt);
-        }
+
+        static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
+        return Awaiter(vt);
 
         // Do not call the base, otherwise the standard Dispose will fire.
     }

--- a/src/Autofac/Core/Registration/ComponentRegistry.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistry.cs
@@ -108,9 +108,18 @@ internal class ComponentRegistry : Disposable, IComponentRegistry
     }
 
     /// <inheritdoc />
-    protected override async ValueTask DisposeAsync(bool disposing)
+    protected override ValueTask DisposeAsync(bool disposing)
     {
-        await _registeredServicesTracker.DisposeAsync().ConfigureAwait(false);
+        var vt = _registeredServicesTracker.DisposeAsync();
+        if (vt.IsCompletedSuccessfully)
+        {
+            return vt;
+        }
+        else
+        {
+            static async ValueTask Awaiter(ValueTask vt) => await vt.ConfigureAwait(false);
+            return Awaiter(vt);
+        }
 
         // Do not call the base, otherwise the standard Dispose will fire.
     }

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -259,13 +259,7 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
     {
         foreach (var registration in _registrations)
         {
-            var vt = registration.DisposeAsync();
-
-            // Don't await if it's already completed (this is a slight gain in performance of using ValueTask).
-            if (!vt.IsCompletedSuccessfully)
-            {
-                await vt.ConfigureAwait(false);
-            }
+            await registration.DisposeAsync().ConfigureAwait(false);
         }
 
         // Do not call the base, otherwise the standard Dispose will fire.


### PR DESCRIPTION
This code may produces leaks: if `ValueTask` backed by `IValueTaskSource` `ValueTaskSource<TResult>.GetResult(token)` won't get called, so it can't free result associated with that token.

And compiler generated code already checks for `IsCompleted`: 
https://sharplab.io/#v2:D4AQDABCCMCsDcBYAUCkBmKAmCBhCA3ihCVJiABwQBqAhgDYCuApiAGwQCyAFHU6xwAuASkLFSEiAEsAZhG6CAdAEkAzrgD2AWwAO9ZoOYATAMqMAxuearVMxvXoBPYeMluQAdiTI3pEAE4IQW8JAF8UcNRkIA==
