### PR TITLE
Fix memory leak regression

### DIFF
--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -249,17 +249,7 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
             registration.Dispose();
         }
 
-        // If we do not explicitly empty the ConcurrentBag that stores our registrations,
-        // this will cause a memory leak due to threads holding a reference to the bag.
-        // In netstandard2.0 the faster 'Clear' method is not available,
-        // so we have do this manually. We'll use the faster method if it's available though.
-#if NETSTANDARD2_0
-        while (_registrations.TryTake(out _))
-        {
-        }
-#else
-        _registrations.Clear();
-#endif
+        ClearRegistrations();
 
         base.Dispose(disposing);
     }
@@ -272,7 +262,24 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
             await registration.DisposeAsync().ConfigureAwait(false);
         }
 
+        ClearRegistrations();
+
         // Do not call the base, otherwise the standard Dispose will fire.
+    }
+
+    private void ClearRegistrations()
+    {
+        // If we do not explicitly empty the ConcurrentBag that stores our registrations,
+        // this will cause a memory leak due to threads holding a reference to the bag.
+        // In netstandard2.0 the faster 'Clear' method is not available,
+        // so we have do this manually. We'll use the faster method if it's available though.
+#if NETSTANDARD2_0
+        while (_registrations.TryTake(out _))
+        {
+        }
+#else
+        _registrations.Clear();
+#endif
     }
 
     private ServiceRegistrationInfo GetInitializedServiceInfo(Service service)


### PR DESCRIPTION
Fix memory leak due to use of ConcurrentBag for registrations by ensuring we empty the bag when we're done with it.

Bug was fixed in https://github.com/autofac/Autofac/pull/1257 
AsyncDispose was not aware of this issue. 

![image](https://user-images.githubusercontent.com/2981998/197700952-6713ad9c-a116-4448-ac31-63daebd9e919.png)
