### PR TITLE
Ignore required properties in the default autowiring property selector.

### DIFF
--- a/src/Autofac/Core/Activators/DefaultPropertySelector.cs
+++ b/src/Autofac/Core/Activators/DefaultPropertySelector.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Autofac.Core;
 
@@ -54,6 +55,18 @@ public class DefaultPropertySelector : IPropertySelector
         {
             return false;
         }
+
+#if NET7_0_OR_GREATER
+        if (propertyInfo.GetCustomAttribute<RequiredMemberAttribute>() is not null)
+        {
+            // The default property selector should not inject required properties,
+            // to avoid duplication with the injection automatically applied inside the
+            // ReflectionActivator.
+            // Any other form of activator (lambda, instance) would generally already be required to
+            // set the required properties in order to create the instance.
+            return false;
+        }
+#endif
 
         if (PreserveSetValues && propertyInfo.CanRead)
         {

--- a/test/Autofac.Test/Core/DefaultPropertySelectorTests.cs
+++ b/test/Autofac.Test/Core/DefaultPropertySelectorTests.cs
@@ -18,12 +18,20 @@ public class DefaultPropertySelectorTests
     [InlineData(true, "PublicPropertyNoSet", false)]
     [InlineData(true, "PublicPropertyThrowsOnGet", false)]
     [InlineData(false, "PublicPropertyThrowsOnGet", true)]
+#if NET7_0_OR_GREATER
+    [InlineData(false, "PublicRequiredProperty", false)]
+#endif
     [Theory]
     public void DefaultTests(bool preserveSetValue, string propertyName, bool expected)
     {
         var finder = new DefaultPropertySelector(preserveSetValue);
 
-        var instance = new HasProperties();
+        var instance = new HasProperties
+        {
+#if NET7_0_OR_GREATER
+            PublicRequiredProperty = new(),
+#endif
+        };
         var property = instance.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
         Assert.Equal(expected, finder.InjectProperty(property, instance));
@@ -52,6 +60,10 @@ public class DefaultPropertySelectorTests
             {
             }
         }
+
+#if NET7_0_OR_GREATER
+        required public Test PublicRequiredProperty { get; set; }
+#endif
 
         public Test PublicPropertyWithDefault { get; set; } = new Test();
 


### PR DESCRIPTION
Noticed during the docs creation for required properties, before this change any registrations with `PropertiesAutowired` applied would duplicate property injection with required properties.

I decided to just blanket ignore required properties in the `DefaultPropertySelector`. My logic for this was as follows:

- Reflection-activated components will already have applied the mandatory property injection we've just added.
- Lambda-activated components will have to create an instance of the object, so the compiler will force them to set those properties.
- Instance components will have to have been created externally, so the compiler will have forced those properties to be set.

_If_ someone inside a lambda uses `Activator.CreateInstance` directly (for some reason) to bypass the required properties, those required properties won't be injected; but then, why aren't you using the reflection activator?