### PR TITLE
Mark RegisterGeneratedFactory obsolete

### DIFF
--- a/src/Autofac/Builder/RegistrationExtensions.cs
+++ b/src/Autofac/Builder/RegistrationExtensions.cs
@@ -25,6 +25,7 @@ public static class RegistrationExtensions
     /// <returns>Registration builder allowing the registration to be configured.</returns>
     /// <remarks>Factory delegates are provided automatically in Autofac 2,
     /// and this method is generally not required.</remarks>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<Delegate, GeneratedFactoryActivatorData, SingleRegistrationStyle>
         RegisterGeneratedFactory(this ContainerBuilder builder, Type delegateType)
     {
@@ -48,6 +49,7 @@ public static class RegistrationExtensions
     /// <returns>Registration builder allowing the registration to be configured.</returns>
     /// <remarks>Factory delegates are provided automatically in Autofac 2, and
     /// this method is generally not required.</remarks>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<Delegate, GeneratedFactoryActivatorData, SingleRegistrationStyle>
         RegisterGeneratedFactory(this ContainerBuilder builder, Type delegateType, Service service)
     {
@@ -68,6 +70,7 @@ public static class RegistrationExtensions
     /// <returns>Registration builder allowing the registration to be configured.</returns>
     /// <remarks>Factory delegates are provided automatically in Autofac 2,
     /// and this method is generally not required.</remarks>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<TDelegate, GeneratedFactoryActivatorData, SingleRegistrationStyle>
         RegisterGeneratedFactory<TDelegate>(this ContainerBuilder builder, Service service)
         where TDelegate : class
@@ -88,6 +91,7 @@ public static class RegistrationExtensions
     /// <returns>Registration builder allowing the registration to be configured.</returns>
     /// <remarks>Factory delegates are provided automatically in Autofac 2,
     /// and this method is generally not required.</remarks>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<TDelegate, GeneratedFactoryActivatorData, SingleRegistrationStyle>
         RegisterGeneratedFactory<TDelegate>(this ContainerBuilder builder)
         where TDelegate : class
@@ -115,6 +119,7 @@ public static class RegistrationExtensions
     /// <exception cref="System.ArgumentNullException">
     /// Thrown if <paramref name="registration" /> is <see langword="null" />.
     /// </exception>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle>
         NamedParameterMapping<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle>(
             this IRegistrationBuilder<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle> registration)
@@ -142,6 +147,7 @@ public static class RegistrationExtensions
     /// <exception cref="System.ArgumentNullException">
     /// Thrown if <paramref name="registration" /> is <see langword="null" />.
     /// </exception>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle>
         PositionalParameterMapping<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle>(
             this IRegistrationBuilder<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle> registration)
@@ -169,6 +175,7 @@ public static class RegistrationExtensions
     /// <exception cref="System.ArgumentNullException">
     /// Thrown if <paramref name="registration" /> is <see langword="null" />.
     /// </exception>
+    [Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
     public static IRegistrationBuilder<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle>
         TypedParameterMapping<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle>(
             this IRegistrationBuilder<TDelegate, TGeneratedFactoryActivatorData, TSingleRegistrationStyle> registration)

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -177,20 +177,12 @@ internal class ServiceRegistrationInfo : IResolvePipelineBuilder
         {
             if (originatedFromSource)
             {
-                if (_sourceImplementations == null)
-                {
-                    _sourceImplementations = new List<IComponentRegistration>();
-                }
-
+                _sourceImplementations ??= new List<IComponentRegistration>();
                 _sourceImplementations.Add(registration);
             }
             else
             {
-                if (_preserveDefaultImplementations == null)
-                {
-                    _preserveDefaultImplementations = new List<IComponentRegistration>();
-                }
-
+                _preserveDefaultImplementations ??= new List<IComponentRegistration>();
                 _preserveDefaultImplementations.Add(registration);
             }
         }
@@ -214,11 +206,7 @@ internal class ServiceRegistrationInfo : IResolvePipelineBuilder
     /// <param name="insertionMode">The insertion mode for the pipeline.</param>
     public void UseServiceMiddleware(IResolveMiddleware middleware, MiddlewareInsertionMode insertionMode = MiddlewareInsertionMode.EndOfPhase)
     {
-        if (_customPipelineBuilder is null)
-        {
-            _customPipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
-        }
-
+        _customPipelineBuilder ??= new ResolvePipelineBuilder(PipelineType.Service);
         _customPipelineBuilder.Use(middleware, insertionMode);
     }
 
@@ -234,11 +222,7 @@ internal class ServiceRegistrationInfo : IResolvePipelineBuilder
             return;
         }
 
-        if (_customPipelineBuilder is null)
-        {
-            _customPipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
-        }
-
+        _customPipelineBuilder ??= new ResolvePipelineBuilder(PipelineType.Service);
         _customPipelineBuilder.UseRange(middleware, insertionMode);
     }
 
@@ -280,10 +264,7 @@ internal class ServiceRegistrationInfo : IResolvePipelineBuilder
 
         // Build the pipeline during service info initialization, so that sources can access it
         // while getting a registration recursively.
-        if (_resolvePipeline is null)
-        {
-            _resolvePipeline = BuildPipeline();
-        }
+        _resolvePipeline ??= BuildPipeline();
     }
 
     /// <summary>

