### PR TITLE
Make IDecoratorContext extend IComponentContext.

### DIFF
--- a/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
+++ b/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
@@ -62,7 +62,7 @@ internal class DecoratorMiddleware : IResolveMiddleware
 
         if (context.DecoratorContext is null)
         {
-            context.DecoratorContext = DecoratorContext.Create(context.Instance.GetType(), serviceType, context.Instance);
+            context.DecoratorContext = DecoratorContext.Create(context, context.Instance.GetType(), serviceType, context.Instance);
         }
         else
         {

--- a/src/Autofac/Features/Decorators/IDecoratorContext.cs
+++ b/src/Autofac/Features/Decorators/IDecoratorContext.cs
@@ -6,7 +6,7 @@ namespace Autofac.Features.Decorators;
 /// <summary>
 /// Defines the context interface used during the decoration process.
 /// </summary>
-public interface IDecoratorContext
+public interface IDecoratorContext : IComponentContext
 {
     /// <summary>
     /// Gets the implementation type of the service that is being decorated.

--- a/test/Autofac.Test/Features/Decorators/DecoratorContextTests.cs
+++ b/test/Autofac.Test/Features/Decorators/DecoratorContextTests.cs
@@ -12,7 +12,7 @@ public class DecoratorContextTests
     {
         const string implementationInstance = "Initial";
 
-        var context = DecoratorContext.Create(typeof(string), typeof(string), implementationInstance);
+        var context = DecoratorContext.Create(Factory.CreateEmptyContext(), typeof(string), typeof(string), implementationInstance);
 
         Assert.Equal(typeof(string), context.ServiceType);
         Assert.Equal(typeof(string), context.ImplementationType);
@@ -25,7 +25,7 @@ public class DecoratorContextTests
     public void UpdateAddsDecoratorStateToContext()
     {
         const string implementationInstance = "Initial";
-        var context = DecoratorContext.Create(typeof(string), typeof(string), implementationInstance);
+        var context = DecoratorContext.Create(Factory.CreateEmptyContext(), typeof(string), typeof(string), implementationInstance);
 
         const string decoratorA = "DecoratorA";
         context = context.UpdateContext(decoratorA);

--- a/test/Autofac.Test/Features/Decorators/DecoratorServiceTests.cs
+++ b/test/Autofac.Test/Features/Decorators/DecoratorServiceTests.cs
@@ -19,7 +19,7 @@ public class DecoratorServiceTests
     {
         var service = new DecoratorService(typeof(string));
 
-        var context = DecoratorContext.Create(typeof(string), typeof(string), "A");
+        var context = DecoratorContext.Create(Factory.CreateEmptyContext(), typeof(string), typeof(string), "A");
 
         Assert.True(service.Condition(context));
     }


### PR DESCRIPTION
Fairly simple change this one; added a test to prove resolve from decorator conditional is possible.

Also added a test to prove that if a decorator resolves _itself_ from inside the conditional, it throws a circular dependency exception (rather than stack-overflowing or something).

Closes #1338.