### PR TITLE
Add support for replacing an instance activator in IComponentRegistration

### DIFF
--- a/src/Autofac/Core/IComponentRegistration.cs
+++ b/src/Autofac/Core/IComponentRegistration.cs
@@ -78,4 +78,18 @@ public interface IComponentRegistration : IDisposable, IAsyncDisposable
     /// </summary>
     /// <param name="registryServices">The available services.</param>
     void BuildResolvePipeline(IComponentRegistryServices registryServices);
+
+    /// <summary>
+    /// Replaces the activator for the registration.
+    /// </summary>
+    /// <remarks>
+    /// You can only invoke this method inside
+    /// a <see cref="IComponentRegistryBuilder.Registered"/> handler.
+    /// </remarks>
+    /// <param name="activator">The new activator.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if <see cref="ReplaceActivator"/> is invoked
+    /// after the registration pipeline has been built, or if this registration targets a different one.
+    /// </exception>
+    void ReplaceActivator(IInstanceActivator activator);
 }

--- a/src/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistrationLifetimeDecorator.cs
@@ -68,6 +68,9 @@ internal class ComponentRegistrationLifetimeDecorator : Disposable, IComponentRe
         _inner.BuildResolvePipeline(registryServices);
     }
 
+    /// <inheritdoc />
+    public void ReplaceActivator(IInstanceActivator activator) => _inner.ReplaceActivator(activator);
+
     /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {

--- a/src/Autofac/Core/Registration/ComponentRegistrationResources.Designer.cs
+++ b/src/Autofac/Core/Registration/ComponentRegistrationResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Autofac.Core.Registration {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ComponentRegistrationResources {
@@ -84,6 +84,33 @@ namespace Autofac.Core.Registration {
         internal static string PipelineNotBuilt {
             get {
                 return ResourceManager.GetString("PipelineNotBuilt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The limit type &apos;{0}&apos; of the new activator is not assignable to service &apos;{1}&apos;..
+        /// </summary>
+        internal static string ReplaceActivatorComponentDoesNotSupportService {
+            get {
+                return ResourceManager.GetString("ReplaceActivatorComponentDoesNotSupportService", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot replace the activator of a registration once the registration pipeline has been built..
+        /// </summary>
+        internal static string ReplaceActivatorPipelineAlreadyBuilt {
+            get {
+                return ResourceManager.GetString("ReplaceActivatorPipelineAlreadyBuilt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot replace the activator of a registration that targets another registration..
+        /// </summary>
+        internal static string ReplaceActivatorTargetingRegistration {
+            get {
+                return ResourceManager.GetString("ReplaceActivatorTargetingRegistration", resourceCulture);
             }
         }
         

--- a/src/Autofac/Core/Registration/ComponentRegistrationResources.resx
+++ b/src/Autofac/Core/Registration/ComponentRegistrationResources.resx
@@ -126,6 +126,15 @@
   <data name="PipelineNotBuilt" xml:space="preserve">
     <value>Not Built</value>
   </data>
+  <data name="ReplaceActivatorComponentDoesNotSupportService" xml:space="preserve">
+    <value>The limit type '{0}' of the new activator is not assignable to service '{1}'.</value>
+  </data>
+  <data name="ReplaceActivatorPipelineAlreadyBuilt" xml:space="preserve">
+    <value>Cannot replace the activator of a registration once the registration pipeline has been built.</value>
+  </data>
+  <data name="ReplaceActivatorTargetingRegistration" xml:space="preserve">
+    <value>Cannot replace the activator of a registration that targets another registration.</value>
+  </data>
   <data name="ToStringFormat" xml:space="preserve">
     <value>Activator = {0}, Services = [{1}], Lifetime = {2}, Sharing = {3}, Ownership = {4}, Pipeline = {5}</value>
   </data>

--- a/test/Autofac.Test/Factory.cs
+++ b/test/Autofac.Test/Factory.cs
@@ -37,6 +37,19 @@ internal static class Factory
             GetDefaultMetadata());
     }
 
+    public static IComponentRegistration CreateTargetingRegistration(IComponentRegistration target)
+    {
+        return new ComponentRegistration(
+            target.Id,
+            target.Activator,
+            target.Lifetime,
+            target.Sharing,
+            target.Ownership,
+            target.Services,
+            target.Metadata,
+            target);
+    }
+
     public static IComponentRegistration CreateSingletonRegistration<T>(T instance)
     {
         return RegistrationBuilder

--- a/test/Autofac.Test/Mocks.cs
+++ b/test/Autofac.Test/Mocks.cs
@@ -109,6 +109,8 @@ internal static class Mocks
         {
             PipelineBuilding?.Invoke(this, new ResolvePipelineBuilder(PipelineType.Registration));
         }
+
+        public void ReplaceActivator(IInstanceActivator activator) => throw new NotImplementedException();
     }
 
     internal class MockTracer : DiagnosticTracerBase

--- a/test/Autofac.Test/ModuleTests.cs
+++ b/test/Autofac.Test/ModuleTests.cs
@@ -47,7 +47,6 @@ public class ModuleTests
         }
     }
 
-
     [Fact]
     public void AttachesToRegistrations()
     {


### PR DESCRIPTION
Have added a `ReplaceActivator` method that throws exceptions if it is called _after_ the `Registered` event, or if the registration is the `Target` of another. 

It feels unwise to allow modification of a registration's activator if the registration's activator is actually from somewhere else.

Targeting registrations are always created _after_ the targeting registration has been built, so no chance of it losing a reference to the 'correct' activator.

Fixes #1337.