--- a/src/Autofac/Core/Resolving/SegmentedStack.cs
+++ b/src/Autofac/Core/Resolving/SegmentedStack.cs
@@ -112,7 +112,7 @@ public sealed class SegmentedStack<T> : IEnumerable<T>
         return new Enumerator(this);
     }
 
-    private struct StackSegment : IDisposable
+    private readonly struct StackSegment : IDisposable
     {
         private readonly SegmentedStack<T> _stack;
         private readonly int _resetPosition;

--- a/src/Autofac/Core/ServiceRegistration.cs
+++ b/src/Autofac/Core/ServiceRegistration.cs
@@ -9,7 +9,7 @@ namespace Autofac.Core;
 /// <summary>
 /// Defines a combination of a service pipeline and a registration. Used to instantiate a <see cref="ResolveRequest"/>.
 /// </summary>
-public struct ServiceRegistration : IEquatable<ServiceRegistration>
+public readonly struct ServiceRegistration : IEquatable<ServiceRegistration>
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ServiceRegistration"/> struct.

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryActivatorData.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryActivatorData.cs
@@ -10,6 +10,7 @@ namespace Autofac.Features.GeneratedFactories;
 /// <summary>
 /// Data used to create factory activators.
 /// </summary>
+[Obsolete("Update your code to use the Func<T> implicit relationship or delegate factories. See https://autofac.readthedocs.io/en/latest/resolve/relationships.html and https://autofac.readthedocs.io/en/latest/advanced/delegate-factories.html for more information.")]
 public class GeneratedFactoryActivatorData : IConcreteActivatorData
 {
     private readonly Type _delegateType;

--- a/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationExtensions.cs
+++ b/src/Autofac/Features/GeneratedFactories/GeneratedFactoryRegistrationExtensions.cs
@@ -6,6 +6,8 @@ using Autofac.Core;
 
 namespace Autofac.Features.GeneratedFactories;
 
+#pragma warning disable CS0618
+
 /// <summary>
 /// Helper methods for registering factories.
 /// </summary>

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -96,16 +96,14 @@ internal static partial class ScanningRegistrationExtensions
             .Where(t => t.IsGenericTypeDefinition)
             .CanBeRegistered(rb.ActivatorData);
 
-        Func<Type, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>> scannedConstructor =
-            (type) => new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
+        static IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> TypeBuilderFactory(Type type) => new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
                 new TypedService(type),
                 new ReflectionActivatorData(type),
                 new DynamicRegistrationStyle());
 
-        Action<IComponentRegistryBuilder, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>> register =
-            (cr, scanned) => cr.AddRegistrationSource(new OpenGenericRegistrationSource(scanned.RegistrationData, scanned.ResolvePipeline, scanned.ActivatorData));
+        static void RegistrationSourceFactory(IComponentRegistryBuilder cr, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> scanned) => cr.AddRegistrationSource(new OpenGenericRegistrationSource(scanned.RegistrationData, scanned.ResolvePipeline, scanned.ActivatorData));
 
-        ScanTypesTemplate(types, cr, rb, scannedConstructor, register);
+        ScanTypesTemplate(types, cr, rb, TypeBuilderFactory, RegistrationSourceFactory);
     }
 
     private static void ScanTypesTemplate<TActivatorData, TScanStyle, TRegistrationBuilderStyle>(

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -101,7 +101,7 @@ internal static partial class ScanningRegistrationExtensions
                 new ReflectionActivatorData(type),
                 new DynamicRegistrationStyle());
 
-        static void RegistrationSourceFactory(IComponentRegistryBuilder cr, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> scanned) => cr.AddRegistrationSource(new OpenGenericRegistrationSource(scanned.RegistrationData, scanned.ResolvePipeline, scanned.ActivatorData));
+        static void RegistrationSourceFactory(IComponentRegistryBuilder registry, IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> data) => registry.AddRegistrationSource(new OpenGenericRegistrationSource(data.RegistrationData, data.ResolvePipeline, data.ActivatorData));
 
         ScanTypesTemplate(types, cr, rb, TypeBuilderFactory, RegistrationSourceFactory);
     }

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -86,9 +86,9 @@ internal static partial class ScanningRegistrationExtensions
             rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
                 swt.ServiceType.IsAssignableFrom(t)));
 
