### PR TITLE
reduce lock contention in LifetimeScope.CreateSharedInstance

### DIFF
--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -369,12 +369,10 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             }
 
             result = creator();
-            if (_sharedInstances.ContainsKey(id))
+            if (!_sharedInstances.TryAdd(id, result))
             {
                 throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, LifetimeScopeResources.SelfConstructingDependencyDetected, result.GetType().FullName));
             }
-
-            _sharedInstances.TryAdd(id, result);
 
             return result;
         }
@@ -408,12 +406,10 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             }
 
             result = creator();
-            if (_sharedQualifiedInstances.ContainsKey(instanceKey))
+            if (!_sharedQualifiedInstances.TryAdd(instanceKey, result))
             {
                 throw new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, LifetimeScopeResources.SelfConstructingDependencyDetected, result.GetType().FullName));
             }
-
-            _sharedQualifiedInstances.TryAdd(instanceKey, result);
 
             return result;
         }

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -356,6 +356,11 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             throw new ArgumentNullException(nameof(creator));
         }
 
+        if (_sharedInstances.TryGetValue(id, out var tempResult))
+        {
+            return tempResult;
+        }
+
         lock (_synchRoot)
         {
             if (_sharedInstances.TryGetValue(id, out var result))
@@ -388,10 +393,15 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             return CreateSharedInstance(primaryId, creator);
         }
 
+        var instanceKey = (primaryId, qualifyingId.Value);
+
+        if (_sharedQualifiedInstances.TryGetValue(instanceKey, out var tempResult))
+        {
+            return tempResult;
+        }
+
         lock (_synchRoot)
         {
-            var instanceKey = (primaryId, qualifyingId.Value);
-
             if (_sharedQualifiedInstances.TryGetValue(instanceKey, out var result))
             {
                 return result;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2981998/227348044-261c5ab9-e32c-448a-8780-2105e1b9ca1a.png)

Found lock contention while load testing of our application. Avoid locking on happy path. 