-        IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> TypeBuilderFactory(Type type) => RegistrationBuilder.ForType(type);
+        static IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> TypeBuilderFactory(Type type) => RegistrationBuilder.ForType(type);
 
-        void SingleComponentRegistration(IComponentRegistryBuilder cr, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> scanned) => RegistrationBuilder.RegisterSingleComponent(cr, scanned);
+        static void SingleComponentRegistration(IComponentRegistryBuilder registry, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> data) => RegistrationBuilder.RegisterSingleComponent(registry, data);
 
         ScanTypesTemplate(closedTypes, cr, rb, TypeBuilderFactory, SingleComponentRegistration);
     }

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -86,13 +86,11 @@ internal static partial class ScanningRegistrationExtensions
             rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
                 swt.ServiceType.IsAssignableFrom(t)));
 
-        Func<Type, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>> scannedConstructor =
-            (type) => RegistrationBuilder.ForType(type);
+        IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> TypeBuilderFactory(Type type) => RegistrationBuilder.ForType(type);
 
-        Action<IComponentRegistryBuilder, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle>> register =
-            (cr, scanned) => RegistrationBuilder.RegisterSingleComponent(cr, scanned);
+        void SingleComponentRegistration(IComponentRegistryBuilder cr, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> scanned) => RegistrationBuilder.RegisterSingleComponent(cr, scanned);
 
-        ScanTypesTemplate(closedTypes, cr, rb, scannedConstructor, register);
+        ScanTypesTemplate(closedTypes, cr, rb, TypeBuilderFactory, SingleComponentRegistration);
     }
 
     /// <summary>

--- a/src/Autofac/ModuleRegistrationExtensions.cs
+++ b/src/Autofac/ModuleRegistrationExtensions.cs
@@ -278,15 +278,15 @@ public static class ModuleRegistrationExtensions
         var registrarCallback = registrar.RegistrarData.Callback;
 
         var original = registrarCallback.Callback;
-        Action<IComponentRegistryBuilder> updated = registry =>
+        void Updated(IComponentRegistryBuilder registry)
         {
             if (predicate(registry))
             {
                 original(registry);
             }
-        };
+        }
 
-        registrarCallback.Callback = updated;
+        registrarCallback.Callback = Updated;
 
         return registrar;
     }

--- a/src/Autofac/RegistrationExtensions.Conditional.cs
+++ b/src/Autofac/RegistrationExtensions.Conditional.cs
@@ -53,15 +53,15 @@ public static partial class RegistrationExtensions
         }
 
         var original = c.Callback;
-        Action<IComponentRegistryBuilder> updated = registry =>
+        void Updated(IComponentRegistryBuilder registry)
         {
             if (predicate(registry))
             {
                 original(registry);
             }
-        };
+        }
 
-        c.Callback = updated;
+        c.Callback = Updated;
         return registration;
     }
 

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -237,10 +237,12 @@ public class RegistrationOnlyIfTests
         builder.RegisterDecorator<IService>((ctx, p, s) => new Decorator(s), "from").OnlyIf(r => true);
         builder.RegisterDecorator<IService>((ctx, s) => new Decorator(s), "from").OnlyIf(r => true);
         builder.RegisterDecorator<IService>(s => new Decorator(s), "from").OnlyIf(r => true);
+#pragma warning disable CS0618
         builder.RegisterGeneratedFactory(typeof(SimpleFactory)).OnlyIf(r => true);
         builder.RegisterGeneratedFactory(typeof(SimpleFactory), new TypedService(typeof(object))).OnlyIf(r => true);
         builder.RegisterGeneratedFactory<SimpleFactory>().OnlyIf(r => true);
         builder.RegisterGeneratedFactory<SimpleFactory>(new TypedService(typeof(object))).OnlyIf(r => true);
+#pragma warning restore CS0618
         builder.RegisterGeneric(typeof(SimpleGeneric<>)).OnlyIf(r => true);
         builder.RegisterGenericDecorator(typeof(Decorator<>), typeof(IService<>), fromKey: "b").OnlyIf(r => true);
         builder.RegisterInstance(new object()).OnlyIf(r => true);

--- a/test/Autofac.Specification.Test/Resolution/ConstructorFinderTests.cs
+++ b/test/Autofac.Specification.Test/Resolution/ConstructorFinderTests.cs
@@ -92,13 +92,14 @@ public class ConstructorFinderTests
     {
         var cb = new ContainerBuilder();
         var finderCalled = false;
-        Func<Type, ConstructorInfo[]> finder = type =>
+        ConstructorInfo[] Finder(Type type)
         {
             finderCalled = true;
             return type.GetConstructors();
-        };
+        }
+
         cb.RegisterType<A1>();
-        cb.RegisterType<MultipleConstructors>().FindConstructorsWith(finder);
+        cb.RegisterType<MultipleConstructors>().FindConstructorsWith(Finder);
         var container = cb.Build();
 
         container.Resolve<MultipleConstructors>();

--- a/test/Autofac.Test/Concurrency/ConcurrencyTests.cs
+++ b/test/Autofac.Test/Concurrency/ConcurrencyTests.cs
@@ -106,7 +106,7 @@ public sealed class ConcurrencyTests
 
         var container = builder.Build();
 
-        ThreadStart work = () =>
+        void Work()
         {
             try
             {
@@ -117,10 +117,10 @@ public sealed class ConcurrencyTests
             {
                 exceptions.Add(ex);
             }
-        };
+        }
 
-        var t1 = new Thread(work);
-        var t2 = new Thread(work);
+        var t1 = new Thread(Work);
+        var t2 = new Thread(Work);
         t1.Start();
         t2.Start();
         t1.Join();

--- a/test/Autofac.Test/Core/Registration/ComponentRegistryTests.cs
+++ b/test/Autofac.Test/Core/Registration/ComponentRegistryTests.cs
@@ -318,9 +318,9 @@ public class ComponentRegistryTests
             var pre = container.ComponentRegistry.RegistrationsFor(chainedService);
             Assert.Single(pre);
 
-            Func<object> func = () => new object();
+            static object ObjectFactory() => new();
             using (var lifetimeScope = container.BeginLifetimeScope(builder =>
-                builder.ComponentRegistryBuilder.Register(RegistrationBuilder.ForDelegate((c, p) => func).CreateRegistration())))
+                builder.ComponentRegistryBuilder.Register(RegistrationBuilder.ForDelegate((c, p) => (Func<object>)ObjectFactory).CreateRegistration())))
             {
                 var post = lifetimeScope.ComponentRegistry.RegistrationsFor(chainedService);
                 Assert.Equal(2, post.Count());

--- a/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
+++ b/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
@@ -6,6 +6,8 @@ using Autofac.Core;
 
 namespace Autofac.Test.Features.GeneratedFactories;
 
+#pragma warning disable CS0618
+
 public class GeneratedFactoriesTests
 {
     public class A<T>
@@ -164,7 +166,7 @@ public class GeneratedFactoriesTests
     }
 
     [Fact]
-    public void CanSetParmeterMappingToPositional()
+    public void CanSetParameterMappingToPositional()
     {
         var builder = new ContainerBuilder();
 
@@ -259,7 +261,7 @@ public class GeneratedFactoriesTests
     }
 
     [Fact]
-    public void CreateGenericFromNongenericFactoryDelegate()
+    public void CreateGenericFromNonGenericFactoryDelegate()
     {
         var builder = new ContainerBuilder();
 
@@ -278,7 +280,7 @@ public class GeneratedFactoriesTests
     }
 
     [Fact]
-    public void CreateGenericFromNongenericFactoryDelegateImpliedServiceType()
+    public void CreateGenericFromNonGenericFactoryDelegateImpliedServiceType()
     {
         var builder = new ContainerBuilder();
 

--- a/test/Autofac.Test/Features/OwnedInstances/OwnedInstanceRegistrationSourceTests.cs
+++ b/test/Autofac.Test/Features/OwnedInstances/OwnedInstanceRegistrationSourceTests.cs
@@ -38,6 +38,7 @@ public class OwnedInstanceRegistrationSourceTests
         Assert.False(containerDisposeTracker.IsDisposed);
     }
 
+#pragma warning disable CS0618
     [Fact]
     public void CanResolveAndUse_OwnedGeneratedFactory()
     {
@@ -55,6 +56,7 @@ public class OwnedInstanceRegistrationSourceTests
 
         Assert.True(isAccessed);
     }
+#pragma warning restore CS0618
 
     [Fact]
     public void IfInnerTypeIsNotRegistered_OwnedTypeIsNotEither()


### PR DESCRIPTION
Fix #1297.

This marks `RegisterGeneratedFactory` extensions and `GeneratedFactoryActivatorData` with an `[Obsolete]` attribute indicating folks should upgrade to use `Func<T>` or delegate factories. Tests for the feature remain, but the obsolete warnings are suppressed around the tests so we don't see them during the build.

While I was here I picked up a couple of optimizations based on Roslyn analyzers:

- Use conditional assignment
- Use local function
- Make struct readonly