### PR TITLE
Re-enable RegsiterTypes filtering; better message for RegisterType issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     "notnull",
     "paramref",
     "startable",
+    "subclassing",
     "typeparam",
     "xunit"
   ],

--- a/bench/Autofac.Benchmarks/LambdaResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/LambdaResolveBenchmark.cs
@@ -1,6 +1,4 @@
-﻿using Autofac.Core;
-
-namespace Autofac.Benchmarks;
+﻿namespace Autofac.Benchmarks;
 
 public class LambdaResolveBenchmark
 {
@@ -13,8 +11,8 @@ public class LambdaResolveBenchmark
 
         builder.RegisterType<MyDependency1>();
 
-        // The original componentcontext way.
-        builder.Register((ctxt) => new MyComponent(ctxt.Resolve<MyDependency1>(), "arg"))
+        // The original component context way.
+        builder.Register((context) => new MyComponent(context.Resolve<MyDependency1>(), "arg"))
                .As<IServiceExistingMethodCapturedArg>();
 
         // Capture the argument directly.

--- a/codegen/Autofac.CodeGen/DelegateRegisterGenerator.cs
+++ b/codegen/Autofac.CodeGen/DelegateRegisterGenerator.cs
@@ -29,11 +29,11 @@ public class DelegateRegisterGenerator : IIncrementalGenerator
         IncrementalValuesProvider<INamedTypeSymbol> classDeclarations = context.SyntaxProvider
             .CreateSyntaxProvider(
                 predicate: static (s, _) => s is ClassDeclarationSyntax classSyn && classSyn.Modifiers.Any(static m => m.IsKind(SyntaxKind.PartialKeyword)),
-                transform: static (ctxt, cancelToken) =>
+                transform: static (context, cancelToken) =>
                 {
-                    var syntax = (ClassDeclarationSyntax)ctxt.Node;
+                    var syntax = (ClassDeclarationSyntax)context.Node;
 
-                    if (ctxt.SemanticModel.GetDeclaredSymbol(syntax, cancelToken) is INamedTypeSymbol symbol)
+                    if (context.SemanticModel.GetDeclaredSymbol(syntax, cancelToken) is INamedTypeSymbol symbol)
                     {
                         // Looking for the exact name of the class.
                         if (symbol.ToDisplayString() == "Autofac.RegistrationExtensions")

--- a/src/Autofac/Builder/ContainerBuildOptions.cs
+++ b/src/Autofac/Builder/ContainerBuildOptions.cs
@@ -4,7 +4,7 @@
 namespace Autofac.Builder;
 
 /// <summary>
-/// Parameterises the construction of a container by a <see cref="ContainerBuilder"/>.
+/// Behaviors for the construction of a container by a <see cref="ContainerBuilder"/>.
 /// </summary>
 [Flags]
 public enum ContainerBuildOptions

--- a/src/Autofac/Builder/RegistrationBuilderResources.resx
+++ b/src/Autofac/Builder/RegistrationBuilderResources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -119,5 +119,8 @@
   </resheader>
   <data name="ComponentDoesNotSupportService" xml:space="preserve">
     <value>The type '{0}' is not assignable to service '{1}'.</value>
+  </data>
+  <data name="OnlyRegisterableTypesAllowed" xml:space="preserve">
+    <value>The type '{0}' is not concrete. Only concrete types (no interfaces, abstract classes, open generics, etc.) can be registered by type.</value>
   </data>
 </root>

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -276,7 +276,7 @@ internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> :
         for (int i = 0; i < services.Length; i++)
         {
             var service = services[i];
-            if (service.FullName != null)
+            if (service.FullName is not null)
             {
                 argArray[i] = new TypedService(service);
             }

--- a/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
+++ b/src/Autofac/Builder/RegistrationBuilder{TLimit,TActivatorData,TRegistrationStyle}.cs
@@ -413,16 +413,16 @@ internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> :
             throw new ArgumentNullException(nameof(handler));
         }
 
-        var middleware = new CoreEventMiddleware(ResolveEventType.OnPreparing, PipelinePhase.ParameterSelection, (ctxt, next) =>
+        var middleware = new CoreEventMiddleware(ResolveEventType.OnPreparing, PipelinePhase.ParameterSelection, (context, next) =>
         {
-            var args = new PreparingEventArgs(ctxt, ctxt.Service, ctxt.Registration, ctxt.Parameters);
+            var args = new PreparingEventArgs(context, context.Service, context.Registration, context.Parameters);
 
             handler(args);
 
-            ctxt.ChangeParameters(args.Parameters);
+            context.ChangeParameters(args.Parameters);
 
             // Go down the pipeline now.
-            next(ctxt);
+            next(context);
         });
 
         ResolvePipeline.Use(middleware);
@@ -461,14 +461,14 @@ internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> :
             throw new ArgumentNullException(nameof(handler));
         }
 
-        var middleware = new CoreEventMiddleware(ResolveEventType.OnActivating, PipelinePhase.Activation, (ctxt, next) =>
+        var middleware = new CoreEventMiddleware(ResolveEventType.OnActivating, PipelinePhase.Activation, (context, next) =>
         {
-            next(ctxt);
+            next(context);
 
-            var args = new ActivatingEventArgs<TLimit>(ctxt, ctxt.Service, ctxt.Registration, ctxt.Parameters, (TLimit)ctxt.Instance!);
+            var args = new ActivatingEventArgs<TLimit>(context, context.Service, context.Registration, context.Parameters, (TLimit)context.Instance!);
 
             handler(args);
-            ctxt.Instance = args.Instance;
+            context.Instance = args.Instance;
         });
 
         // Activation events have to run at the start of the phase, to make sure
@@ -509,28 +509,28 @@ internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> :
             throw new ArgumentNullException(nameof(handler));
         }
 
-        var middleware = new CoreEventMiddleware(ResolveEventType.OnActivated, PipelinePhase.Activation, (ctxt, next) =>
+        var middleware = new CoreEventMiddleware(ResolveEventType.OnActivated, PipelinePhase.Activation, (context, next) =>
         {
             // Go down the pipeline first.
-            next(ctxt);
+            next(context);
 
-            if (!ctxt.NewInstanceActivated)
+            if (!context.NewInstanceActivated)
             {
                 return;
             }
 
             // Make sure we use the instance at this point, before it is replaced by any decorators.
-            var newInstance = (TLimit)ctxt.Instance!;
+            var newInstance = (TLimit)context.Instance!;
 
             // In order to behave in the same manner as the original activation handler,
             // we need to attach to the RequestCompleting event so these run at the end after everything else.
-            ctxt.RequestCompleting += (sender, evArgs) =>
-        {
-            var ctxt = evArgs.RequestContext;
-            var args = new ActivatedEventArgs<TLimit>(ctxt, ctxt.Service, ctxt.Registration, ctxt.Parameters, newInstance);
+            context.RequestCompleting += (sender, evArgs) =>
+            {
+                var eventContext = evArgs.RequestContext;
+                var args = new ActivatedEventArgs<TLimit>(eventContext, eventContext.Service, eventContext.Registration, eventContext.Parameters, newInstance);
 
-            handler(args);
-        };
+                handler(args);
+            };
         });
 
         // Need to insert OnActivated at the start of the phase, to ensure we attach to RequestCompleting in the same order
@@ -568,30 +568,30 @@ internal class RegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> :
     /// <returns>A registration builder allowing further configuration of the component.</returns>
     public IRegistrationBuilder<TLimit, TActivatorData, TRegistrationStyle> PropertiesAutowired(IPropertySelector propertySelector, bool allowCircularDependencies)
     {
-        ResolvePipeline.Use(nameof(PropertiesAutowired), PipelinePhase.Activation, (ctxt, next) =>
+        ResolvePipeline.Use(nameof(PropertiesAutowired), PipelinePhase.Activation, (context, next) =>
         {
             // Continue down the pipeline.
-            next(ctxt);
+            next(context);
 
-            if (!ctxt.NewInstanceActivated)
+            if (!context.NewInstanceActivated)
             {
                 return;
             }
 
             if (allowCircularDependencies)
             {
-                var capturedInstance = ctxt.Instance;
+                var capturedInstance = context.Instance;
 
                 // If we are allowing circular deps, then we need to run when all requests have completed (similar to Activated).
-                ctxt.RequestCompleting += (o, args) =>
-            {
-                var evCtxt = args.RequestContext;
-                AutowiringPropertyInjector.InjectProperties(evCtxt, capturedInstance!, propertySelector, evCtxt.Parameters);
-            };
+                context.RequestCompleting += (o, args) =>
+                {
+                    var eventContext = args.RequestContext;
+                    AutowiringPropertyInjector.InjectProperties(eventContext, capturedInstance!, propertySelector, eventContext.Parameters);
+                };
             }
             else
             {
-                AutowiringPropertyInjector.InjectProperties(ctxt, ctxt.Instance!, propertySelector, ctxt.Parameters);
+                AutowiringPropertyInjector.InjectProperties(context, context.Instance!, propertySelector, context.Parameters);
             }
         });
 

--- a/src/Autofac/Core/Activators/Delegate/DelegateActivator.cs
+++ b/src/Autofac/Core/Activators/Delegate/DelegateActivator.cs
@@ -10,7 +10,6 @@ namespace Autofac.Core.Activators.Delegate;
 /// <summary>
 /// Activate instances using a delegate.
 /// </summary>
-[SuppressMessage("Microsoft.Design", "CA1063:ImplementIDisposableCorrectly", Justification = "There is nothing in the derived class to dispose so no override is necessary.")]
 public class DelegateActivator : InstanceActivator, IInstanceActivator
 {
     private readonly Func<IComponentContext, IEnumerable<Parameter>, object> _activationFunction;
@@ -34,11 +33,11 @@ public class DelegateActivator : InstanceActivator, IInstanceActivator
             throw new ArgumentNullException(nameof(pipelineBuilder));
         }
 
-        pipelineBuilder.Use(this.DisplayName(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
+        pipelineBuilder.Use(this.DisplayName(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (context, next) =>
         {
-            ctxt.Instance = ActivateInstance(ctxt, ctxt.Parameters);
+            context.Instance = ActivateInstance(context, context.Parameters);
 
-            next(ctxt);
+            next(context);
         });
     }
 

--- a/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
+++ b/src/Autofac/Core/Activators/ProvidedInstance/ProvidedInstanceActivator.cs
@@ -34,11 +34,11 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
             throw new ArgumentNullException(nameof(pipelineBuilder));
         }
 
-        pipelineBuilder.Use(this.DisplayName(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (ctxt, next) =>
+        pipelineBuilder.Use(this.DisplayName(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (context, next) =>
         {
-            ctxt.Instance = GetInstance();
+            context.Instance = GetInstance();
 
-            next(ctxt);
+            next(context);
         });
     }
 
@@ -83,7 +83,7 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
 
                 // Type only implements IAsyncDisposable. We will need to do sync-over-async.
                 // We want to ensure we lose all context here, because if we don't we can deadlock.
-                // So we push this disposal onto the threadpool.
+                // So we push this disposal onto the thread pool.
                 Task.Run(async () => await asyncDisposable.DisposeAsync().ConfigureAwait(false))
                     .ConfigureAwait(false)
                     .GetAwaiter().GetResult();
@@ -122,7 +122,6 @@ public class ProvidedInstanceActivator : InstanceActivator, IInstanceActivator
         // Do not call the base, otherwise the standard Dispose will fire.
     }
 
-    [SuppressMessage("CA2222", "CA2222", Justification = "False positive. GetType doesn't hide an inherited member.")]
     private static Type GetType(object instance)
     {
         if (instance == null)

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -74,7 +74,7 @@ internal static class AutowiringPropertyInjector
             var parameter = resolveParameters.FirstOrDefault(p =>
                 p.CanSupplyValue(setParameter, context, out valueProvider) &&
                 !(p is NamedParameter n && n.Name.Equals("value", StringComparison.Ordinal)));
-            if (parameter != null)
+            if (parameter is not null)
             {
                 var setter = ReflectionCacheSet.Shared.Internal.AutowiringPropertySetters.GetOrAdd(property, MakeFastPropertySetter);
                 setter(instance, valueProvider!());

--- a/src/Autofac/Core/Activators/Reflection/DefaultValueParameter.cs
+++ b/src/Autofac/Core/Activators/Reflection/DefaultValueParameter.cs
@@ -37,7 +37,7 @@ public class DefaultValueParameter : Parameter
             // Workaround for https://github.com/dotnet/corefx/issues/17943
             if (pi.Member.DeclaringType?.Assembly.IsDynamic ?? true)
             {
-                hasDefaultValue = pi.DefaultValue != null && pi.HasDefaultValue;
+                hasDefaultValue = pi.DefaultValue is not null && pi.HasDefaultValue;
             }
             else
             {

--- a/src/Autofac/Core/Activators/Reflection/InjectableProperty.cs
+++ b/src/Autofac/Core/Activators/Reflection/InjectableProperty.cs
@@ -1,15 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
-using System.Text;
-using Autofac.Core.Resolving;
-using Autofac.Core.Resolving.Pipeline;
-using Autofac.Util;
-using Autofac.Util.Cache;
 
 namespace Autofac.Core.Activators.Reflection;
 
@@ -53,11 +46,11 @@ internal class InjectableProperty
     /// </summary>
     /// <param name="instance">The object instance.</param>
     /// <param name="p">The parameter that may provide the value.</param>
-    /// <param name="ctxt">The component context.</param>
+    /// <param name="context">The component context.</param>
     /// <returns>True if the parameter could provide a value, and the property was set. False otherwise.</returns>
-    public bool TrySupplyValue(object instance, Parameter p, IComponentContext ctxt)
+    public bool TrySupplyValue(object instance, Parameter p, IComponentContext context)
     {
-        if (p.CanSupplyValue(_setterParameter, ctxt, out var vp))
+        if (p.CanSupplyValue(_setterParameter, context, out var vp))
         {
             Property.SetValue(instance, vp(), null);
 

--- a/src/Autofac/Core/AutoActivateService.cs
+++ b/src/Autofac/Core/AutoActivateService.cs
@@ -33,7 +33,7 @@ internal class AutoActivateService : Service
     public override bool Equals(object? obj)
     {
         var that = obj as AutoActivateService;
-        return that != null;
+        return that is not null;
     }
 
     /// <summary>

--- a/src/Autofac/Core/InternalReflectionCaches.cs
+++ b/src/Autofac/Core/InternalReflectionCaches.cs
@@ -15,7 +15,7 @@ namespace Autofac.Core;
 internal class InternalReflectionCaches
 {
     /// <summary>
-    /// Gets the cache used by <see cref="Util.AssemblyExtensions.GetPermittedTypesForAssemblyScanning"/>.
+    /// Gets the cache used by <see cref="Features.Scanning.AssemblyExtensions.GetPermittedTypesForAssemblyScanning"/>.
     /// </summary>
     public ReflectionCacheAssemblyDictionary<Assembly, IEnumerable<Type>> AssemblyScanAllowedTypes { get; }
 
@@ -55,7 +55,7 @@ internal class InternalReflectionCaches
     public ReflectionCacheDictionary<Type, ConstructorInfo[]> DefaultPublicConstructors { get; }
 
     /// <summary>
-    /// Gets a cache of memoized <see cref="System.Type.GetGenericTypeDefinition"/>.
+    /// Gets a cache of memoized <see cref="Type.GetGenericTypeDefinition"/>.
     /// </summary>
     public ReflectionCacheDictionary<Type, Type> GenericTypeDefinitionByType { get; }
 

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -250,7 +250,7 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
         scope.Disposer.AddInstanceForDisposal(localsBuilder);
 
         if (localsBuilder.Properties.TryGetValue(MetadataKeys.ContainerBuildOptions, out var options)
-            && options != null
+            && options is not null
             && !((ContainerBuildOptions)options).HasFlag(ContainerBuildOptions.IgnoreStartableComponents))
         {
             StartableManager.StartStartableComponents(localsBuilder.Properties, scope);
@@ -296,7 +296,7 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
         // Issue #272: Only the most nested parent registry with HasLocalComponents is registered as an external source
         // It provides all non-adapting registrations from itself and from it's parent registries
         ISharingLifetimeScope? parent = this;
-        while (parent != null)
+        while (parent is not null)
         {
             if (parent.ComponentRegistry.HasLocalComponents)
             {

--- a/src/Autofac/Core/Lifetime/MatchingScopeLifetime.cs
+++ b/src/Autofac/Core/Lifetime/MatchingScopeLifetime.cs
@@ -50,7 +50,7 @@ public class MatchingScopeLifetime : IComponentLifetime
         }
 
         ISharingLifetimeScope? next = mostNestedVisibleScope;
-        while (next != null)
+        while (next is not null)
         {
             if (_tagsToMatch.Contains(next.Tag))
             {

--- a/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
+++ b/src/Autofac/Core/Registration/ServiceRegistrationInfo.cs
@@ -167,8 +167,8 @@ internal class ServiceRegistrationInfo : IResolvePipelineBuilder
 
     private bool Any =>
         _defaultImplementations.Count > 0 ||
-        _sourceImplementations != null ||
-        _preserveDefaultImplementations != null;
+        _sourceImplementations is not null ||
+        _preserveDefaultImplementations is not null;
 
     /// <summary>
     /// Add an implementation for the service.
@@ -252,13 +252,13 @@ internal class ServiceRegistrationInfo : IResolvePipelineBuilder
                                                   _sourceImplementations?.First() ??
                                                   _preserveDefaultImplementations?.First();
 
-        return registration != null;
+        return registration is not null;
     }
 
     /// <summary>
     /// Gets a value indicating whether this service info is initializing.
     /// </summary>
-    public bool IsInitializing => !IsInitialized && _sourcesToQuery != null;
+    public bool IsInitializing => !IsInitialized && _sourcesToQuery is not null;
 
     /// <summary>
     /// Gets a value indicating whether there are any sources left to query.

--- a/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
@@ -32,7 +32,7 @@ internal class ResolvePipelineBuilder : IResolvePipelineBuilder, IEnumerable<IRe
     /// <summary>
     /// Termination action for the end of pipelines.
     /// </summary>
-    private static readonly Action<ResolveRequestContext> TerminateAction = ctxt => { };
+    private static readonly Action<ResolveRequestContext> TerminateAction = context => { };
 
     private MiddlewareDeclaration? _first;
     private MiddlewareDeclaration? _last;
@@ -243,37 +243,37 @@ internal class ResolvePipelineBuilder : IResolvePipelineBuilder, IEnumerable<IRe
         {
             var stagePhase = stage.Phase;
 
-            return (ctxt) =>
+            return (context) =>
             {
                 // Same basic flow in if/else, but doing a one-time check for diagnostics
                 // and choosing the "diagnostics enabled" version vs. the more common
                 // "no diagnostics enabled" path: hot-path optimization.
-                if (ctxt.DiagnosticSource.IsEnabled())
+                if (context.DiagnosticSource.IsEnabled())
                 {
-                    ctxt.DiagnosticSource.MiddlewareStart(ctxt, stage);
+                    context.DiagnosticSource.MiddlewareStart(context, stage);
                     var succeeded = false;
                     try
                     {
-                        ctxt.PhaseReached = stagePhase;
-                        stage.Execute(ctxt, next);
+                        context.PhaseReached = stagePhase;
+                        stage.Execute(context, next);
                         succeeded = true;
                     }
                     finally
                     {
                         if (succeeded)
                         {
-                            ctxt.DiagnosticSource.MiddlewareSuccess(ctxt, stage);
+                            context.DiagnosticSource.MiddlewareSuccess(context, stage);
                         }
                         else
                         {
-                            ctxt.DiagnosticSource.MiddlewareFailure(ctxt, stage);
+                            context.DiagnosticSource.MiddlewareFailure(context, stage);
                         }
                     }
                 }
                 else
                 {
-                    ctxt.PhaseReached = stagePhase;
-                    stage.Execute(ctxt, next);
+                    context.PhaseReached = stagePhase;
+                    stage.Execute(context, next);
                 }
             };
         }

--- a/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContext.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContext.cs
@@ -10,7 +10,7 @@ namespace Autofac.Core.Resolving.Pipeline;
 public abstract class ResolveRequestContext : IComponentContext
 {
     /// <summary>
-    /// Gets a reference to the owning resolve operation (which might emcompass multiple nested requests).
+    /// Gets a reference to the owning resolve operation (which might encompass multiple nested requests).
     /// </summary>
     public abstract IResolveOperation Operation { get; }
 
@@ -36,10 +36,12 @@ public abstract class ResolveRequestContext : IComponentContext
     public abstract IComponentRegistration? DecoratorTarget { get; }
 
     /// <summary>
-    /// Gets or sets the instance that will be returned as the result of the resolve request.
-    /// On the way back up the pipeline, after calling next(ctxt), this value will be populated
-    /// with the resolved instance. Check the <see cref="NewInstanceActivated"/> property to determine
-    /// whether the object here was a newly activated instance, or a shared instance previously activated.
+    /// Gets or sets the instance that will be returned as the result of the
+    /// resolve request. On the way back up the pipeline, after calling the next
+    /// middleware in the chain, this value will be populated with the resolved
+    /// instance. Check the <see cref="NewInstanceActivated"/> property to
+    /// determine whether the object here was a newly activated instance, or a
+    /// shared instance previously activated.
     /// </summary>
     [DisallowNull]
     public abstract object? Instance { get; set; }

--- a/src/Autofac/Core/Resolving/ResolvePipeline.cs
+++ b/src/Autofac/Core/Resolving/ResolvePipeline.cs
@@ -22,8 +22,8 @@ internal class ResolvePipeline : IResolvePipeline
     }
 
     /// <inheritdoc />
-    public void Invoke(ResolveRequestContext ctxt)
+    public void Invoke(ResolveRequestContext context)
     {
-        _entryPoint?.Invoke(ctxt);
+        _entryPoint?.Invoke(context);
     }
 }

--- a/src/Autofac/Core/UniqueService.cs
+++ b/src/Autofac/Core/UniqueService.cs
@@ -44,7 +44,7 @@ public sealed class UniqueService : Service
     {
         var that = obj as UniqueService;
 
-        return that != null && _id == that._id;
+        return that is not null && _id == that._id;
     }
 
     /// <summary>

--- a/src/Autofac/Features/AttributeFilters/RegistrationExtensions.cs
+++ b/src/Autofac/Features/AttributeFilters/RegistrationExtensions.cs
@@ -48,7 +48,7 @@ public static class RegistrationExtensions
             (p, c) =>
             {
                 var filter = p.GetCustomAttributes<ParameterFilterAttribute>(true).FirstOrDefault();
-                return filter != null && filter.CanResolveParameter(p, c);
+                return filter is not null && filter.CanResolveParameter(p, c);
             },
             (p, c) =>
             {

--- a/src/Autofac/Features/Metadata/MetadataViewProvider.cs
+++ b/src/Autofac/Features/Metadata/MetadataViewProvider.cs
@@ -43,7 +43,7 @@ internal static class MetadataViewProvider
             return ps.Length == 1 && ps[0].ParameterType == typeof(IDictionary<string, object>);
         });
 
-        if (dictionaryConstructor != null)
+        if (dictionaryConstructor is not null)
         {
             var providerArg = Expression.Parameter(typeof(IDictionary<string, object?>), "metadata");
             return Expression.Lambda<Func<IDictionary<string, object?>, TMetadata>>(
@@ -53,7 +53,7 @@ internal static class MetadataViewProvider
         }
 
         var parameterlessConstructor = publicConstructors.SingleOrDefault(ci => ci.GetParameters().Length == 0);
-        if (parameterlessConstructor != null)
+        if (parameterlessConstructor is not null)
         {
             var providerArg = Expression.Parameter(typeof(IDictionary<string, object>), "metadata");
             var resultVar = Expression.Variable(typeof(TMetadata), "result");
@@ -63,8 +63,8 @@ internal static class MetadataViewProvider
 
             foreach (var prop in typeof(TMetadata).GetRuntimeProperties()
                 .Where(prop =>
-                    prop.GetMethod != null && !prop.GetMethod.IsStatic &&
-                    prop.SetMethod != null && !prop.SetMethod.IsStatic))
+                    prop.GetMethod is not null && !prop.GetMethod.IsStatic &&
+                    prop.SetMethod is not null && !prop.SetMethod.IsStatic))
             {
                 var dva = Expression.Constant(prop.GetCustomAttribute<DefaultValueAttribute>(false), typeof(DefaultValueAttribute));
                 var name = Expression.Constant(prop.Name, typeof(string));

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationExtensions.cs
@@ -13,7 +13,7 @@ namespace Autofac.Features.OpenGenerics;
 internal static class OpenGenericRegistrationExtensions
 {
     /// <summary>
-    /// Register an un-parameterised generic type, e.g. Repository&lt;&gt;.
+    /// Register an un-parameterized generic type, e.g. Repository&lt;&gt;.
     /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
     /// </summary>
     /// <param name="builder">Container builder.</param>
@@ -36,7 +36,7 @@ internal static class OpenGenericRegistrationExtensions
     }
 
     /// <summary>
-    /// Register an un-parameterised generic type, e.g. Repository&lt;&gt;.
+    /// Register an un-parameterized generic type, e.g. Repository&lt;&gt;.
     /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
     /// </summary>
     /// <param name="builder">Container builder.</param>
@@ -59,7 +59,7 @@ internal static class OpenGenericRegistrationExtensions
     }
 
     /// <summary>
-    /// Creates an un-parameterised generic type, e.g. Repository&lt;&gt;, without registering it.
+    /// Creates an un-parameterized generic type, e.g. Repository&lt;&gt;, without registering it.
     /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
     /// </summary>
     /// <param name="implementer">The open generic implementation type.</param>
@@ -86,7 +86,7 @@ internal static class OpenGenericRegistrationExtensions
     }
 
     /// <summary>
-    /// Creates a registration builder for an un-parameterised generic type, e.g. Repository&lt;&gt;, without registering it.
+    /// Creates a registration builder for an un-parameterized generic type, e.g. Repository&lt;&gt;, without registering it.
     /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
     /// </summary>
     /// <param name="factory">Delegate responsible for generating an instance of a closed generic based on the open generic type being registered.</param>

--- a/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericServiceBinder.cs
@@ -40,7 +40,7 @@ internal static class OpenGenericServiceBinder
                 var implementorGenericArguments = TryMapImplementationGenericArguments(
                     openGenericImplementationType, serviceWithType.ServiceType, definitionService.ServiceType, serviceGenericArguments);
 
-                if (implementorGenericArguments.All(a => a != null) &&
+                if (implementorGenericArguments.All(a => a is not null) &&
                     openGenericImplementationType.IsCompatibleWithGenericParameterConstraints(implementorGenericArguments!))
                 {
                     var constructedImplementationTypeTmp = openGenericImplementationType.MakeGenericType(implementorGenericArguments!);
@@ -198,7 +198,7 @@ internal static class OpenGenericServiceBinder
     private static Type? GetGenericBaseType(Type implementationType, Type serviceTypeDefinition)
     {
         var baseType = implementationType.BaseType;
-        while (baseType != null)
+        while (baseType is not null)
         {
             if (baseType.IsGenericType && baseType.GetGenericTypeDefinition() == serviceTypeDefinition)
             {
@@ -224,7 +224,7 @@ internal static class OpenGenericServiceBinder
             .Select(argdef => argdef.Value)
             .FirstOrDefault();
 
-        if (matchingRegularType != null)
+        if (matchingRegularType is not null)
         {
             return matchingRegularType;
         }
@@ -234,7 +234,7 @@ internal static class OpenGenericServiceBinder
             .Select(argdef => TryFindServiceArgumentForImplementationArgumentDefinition(
                 implementationGenericArgumentDefinition, argdef.Key.GenericTypeArguments.Zip(
                     argdef.Value.GenericTypeArguments, (a, b) => new KeyValuePair<Type, Type>(a, b))))
-            .FirstOrDefault(x => x != null);
+            .FirstOrDefault(x => x is not null);
     }
 
     /// <summary>

--- a/src/Autofac/Features/OwnedInstances/InstancePerOwnedKey.cs
+++ b/src/Autofac/Features/OwnedInstances/InstancePerOwnedKey.cs
@@ -21,7 +21,7 @@ internal class InstancePerOwnedKey : IEquatable<IServiceWithType>
 
     /// <inheritdoc/>
     public bool Equals(IServiceWithType? other)
-        => other != null && _serviceWithType.ServiceType == other.ServiceType;
+        => other is not null && _serviceWithType.ServiceType == other.ServiceType;
 
     /// <inheritdoc/>
     public override bool Equals(object? obj)

--- a/src/Autofac/Features/OwnedInstances/Owned.cs
+++ b/src/Autofac/Features/OwnedInstances/Owned.cs
@@ -91,7 +91,7 @@ public class Owned<T> : Disposable
         if (disposing)
         {
             var lt = Interlocked.Exchange(ref _lifetime, null);
-            if (lt != null)
+            if (lt is not null)
             {
                 Value = default!;
                 lt.Dispose();
@@ -110,7 +110,7 @@ public class Owned<T> : Disposable
         if (disposing)
         {
             var lt = Interlocked.Exchange(ref _lifetime, null);
-            if (lt != null)
+            if (lt is not null)
             {
                 Value = default!;
                 if (lt is IAsyncDisposable asyncDisposable)

--- a/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
+++ b/src/Autofac/Features/ResolveAnything/AnyConcreteTypeNotAlreadyRegisteredSource.cs
@@ -4,6 +4,7 @@
 using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Core.Registration;
+using Autofac.Util;
 
 namespace Autofac.Features.ResolveAnything;
 
@@ -55,9 +56,7 @@ public class AnyConcreteTypeNotAlreadyRegisteredSource : IRegistrationSource, IP
         }
 
         var serviceType = ts.ServiceType;
-        if (!serviceType.IsClass ||
-            serviceType.IsSubclassOf(typeof(Delegate)) ||
-            serviceType.IsAbstract ||
+        if (!serviceType.MayAllowReflectionActivation(allowCompilerGenerated: true) ||
             serviceType.IsGenericTypeDefinition ||
             !_predicate(ts.ServiceType) ||
             registrationAccessor(service).Any())

--- a/src/Autofac/Features/Scanning/AssemblyExtensions.cs
+++ b/src/Autofac/Features/Scanning/AssemblyExtensions.cs
@@ -24,7 +24,7 @@ internal static class AssemblyExtensions
         static IReadOnlyList<Type> Uncached(Assembly assembly)
         {
             return assembly.GetLoadableTypes()
-                           .WhichCanBeRegistered()
+                           .WhichAreAllowedThroughScanning()
                            .ToList();
         }
 

--- a/src/Autofac/Features/Scanning/AssemblyExtensions.cs
+++ b/src/Autofac/Features/Scanning/AssemblyExtensions.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;
+using Autofac.Builder;
 using Autofac.Core;
+using Autofac.Core.Registration;
 using Autofac.Util;
 
 namespace Autofac.Features.Scanning;
@@ -27,5 +29,25 @@ internal static class AssemblyExtensions
         }
 
         return ReflectionCacheSet.Shared.Internal.AssemblyScanAllowedTypes.GetOrAdd(assembly, Uncached);
+    }
+
+    /// <summary>
+    /// Given a set of assemblies, locates all the loadable, registerable types and adds them to the component registry.
+    /// </summary>
+    /// <param name="assemblies">
+    /// The set of assemblies to scan for types.
+    /// </param>
+    /// <param name="cr">
+    /// The registry into which registerable types should be added.
+    /// </param>
+    /// <param name="rb">
+    /// A "template" registration builder that is used to provide activator data
+    /// filters and serve as the basis for individual component registrations.
+    /// </param>
+    internal static void ScanAssemblies(this IEnumerable<Assembly> assemblies, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
+    {
+        assemblies
+            .SelectMany(a => a.GetPermittedTypesForAssemblyScanning())
+            .FilterAndRegisterConcreteTypes(cr, rb);
     }
 }

--- a/src/Autofac/Features/Scanning/AssemblyExtensions.cs
+++ b/src/Autofac/Features/Scanning/AssemblyExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Reflection;
+using Autofac.Core;
+using Autofac.Util;
+
+namespace Autofac.Features.Scanning;
+
+/// <summary>
+/// Extensions for assemblies used during assembly scanning operations.
+/// </summary>
+internal static class AssemblyExtensions
+{
+    /// <summary>
+    /// Get the set of types that Autofac will allow to be loaded from the given assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to load types from.</param>
+    /// <returns>The set of loadable types.</returns>
+    internal static IEnumerable<Type> GetPermittedTypesForAssemblyScanning(this Assembly assembly)
+    {
+        static IReadOnlyList<Type> Uncached(Assembly assembly)
+        {
+            return assembly.GetLoadableTypes()
+                           .WhichCanBeRegistered()
+                           .ToList();
+        }
+
+        return ReflectionCacheSet.Shared.Internal.AssemblyScanAllowedTypes.GetOrAdd(assembly, Uncached);
+    }
+}

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -94,7 +94,7 @@ internal static partial class ScanningRegistrationExtensions
 
         var types = assemblies.SelectMany(a => a.GetPermittedTypesForAssemblyScanning())
             .Where(t => t.IsGenericTypeDefinition)
-            .CanBeRegistered(rb.ActivatorData);
+            .AllowedByActivatorFilters(rb.ActivatorData);
 
         static IRegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle> TypeBuilderFactory(Type type) => new RegistrationBuilder<object, ReflectionActivatorData, DynamicRegistrationStyle>(
                 new TypedService(type),
@@ -130,16 +130,6 @@ internal static partial class ScanningRegistrationExtensions
         {
             postScanningCallback(cr);
         }
-    }
-
-    private static IEnumerable<Type> CanBeRegistered<TActivatorData, TStyle>(this IEnumerable<Type> types, BaseScanningActivatorData<TActivatorData, TStyle> activatorData)
-        where TActivatorData : ReflectionActivatorData
-    {
-        // Issue #897: For back compat reasons we can't filter out
-        // non-public types here. Folks use assembly scanning on their
-        // own stuff, so encapsulation is a tricky thing to manage.
-        // If people want only public types, a LINQ Where clause can be used.
-        return types.Where(t => activatorData.Filters.All(p => p(t)));
     }
 
     private static void ConfigureFrom<TActivatorData, TScanStyle, TRegistrationBuilderStyle>(

--- a/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/OpenGenericScanningRegistrationExtensions.cs
@@ -78,7 +78,7 @@ internal static class OpenGenericScanningRegistrationExtensions
                     return impl.IsOpenGenericTypeOf(c.ServiceType);
                 }
 
-                return s != null;
+                return s is not null;
             });
             rb.As(applied.ToArray());
         });

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -217,7 +217,7 @@ internal static class ScanningRegistrationExtensions
                         return c.ServiceType.IsAssignableFrom(impl);
                     }
 
-                    return s != null;
+                    return s is not null;
                 });
             rb.As(applied.ToArray());
         });

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -79,8 +79,9 @@ internal static partial class ScanningRegistrationExtensions
 
     private static void ScanTypes(IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
     {
-        var closedTypes = types.Where(t => t != null && !t.IsGenericTypeDefinition)
-            .CanBeRegistered(rb.ActivatorData);
+        var closedTypes = types.WhichCanBeRegistered()
+            .Where(t => !t.IsGenericTypeDefinition)
+            .AllowedByActivatorFilters(rb.ActivatorData);
 
         rb.ActivatorData.Filters.Add(t =>
             rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -12,7 +12,7 @@ namespace Autofac.Features.Scanning;
 /// <summary>
 /// Helper methods to assist in scanning registration.
 /// </summary>
-internal static partial class ScanningRegistrationExtensions
+internal static class ScanningRegistrationExtensions
 {
     /// <summary>
     /// Register types from the specified assemblies.
@@ -21,7 +21,7 @@ internal static partial class ScanningRegistrationExtensions
     /// <param name="assemblies">The set of assemblies.</param>
     /// <returns>A registration builder.</returns>
     public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
-        RegisterAssemblyTypes(ContainerBuilder builder, params Assembly[] assemblies)
+        ScanAndRegisterAssemblyTypes(this ContainerBuilder builder, params Assembly[] assemblies)
     {
         if (builder == null)
         {
@@ -38,7 +38,7 @@ internal static partial class ScanningRegistrationExtensions
             new ScanningActivatorData(),
             new DynamicRegistrationStyle());
 
-        rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => ScanAssemblies(assemblies, cr, rb));
+        rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => assemblies.ScanAssemblies(cr, rb));
 
         return rb;
     }
@@ -50,7 +50,7 @@ internal static partial class ScanningRegistrationExtensions
     /// <param name="types">The set of types.</param>
     /// <returns>A registration builder.</returns>
     public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
-        RegisterTypes(ContainerBuilder builder, params Type[] types)
+        ScanAndRegisterTypes(this ContainerBuilder builder, params Type[] types)
     {
         if (builder == null)
         {
@@ -67,31 +67,9 @@ internal static partial class ScanningRegistrationExtensions
             new ScanningActivatorData(),
             new DynamicRegistrationStyle());
 
-        rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => ScanTypes(types, cr, rb));
+        rb.RegistrationData.DeferredCallback = builder.RegisterCallback(cr => TypeExtensions.FilterAndRegisterConcreteTypes(types, cr, rb));
 
         return rb;
-    }
-
-    private static void ScanAssemblies(IEnumerable<Assembly> assemblies, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
-    {
-        ScanTypes(assemblies.SelectMany(a => a.GetPermittedTypesForAssemblyScanning()), cr, rb);
-    }
-
-    private static void ScanTypes(IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
-    {
-        var closedTypes = types.WhichCanBeRegistered()
-            .Where(t => !t.IsGenericTypeDefinition)
-            .AllowedByActivatorFilters(rb.ActivatorData);
-
-        rb.ActivatorData.Filters.Add(t =>
-            rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
-                swt.ServiceType.IsAssignableFrom(t)));
-
-        static IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> TypeBuilderFactory(Type type) => RegistrationBuilder.ForType(type);
-
-        static void SingleComponentRegistration(IComponentRegistryBuilder registry, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> data) => RegistrationBuilder.RegisterSingleComponent(registry, data);
-
-        ScanTypesTemplate(closedTypes, cr, rb, TypeBuilderFactory, SingleComponentRegistration);
     }
 
     /// <summary>

--- a/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
+++ b/src/Autofac/Features/Scanning/ScanningRegistrationExtensions.cs
@@ -79,7 +79,7 @@ internal static partial class ScanningRegistrationExtensions
 
     private static void ScanTypes(IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
     {
-        var closedTypes = types.Where(t => !t.IsGenericTypeDefinition)
+        var closedTypes = types.Where(t => t != null && !t.IsGenericTypeDefinition)
             .CanBeRegistered(rb.ActivatorData);
 
         rb.ActivatorData.Filters.Add(t =>

--- a/src/Autofac/Features/Scanning/TypeExtensions.cs
+++ b/src/Autofac/Features/Scanning/TypeExtensions.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Builder;
+using Autofac.Core;
+using Autofac.Core.Registration;
 using Autofac.Util;
 
 namespace Autofac.Features.Scanning;
@@ -24,10 +26,6 @@ internal static class TypeExtensions
     internal static IEnumerable<Type> AllowedByActivatorFilters<TActivatorData, TRegistrationStyle>(this IEnumerable<Type> types, BaseScanningActivatorData<TActivatorData, TRegistrationStyle> activatorData)
         where TActivatorData : ReflectionActivatorData
     {
-        // Issue #897: For back compat reasons we can't filter out
-        // non-public types here. Folks use assembly scanning on their
-        // own stuff, so encapsulation is a tricky thing to manage.
-        // If people want only public types, a LINQ Where clause can be used.
         return types.Where(t => activatorData.Filters.All(p => p(t)));
     }
 
@@ -51,6 +49,136 @@ internal static class TypeExtensions
     /// <returns>
     /// <see langword="true"/> if the type is allowed to be registered during scanning based on its reflection attributes; otherwise <see langword="false"/>.
     /// </returns>
+    // Issue #897: For back compat reasons we can't filter out
+    // non-public types here. Folks use assembly scanning on their
+    // own stuff, so encapsulation is a tricky thing to manage.
+    // If people want only public types, a LINQ Where clause can be used.
+    //
     // Run IsCompilerGenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
     internal static bool IsRegisterableType(this Type? type) => type != null && type.IsClass && !type.IsAbstract && !type.IsDelegate() && !type.IsCompilerGenerated();
+
+    /// <summary>
+    /// Filters a list of types down to only those that are concrete
+    /// (<see cref="IsRegisterableType"/>), not open generic, and allowed by the
+    /// provided activator data. Registers those types into the provided
+    /// registry.
+    /// </summary>
+    /// <param name="types">
+    /// The set of types to filter and register.
+    /// </param>
+    /// <param name="cr">
+    /// The registry builder into which the filtered types should be registered.
+    /// </param>
+    /// <param name="rb">
+    /// A "template" registration builder that is used to provide activator data
+    /// filters and serve as the basis for individual component registrations.
+    /// </param>
+    internal static void FilterAndRegisterConcreteTypes(this IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
+    {
+        var closedTypes = types.WhichCanBeRegistered()
+            .Where(t => !t.IsGenericTypeDefinition)
+            .AllowedByActivatorFilters(rb.ActivatorData);
+
+        rb.ActivatorData.Filters.Add(t =>
+            rb.RegistrationData.Services.OfType<IServiceWithType>().All(swt =>
+                swt.ServiceType.IsAssignableFrom(t)));
+
+        static IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> TypeBuilderFactory(Type type) => RegistrationBuilder.ForType(type);
+
+        static void SingleComponentRegistration(IComponentRegistryBuilder registry, IRegistrationBuilder<object, ConcreteReflectionActivatorData, SingleRegistrationStyle> data) => RegistrationBuilder.RegisterSingleComponent(registry, data);
+
+        closedTypes.RegisterUsingTemplate(cr, rb, TypeBuilderFactory, SingleComponentRegistration);
+    }
+
+    /// <summary>
+    /// Executes a "template" to convert a set of types into a set of
+    /// registrations and then register them with the container. This is used
+    /// for both concrete and open generic type scanning, so the template
+    /// differs based on the thing being scanned.
+    /// </summary>
+    /// <typeparam name="TActivatorData">
+    /// Activator data type. Usually <see cref="ConcreteReflectionActivatorData"/>
+    /// for concrete types or <see cref="ReflectionActivatorData"/> for open generics.
+    /// </typeparam>
+    /// <typeparam name="TScanStyle">
+    /// Scanning style type. Usually <see cref="SingleRegistrationStyle"/> for
+    /// concrete types or <see cref="DynamicRegistrationStyle"/> for open
+    /// generics.
+    /// </typeparam>
+    /// <typeparam name="TRegistrationBuilderStyle">
+    /// Registration style type. Usually <see cref="DynamicRegistrationStyle"/>
+    /// regardless of what's being registered.
+    /// </typeparam>
+    /// <param name="types">
+    /// The set of types to scan and register.
+    /// </param>
+    /// <param name="cr">
+    /// The registry builder into which the built component registrations should
+    /// be added.
+    /// </param>
+    /// <param name="rb">
+    /// A base/template registration builder for scanned registrations.
+    /// </param>
+    /// <param name="scannedConstructorFunc">
+    /// A function that takes a type and generates the registration for that
+    /// type. Will be configured based on <paramref name="rb"/>.
+    /// </param>
+    /// <param name="register">
+    /// A function that takes the built registration and adds it to the
+    /// <paramref name="cr"/> registry builder.
+    /// </param>
+    internal static void RegisterUsingTemplate<TActivatorData, TScanStyle, TRegistrationBuilderStyle>(
+        this IEnumerable<Type> types,
+        IComponentRegistryBuilder cr,
+        IRegistrationBuilder<object, BaseScanningActivatorData<TActivatorData, TScanStyle>, TRegistrationBuilderStyle> rb,
+        Func<Type, IRegistrationBuilder<object, TActivatorData, TScanStyle>> scannedConstructorFunc,
+        Action<IComponentRegistryBuilder, IRegistrationBuilder<object, TActivatorData, TScanStyle>> register)
+        where TActivatorData : ReflectionActivatorData
+    {
+        foreach (var t in types)
+        {
+            var scanned = scannedConstructorFunc(t);
+
+            scanned.ConfigureFrom(rb, t);
+
+            if (scanned.RegistrationData.Services.Any())
+            {
+                register(cr, scanned);
+            }
+        }
+
+        foreach (var postScanningCallback in rb.ActivatorData.PostScanningCallbacks)
+        {
+            postScanningCallback(cr);
+        }
+    }
+
+    /// <summary>
+    /// Copies all the activator data from a "template" registration into a
+    /// scanned registration. This is how constructor finders, parameters, and
+    /// other registration data gets from the top level registration call into
+    /// individual type registrations.
+    /// </summary>
+    private static void ConfigureFrom<TActivatorData, TScanStyle, TRegistrationBuilderStyle>(
+        this IRegistrationBuilder<object, TActivatorData, TScanStyle> scanned,
+        IRegistrationBuilder<object, BaseScanningActivatorData<TActivatorData, TScanStyle>, TRegistrationBuilderStyle> rb,
+        Type type)
+    where TActivatorData : ReflectionActivatorData
+    {
+        scanned
+            .FindConstructorsWith(rb.ActivatorData.ConstructorFinder)
+            .UsingConstructor(rb.ActivatorData.ConstructorSelector)
+            .WithParameters(rb.ActivatorData.ConfiguredParameters)
+            .WithProperties(rb.ActivatorData.ConfiguredProperties);
+
+        // Copy middleware from the scanning registration.
+        scanned.ResolvePipeline.UseRange(rb.ResolvePipeline.Middleware);
+
+        scanned.RegistrationData.CopyFrom(rb.RegistrationData, false);
+
+        foreach (var action in rb.ActivatorData.ConfigurationActions)
+        {
+            action(type, scanned);
+        }
+    }
 }

--- a/src/Autofac/Features/Scanning/TypeExtensions.cs
+++ b/src/Autofac/Features/Scanning/TypeExtensions.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Builder;
+using Autofac.Util;
+
+namespace Autofac.Features.Scanning;
+
+/// <summary>
+/// Extension methods for working with types in a scanning context.
+/// </summary>
+internal static class TypeExtensions
+{
+    /// <summary>
+    /// Filters a list of types using the set of filters associated with the provided activator data.
+    /// </summary>
+    /// <typeparam name="TActivatorData">Activator builder type.</typeparam>
+    /// <typeparam name="TRegistrationStyle">Registration style type.</typeparam>
+    /// <param name="types">The set of types to filter.</param>
+    /// <param name="activatorData">The activator data with filters to run on the type list.</param>
+    /// <returns>
+    /// A filtered list of types that can be registered according to the activator data.
+    /// </returns>
+    internal static IEnumerable<Type> AllowedByActivatorFilters<TActivatorData, TRegistrationStyle>(this IEnumerable<Type> types, BaseScanningActivatorData<TActivatorData, TRegistrationStyle> activatorData)
+        where TActivatorData : ReflectionActivatorData
+    {
+        // Issue #897: For back compat reasons we can't filter out
+        // non-public types here. Folks use assembly scanning on their
+        // own stuff, so encapsulation is a tricky thing to manage.
+        // If people want only public types, a LINQ Where clause can be used.
+        return types.Where(t => activatorData.Filters.All(p => p(t)));
+    }
+
+    /// <summary>
+    /// Filters a list of types down to only those concrete types allowed by scanning registrations.
+    /// </summary>
+    /// <param name="types">
+    /// The types to check.
+    /// </param>
+    /// <returns>
+    /// A filtered set of types that remove non-concrete types (interfaces, abstract classes, etc.).
+    /// </returns>
+    internal static IEnumerable<Type> WhichCanBeRegistered(this IEnumerable<Type> types) => types.Where(t => t.IsRegisterableType());
+
+    /// <summary>
+    /// Determines if a type is a concrete type that is allowed to be registered during scanning.
+    /// </summary>
+    /// <param name="type">
+    /// The type to check.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the type is allowed to be registered during scanning based on its reflection attributes; otherwise <see langword="false"/>.
+    /// </returns>
+    // Run IsCompilerGenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
+    internal static bool IsRegisterableType(this Type? type) => type != null && type.IsClass && !type.IsAbstract && !type.IsDelegate() && !type.IsCompilerGenerated();
+}

--- a/src/Autofac/Features/Scanning/TypeExtensions.cs
+++ b/src/Autofac/Features/Scanning/TypeExtensions.cs
@@ -38,29 +38,13 @@ internal static class TypeExtensions
     /// <returns>
     /// A filtered set of types that remove non-concrete types (interfaces, abstract classes, etc.).
     /// </returns>
-    internal static IEnumerable<Type> WhichCanBeRegistered(this IEnumerable<Type> types) => types.Where(t => t.IsRegisterableType());
-
-    /// <summary>
-    /// Determines if a type is a concrete type that is allowed to be registered during scanning.
-    /// </summary>
-    /// <param name="type">
-    /// The type to check.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> if the type is allowed to be registered during scanning based on its reflection attributes; otherwise <see langword="false"/>.
-    /// </returns>
-    // Issue #897: For back compat reasons we can't filter out
-    // non-public types here. Folks use assembly scanning on their
-    // own stuff, so encapsulation is a tricky thing to manage.
-    // If people want only public types, a LINQ Where clause can be used.
-    //
-    // Run IsCompilerGenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
-    internal static bool IsRegisterableType(this Type? type) => type != null && type.IsClass && !type.IsAbstract && !type.IsDelegate() && !type.IsCompilerGenerated();
+    internal static IEnumerable<Type> WhichAreAllowedThroughScanning(this IEnumerable<Type> types) => types.Where(t => t.MayAllowReflectionActivation());
 
     /// <summary>
     /// Filters a list of types down to only those that are concrete
-    /// (<see cref="IsRegisterableType"/>), not open generic, and allowed by the
-    /// provided activator data. Registers those types into the provided
+    /// (<see cref="InternalTypeExtensions.MayAllowReflectionActivation"/>), not open generic,
+    /// and allowed by the provided activator data. Registers those types into
+    /// the provided
     /// registry.
     /// </summary>
     /// <param name="types">
@@ -75,7 +59,7 @@ internal static class TypeExtensions
     /// </param>
     internal static void FilterAndRegisterConcreteTypes(this IEnumerable<Type> types, IComponentRegistryBuilder cr, IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle> rb)
     {
-        var closedTypes = types.WhichCanBeRegistered()
+        var closedTypes = types.WhichAreAllowedThroughScanning()
             .Where(t => !t.IsGenericTypeDefinition)
             .AllowedByActivatorFilters(rb.ActivatorData);
 

--- a/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
+++ b/src/Autofac/Features/Variance/ContravariantRegistrationSource.cs
@@ -115,7 +115,7 @@ public class ContravariantRegistrationSource : IRegistrationSource
 
     private static IEnumerable<Type> GetBagOfTypesAssignableFrom(Type type)
     {
-        if (type.BaseType != null)
+        if (type.BaseType is not null)
         {
             yield return type.BaseType;
             foreach (var fromBase in GetBagOfTypesAssignableFrom(type.BaseType))

--- a/src/Autofac/RegistrationExtensions.AssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.AssemblyScanning.cs
@@ -27,7 +27,7 @@ public static partial class RegistrationExtensions
     public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
         RegisterAssemblyTypes(this ContainerBuilder builder, params Assembly[] assemblies)
     {
-        return ScanningRegistrationExtensions.RegisterAssemblyTypes(builder, assemblies);
+        return builder.ScanAndRegisterAssemblyTypes(assemblies);
     }
 
     /// <summary>
@@ -273,7 +273,7 @@ public static partial class RegistrationExtensions
     public static IRegistrationBuilder<object, ScanningActivatorData, DynamicRegistrationStyle>
         RegisterTypes(this ContainerBuilder builder, params Type[] types)
     {
-        return ScanningRegistrationExtensions.RegisterTypes(builder, types);
+        return builder.ScanAndRegisterTypes(types);
     }
 
     /// <summary>

--- a/src/Autofac/RegistrationExtensions.Composite.cs
+++ b/src/Autofac/RegistrationExtensions.Composite.cs
@@ -103,11 +103,11 @@ public static partial class RegistrationExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        var rb = builder.Register((ctxt, p) =>
+        var rb = builder.Register((context, p) =>
         {
-            var concreteItems = ctxt.Resolve<IEnumerable<TService>>();
+            var concreteItems = context.Resolve<IEnumerable<TService>>();
 
-            return compositeDelegate(ctxt, p, concreteItems);
+            return compositeDelegate(context, p, concreteItems);
         });
 
         ApplyCompositeConfiguration(builder, rb);
@@ -134,12 +134,12 @@ public static partial class RegistrationExtensions
         Func<IComponentContext, IEnumerable<TService>, TService> compositeDelegate)
         where TService : notnull
     {
-        return builder.RegisterComposite<TService>((ctxt, p, concrete) => compositeDelegate(ctxt, concrete));
+        return builder.RegisterComposite<TService>((context, p, concrete) => compositeDelegate(context, concrete));
     }
 
     /// <summary>
     /// <para>
-    /// Register an un-parameterised generic type, e.g. Composite&lt;&gt; to function as a composite
+    /// Register an un-parameterized generic type, e.g. Composite&lt;&gt; to function as a composite
     /// for an open generic service, e.g. IRepository&lt;&gt;. Composites will be made as they are requested,
     /// e.g. with Resolve&lt;IRepository&lt;int&gt;&gt;().
     /// </para>

--- a/src/Autofac/RegistrationExtensions.EventHandler.cs
+++ b/src/Autofac/RegistrationExtensions.EventHandler.cs
@@ -47,7 +47,7 @@ public static partial class RegistrationExtensions
     }
 
     /// <summary>
-    /// Provide a handler to be called when the component is registred.
+    /// Provide a handler to be called when the component is registered.
     /// </summary>
     /// <typeparam name="TLimit">Registration limit type.</typeparam>
     /// <typeparam name="TRegistrationStyle">Registration style.</typeparam>
@@ -108,12 +108,12 @@ public static partial class RegistrationExtensions
         // have closed over the wrong thing.
         registration.ExternallyOwned();
 
-        var middleware = new CoreEventMiddleware(ResolveEventType.OnRelease, PipelinePhase.Activation, (ctxt, next) =>
+        var middleware = new CoreEventMiddleware(ResolveEventType.OnRelease, PipelinePhase.Activation, (context, next) =>
         {
             // Continue down the pipeline.
-            next(ctxt);
+            next(context);
 
-            ctxt.ActivationScope.Disposer.AddInstanceForAsyncDisposal(new ReleaseAction<TLimit>(releaseAction, () => (TLimit)ctxt.Instance!));
+            context.ActivationScope.Disposer.AddInstanceForAsyncDisposal(new ReleaseAction<TLimit>(releaseAction, () => (TLimit)context.Instance!));
         });
 
         registration.ResolvePipeline.Use(middleware, MiddlewareInsertionMode.StartOfPhase);
@@ -151,14 +151,14 @@ public static partial class RegistrationExtensions
 
         registration.ExternallyOwned();
 
-        var middleware = new CoreEventMiddleware(ResolveEventType.OnRelease, PipelinePhase.Activation, (ctxt, next) =>
+        var middleware = new CoreEventMiddleware(ResolveEventType.OnRelease, PipelinePhase.Activation, (context, next) =>
         {
             // Continue down the pipeline.
-            next(ctxt);
+            next(context);
 
             // Use an async release action that invokes the release callback in a proper async/await flow if someone
             // is using actual async disposal.
-            ctxt.ActivationScope.Disposer.AddInstanceForAsyncDisposal(new AsyncReleaseAction<TLimit>(releaseAction, () => (TLimit)ctxt.Instance!));
+            context.ActivationScope.Disposer.AddInstanceForAsyncDisposal(new AsyncReleaseAction<TLimit>(releaseAction, () => (TLimit)context.Instance!));
         });
 
         registration.ResolvePipeline.Use(middleware, MiddlewareInsertionMode.StartOfPhase);

--- a/src/Autofac/RegistrationExtensions.Generics.cs
+++ b/src/Autofac/RegistrationExtensions.Generics.cs
@@ -14,7 +14,7 @@ namespace Autofac;
 public static partial class RegistrationExtensions
 {
     /// <summary>
-    /// Register an un-parameterised generic type, e.g. Repository&lt;&gt;.
+    /// Register an un-parameterized generic type, e.g. Repository&lt;&gt;.
     /// Concrete types will be made as they are requested, e.g. with Resolve&lt;Repository&lt;int&gt;&gt;().
     /// </summary>
     /// <param name="builder">Container builder.</param>
@@ -35,7 +35,7 @@ public static partial class RegistrationExtensions
     public static IRegistrationBuilder<object, OpenGenericDelegateActivatorData, DynamicRegistrationStyle>
         RegisterGeneric(this ContainerBuilder builder, Func<IComponentContext, Type[], object> factory)
     {
-        return builder.RegisterGeneric((ctxt, types, parameters) => factory(ctxt, types));
+        return builder.RegisterGeneric((context, types, parameters) => factory(context, types));
     }
 
     /// <summary>

--- a/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
+++ b/src/Autofac/RegistrationExtensions.OpenGenericAssemblyScanning.cs
@@ -26,7 +26,7 @@ public static partial class RegistrationExtensions
     public static IRegistrationBuilder<object, OpenGenericScanningActivatorData, DynamicRegistrationStyle>
         RegisterAssemblyOpenGenericTypes(this ContainerBuilder builder, params Assembly[] assemblies)
     {
-        return ScanningRegistrationExtensions.RegisterOpenGenericAssemblyTypes(builder, assemblies);
+        return builder.ScanAndRegisterOpenGenericAssemblyTypes(assemblies);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public static partial class RegistrationExtensions
             throw new ArgumentNullException(nameof(serviceMapping));
         }
 
-        return ScanningRegistrationExtensions.As(registration, serviceMapping);
+        return OpenGenericScanningRegistrationExtensions.As(registration, serviceMapping);
     }
 
     /// <summary>
@@ -212,7 +212,7 @@ public static partial class RegistrationExtensions
         AssignableTo<TLimit, TRegistrationStyle>(
             this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType)
     {
-        return ScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType);
+        return OpenGenericScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType);
     }
 
     /// <summary>
@@ -228,7 +228,7 @@ public static partial class RegistrationExtensions
         AssignableTo<TLimit, TRegistrationStyle>(
             this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, object serviceKey)
     {
-        return ScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType, serviceKey);
+        return OpenGenericScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType, serviceKey);
     }
 
     /// <summary>
@@ -244,7 +244,7 @@ public static partial class RegistrationExtensions
         AssignableTo<TLimit, TRegistrationStyle>(
             this IRegistrationBuilder<TLimit, OpenGenericScanningActivatorData, TRegistrationStyle> registration, Type openGenericServiceType, Func<Type, object> serviceKeyMapping)
     {
-        return ScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType, serviceKeyMapping);
+        return OpenGenericScanningRegistrationExtensions.AssignableTo(registration, openGenericServiceType, serviceKeyMapping);
     }
 
     /// <summary>

--- a/src/Autofac/TypeExtensions.cs
+++ b/src/Autofac/TypeExtensions.cs
@@ -37,7 +37,7 @@ public static class TypeExtensions
             throw new ArgumentNullException(nameof(@namespace));
         }
 
-        return @this.Namespace != null &&
+        return @this.Namespace is not null &&
             (@this.Namespace == @namespace || @this.Namespace.StartsWith(@namespace + ".", StringComparison.Ordinal));
     }
 

--- a/src/Autofac/Util/AssemblyExtensions.cs
+++ b/src/Autofac/Util/AssemblyExtensions.cs
@@ -40,22 +40,4 @@ public static class AssemblyExtensions
             return ex.Types.Where(t => t is not null)!;
         }
     }
-
-    /// <summary>
-    /// Get the set of types that Autofac will allow to be loaded from the given assembly.
-    /// </summary>
-    /// <param name="assembly">The assembly to load types from.</param>
-    /// <returns>The set of loadable types.</returns>
-    internal static IEnumerable<Type> GetPermittedTypesForAssemblyScanning(this Assembly assembly)
-    {
-        static IReadOnlyList<Type> Uncached(Assembly assembly)
-        {
-            // Run IsCompilerGenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
-            return assembly.GetLoadableTypes()
-                           .Where(t => t.IsClass && !t.IsAbstract && !t.IsDelegate() && !t.IsCompilerGenerated())
-                           .ToList();
-        }
-
-        return ReflectionCacheSet.Shared.Internal.AssemblyScanAllowedTypes.GetOrAdd(assembly, Uncached);
-    }
 }

--- a/src/Autofac/Util/InternalTypeExtensions.cs
+++ b/src/Autofac/Util/InternalTypeExtensions.cs
@@ -238,7 +238,7 @@ internal static class InternalTypeExtensions
     // If people want only public types, a LINQ Where clause can be used.
     //
     // Run IsCompilerGenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
-    internal static bool MayAllowReflectionActivation(this Type? type, bool allowCompilerGenerated = false) => type != null && type.IsClass && !type.IsAbstract && !type.IsDelegate() && (allowCompilerGenerated || !type.IsCompilerGenerated());
+    internal static bool MayAllowReflectionActivation(this Type? type, bool allowCompilerGenerated = false) => type is not null && type.IsClass && !type.IsAbstract && !type.IsDelegate() && (allowCompilerGenerated || !type.IsCompilerGenerated());
 
     private static bool CheckBaseTypeIsOpenGenericTypeOf(this Type @this, Type type)
     {

--- a/src/Autofac/Util/InternalTypeExtensions.cs
+++ b/src/Autofac/Util/InternalTypeExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Autofac.Core;
@@ -149,7 +148,7 @@ internal static class InternalTypeExtensions
     }
 
     /// <summary>
-    /// Checks whether a given type is a generic list of colleciton interface type, e.g. <see cref="IList{T}"/>, <see cref="ICollection{T}"/> and the read-only variants.
+    /// Checks whether a given type is a generic list of collection interface type, e.g. <see cref="IList{T}"/>, <see cref="ICollection{T}"/> and the read-only variants.
     /// </summary>
     /// <param name="type">The type to check.</param>
     /// <returns>True if the type is one of the supported list/collection types.</returns>
@@ -168,7 +167,7 @@ internal static class InternalTypeExtensions
     }
 
     /// <summary>
-    /// Checks whether a given type is a closed generic defined by the specifed open generic.
+    /// Checks whether a given type is a closed generic defined by the specified open generic.
     /// </summary>
     /// <param name="this">The type to check.</param>
     /// <param name="openGeneric">The open generic to check against.</param>
@@ -213,6 +212,33 @@ internal static class InternalTypeExtensions
         return @this.CheckBaseTypeIsOpenGenericTypeOf(type)
           || @this.CheckInterfacesAreOpenGenericTypeOf(type);
     }
+
+    /// <summary>
+    /// Filters off interfaces, abstract types, and generally non-registerable
+    /// types. Largely used during type/assembly scanning, but also can
+    /// determine if this is something we can activate by reflection.
+    /// Intentionally does NOT filter out open generic definitions because this
+    /// gets used in both concrete and open generic scanning.
+    /// </summary>
+    /// <param name="type">
+    /// The type to check.
+    /// </param>
+    /// <param name="allowCompilerGenerated">
+    /// <see langword="true"/> to allow compiler-generated types to be
+    /// considered registerable. Defaults to <see langword="false"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the type is allowed to be registered during
+    /// scanning based on its reflection attributes; otherwise <see
+    /// langword="false"/>.
+    /// </returns>
+    // Issue #897: For back compat reasons we can't filter out
+    // non-public types here. Folks use assembly scanning on their
+    // own stuff, so encapsulation is a tricky thing to manage.
+    // If people want only public types, a LINQ Where clause can be used.
+    //
+    // Run IsCompilerGenerated check last due to perf. See AssemblyScanningPerformanceTests.MeasurePerformance.
+    internal static bool MayAllowReflectionActivation(this Type? type, bool allowCompilerGenerated = false) => type != null && type.IsClass && !type.IsAbstract && !type.IsDelegate() && (allowCompilerGenerated || !type.IsCompilerGenerated());
 
     private static bool CheckBaseTypeIsOpenGenericTypeOf(this Type @this, Type type)
     {
@@ -287,7 +313,9 @@ internal static class InternalTypeExtensions
                    .Any(p => ParameterEqualsConstraint(p, constraint));
     }
 
+#if NET6_0_OR_GREATER
     [SuppressMessage("Microsoft.Design", "CA1031", Justification = "Implementing a real TryMakeGenericType is not worth the effort.")]
+#endif
     private static bool ParameterEqualsConstraint(Type parameter, Type constraint)
     {
         var genericArguments = parameter.GenericTypeArguments;

--- a/src/Autofac/Util/ReflectionExtensions.cs
+++ b/src/Autofac/Util/ReflectionExtensions.cs
@@ -32,7 +32,7 @@ internal static class ReflectionExtensions
     public static bool TryGetDeclaringProperty(this ParameterInfo pi, [NotNullWhen(returnValue: true)] out PropertyInfo? prop)
     {
         var mi = pi.Member as MethodInfo;
-        if (mi != null && mi.IsSpecialName && mi.Name.StartsWith("set_", StringComparison.Ordinal) && mi.DeclaringType != null)
+        if (mi is not null && mi.IsSpecialName && mi.Name.StartsWith("set_", StringComparison.Ordinal) && mi.DeclaringType is not null)
         {
             prop = mi.DeclaringType.GetDeclaredProperty(mi.Name.Substring(4));
             return true;

--- a/src/Autofac/Util/Traverse.cs
+++ b/src/Autofac/Util/Traverse.cs
@@ -19,7 +19,7 @@ internal static class Traverse
         where T : class
     {
         var item = first;
-        while (item != null)
+        while (item is not null)
         {
             yield return item;
             item = next(item);

--- a/test/Autofac.Specification.Test/Diagnostics/DefaultDiagnosticTracerTests.cs
+++ b/test/Autofac.Specification.Test/Diagnostics/DefaultDiagnosticTracerTests.cs
@@ -13,7 +13,7 @@ public class DefaultDiagnosticTracerTests
         var tracer = new DefaultDiagnosticTracer();
 
         var containerBuilder = new ContainerBuilder();
-        containerBuilder.Register(ctxt => "Hello");
+        containerBuilder.Register(context => "Hello");
 
         var container = containerBuilder.Build();
 
@@ -39,7 +39,7 @@ public class DefaultDiagnosticTracerTests
         var tracer = new DefaultDiagnosticTracer();
 
         var containerBuilder = new ContainerBuilder();
-        containerBuilder.Register<string>(ctxt => throw new InvalidOperationException());
+        containerBuilder.Register<string>(context => throw new InvalidOperationException());
 
         var container = containerBuilder.Build();
 

--- a/test/Autofac.Specification.Test/Features/CircularDependencyTests.cs
+++ b/test/Autofac.Specification.Test/Features/CircularDependencyTests.cs
@@ -147,7 +147,7 @@ public class CircularDependencyTests
         builder.Register(
             ctx => new[] { nameof(Plugin1), nameof(Plugin2) }
                 .Select(name => SafeResolvePlugin(name, ctx))
-                .Where(p => p != null)
+                .Where(p => p is not null)
                 .ToArray())
             .As<IEnumerable<IPlugin>>()
             .SingleInstance();

--- a/test/Autofac.Specification.Test/Features/CompositeTests.cs
+++ b/test/Autofac.Specification.Test/Features/CompositeTests.cs
@@ -88,7 +88,7 @@ public class CompositeTests
         builder.Register(ctx => new S1()).As<I1>();
         builder.Register(ctx => new S2()).As<I1>();
 
-        builder.RegisterComposite<I1>((ctxt, concrete) => new MyComposite(concrete));
+        builder.RegisterComposite<I1>((context, concrete) => new MyComposite(concrete));
 
         var container = builder.Build();
 
@@ -417,7 +417,7 @@ public class CompositeTests
 
         var container = builder.Build();
 
-        var nested = container.BeginLifetimeScope(cfg => cfg.Register(ctxt => new S3()).As<I1>());
+        var nested = container.BeginLifetimeScope(cfg => cfg.Register(context => new S3()).As<I1>());
 
         var comp = (MyComposite)nested.Resolve<I1>();
 
@@ -444,7 +444,7 @@ public class CompositeTests
         builder.Register(ctx => new S2()).As<I1>();
         builder.RegisterDecorator<DecoratorForI1, I1>();
 
-        builder.RegisterComposite<I1>((ctxt, concrete) => new MyComposite(concrete));
+        builder.RegisterComposite<I1>((context, concrete) => new MyComposite(concrete));
 
         var container = builder.Build();
 

--- a/test/Autofac.Specification.Test/Registration/OpenGenericDelegateTests.cs
+++ b/test/Autofac.Specification.Test/Registration/OpenGenericDelegateTests.cs
@@ -33,7 +33,7 @@ public class OpenGenericDelegateTests
     {
         var builder = new ContainerBuilder();
 
-        builder.RegisterGeneric((ctxt, types) => Activator.CreateInstance(typeof(ImplementationA<>).MakeGenericType(types)))
+        builder.RegisterGeneric((context, types) => Activator.CreateInstance(typeof(ImplementationA<>).MakeGenericType(types)))
                .As(typeof(IInterfaceA<>));
 
         var container = builder.Build();
@@ -50,7 +50,7 @@ public class OpenGenericDelegateTests
     {
         var builder = new ContainerBuilder();
 
-        builder.RegisterGeneric((ctxt, types) => Activator.CreateInstance(typeof(ImplementationA<>).MakeGenericType(types)))
+        builder.RegisterGeneric((context, types) => Activator.CreateInstance(typeof(ImplementationA<>).MakeGenericType(types)))
                .As(typeof(IInterfaceA<>));
 
         var container = builder.Build();
@@ -63,7 +63,7 @@ public class OpenGenericDelegateTests
     {
         var builder = new ContainerBuilder();
 
-        builder.RegisterGeneric((ctxt, types) => Activator.CreateInstance(typeof(ImplementationMultiType<,>).MakeGenericType(types)))
+        builder.RegisterGeneric((context, types) => Activator.CreateInstance(typeof(ImplementationMultiType<,>).MakeGenericType(types)))
                .As(typeof(IInterfaceMultiType<,>));
 
         var container = builder.Build();
@@ -80,7 +80,7 @@ public class OpenGenericDelegateTests
     {
         var builder = new ContainerBuilder();
 
-        builder.RegisterGeneric((ctxt, types) =>
+        builder.RegisterGeneric((context, types) =>
         {
             var chosenType = types.Length == 2 ? typeof(ImplementationMultiType<,>) : typeof(ImplementationA<>);
 
@@ -107,7 +107,7 @@ public class OpenGenericDelegateTests
 
         List<Parameter> passedParameters = null;
 
-        builder.RegisterGeneric((ctxt, types, parameters) =>
+        builder.RegisterGeneric((context, types, parameters) =>
         {
             passedParameters = parameters.ToList();
 
@@ -129,7 +129,7 @@ public class OpenGenericDelegateTests
     {
         var builder = new ContainerBuilder();
 
-        builder.RegisterGeneric((ctxt, types) => "bad")
+        builder.RegisterGeneric((context, types) => "bad")
                .As(typeof(IInterfaceA<>));
 
         var container = builder.Build();
@@ -144,7 +144,7 @@ public class OpenGenericDelegateTests
     {
         var builder = new ContainerBuilder();
 
-        builder.RegisterGeneric((ctxt, types) => throw new DivideByZeroException())
+        builder.RegisterGeneric((context, types) => throw new DivideByZeroException())
                .As(typeof(IInterfaceA<>));
 
         var container = builder.Build();

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -113,9 +113,9 @@ public class RegistrationOnlyIfTests
 
         builder.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
 
-        builder.RegisterServiceMiddleware<IService>(PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+        builder.RegisterServiceMiddleware<IService>(PipelinePhase.ResolveRequestStart, (context, next) =>
         {
-            next(ctxt);
+            next(context);
             middlewareInvoked = true;
         });
 

--- a/test/Autofac.Specification.Test/Registration/TypeRegistrationTests.cs
+++ b/test/Autofac.Specification.Test/Registration/TypeRegistrationTests.cs
@@ -31,6 +31,16 @@ public class TypeRegistrationTests
     {
     }
 
+    public struct MyValueType
+    {
+        public MyValueType(IMyService service)
+        {
+            Service = service;
+        }
+
+        public IMyService Service { get; }
+    }
+
     [Fact]
     public void AsImplementedInterfacesGeneric()
     {
@@ -113,6 +123,7 @@ public class TypeRegistrationTests
         Assert.Throws<ArgumentException>(() => builder.RegisterType<IMyService>());
         Assert.Throws<ArgumentException>(() => builder.RegisterType<MyDelegate>());
         Assert.Throws<ArgumentException>(() => builder.RegisterType<MyAbstractClass>());
+        Assert.Throws<ArgumentException>(() => builder.RegisterType<MyValueType>());
     }
 
     [Theory]
@@ -120,6 +131,7 @@ public class TypeRegistrationTests
     [InlineData(typeof(IMyService))]
     [InlineData(typeof(MyAbstractClass))]
     [InlineData(typeof(MyOpenGeneric<>))]
+    [InlineData(typeof(MyValueType))]
     public void RegisterTypeMustBeConcrete_Parameter(Type type)
     {
         var builder = new ContainerBuilder();
@@ -142,7 +154,14 @@ public class TypeRegistrationTests
     public void RegisterTypesIgnoresNonRegisterableTypes()
     {
         var container = new ContainerBuilder().Build().BeginLifetimeScope(b =>
-            b.RegisterTypes(typeof(IMyService), typeof(MyDelegate), typeof(MyAbstractClass), typeof(MyOpenGeneric<>), typeof(MyOpenGeneric<int>), typeof(MyComponent)));
+            b.RegisterTypes(
+                typeof(IMyService),
+                typeof(MyDelegate),
+                typeof(MyAbstractClass),
+                typeof(MyOpenGeneric<>),
+                typeof(MyValueType),
+                typeof(MyOpenGeneric<int>),
+                typeof(MyComponent)));
 
         Assert.Equal(2, container.ComponentRegistry.Registrations.Count());
         Assert.True(container.TryResolve(typeof(MyComponent), out object _));
@@ -150,6 +169,7 @@ public class TypeRegistrationTests
         Assert.False(container.TryResolve(typeof(IMyService), out _));
         Assert.False(container.TryResolve(typeof(MyDelegate), out _));
         Assert.False(container.TryResolve(typeof(MyAbstractClass), out _));
+        Assert.False(container.TryResolve(typeof(MyValueType), out _));
     }
 
     [Fact]

--- a/test/Autofac.Specification.Test/Registration/TypeRegistrationTests.cs
+++ b/test/Autofac.Specification.Test/Registration/TypeRegistrationTests.cs
@@ -107,6 +107,26 @@ public class TypeRegistrationTests
     }
 
     [Fact]
+    public void RegisterTypeMustBeConcrete_Generic()
+    {
+        var builder = new ContainerBuilder();
+        Assert.Throws<ArgumentException>(() => builder.RegisterType<IMyService>());
+        Assert.Throws<ArgumentException>(() => builder.RegisterType<MyDelegate>());
+        Assert.Throws<ArgumentException>(() => builder.RegisterType<MyAbstractClass>());
+    }
+
+    [Theory]
+    [InlineData(typeof(MyDelegate))]
+    [InlineData(typeof(IMyService))]
+    [InlineData(typeof(MyAbstractClass))]
+    [InlineData(typeof(MyOpenGeneric<>))]
+    public void RegisterTypeMustBeConcrete_Parameter(Type type)
+    {
+        var builder = new ContainerBuilder();
+        Assert.Throws<ArgumentException>(() => builder.RegisterType(type));
+    }
+
+    [Fact]
     public void RegisterTypesCanBeFilteredByAssignableTo()
     {
         var container = new ContainerBuilder().Build().BeginLifetimeScope(b =>

--- a/test/Autofac.Specification.Test/Registration/TypeRegistrationTests.cs
+++ b/test/Autofac.Specification.Test/Registration/TypeRegistrationTests.cs
@@ -21,6 +21,16 @@ public class TypeRegistrationTests
     {
     }
 
+    public delegate void MyDelegate();
+
+    public abstract class MyAbstractClass
+    {
+    }
+
+    public class MyOpenGeneric<T>
+    {
+    }
+
     [Fact]
     public void AsImplementedInterfacesGeneric()
     {
@@ -106,6 +116,30 @@ public class TypeRegistrationTests
         Assert.Single(container.ComponentRegistry.Registrations);
         Assert.True(container.TryResolve(typeof(MyComponent), out object obj));
         Assert.False(container.TryResolve(typeof(MyComponent2), out obj));
+    }
+
+    [Fact]
+    public void RegisterTypesIgnoresNonRegisterableTypes()
+    {
+        var container = new ContainerBuilder().Build().BeginLifetimeScope(b =>
+            b.RegisterTypes(typeof(IMyService), typeof(MyDelegate), typeof(MyAbstractClass), typeof(MyOpenGeneric<>), typeof(MyOpenGeneric<int>), typeof(MyComponent)));
+
+        Assert.Equal(2, container.ComponentRegistry.Registrations.Count());
+        Assert.True(container.TryResolve(typeof(MyComponent), out object _));
+        Assert.True(container.TryResolve(typeof(MyOpenGeneric<int>), out object _));
+        Assert.False(container.TryResolve(typeof(IMyService), out _));
+        Assert.False(container.TryResolve(typeof(MyDelegate), out _));
+        Assert.False(container.TryResolve(typeof(MyAbstractClass), out _));
+    }
+
+    [Fact]
+    public void RegisterTypesIgnoresNullValues()
+    {
+        var container = new ContainerBuilder().Build().BeginLifetimeScope(b =>
+            b.RegisterTypes(null, typeof(MyComponent), null));
+
+        Assert.Single(container.ComponentRegistry.Registrations);
+        Assert.True(container.TryResolve(typeof(MyComponent), out object _));
     }
 
     [Fact]

--- a/test/Autofac.Test.CodeGen/Helpers/ModuleInitializer.cs
+++ b/test/Autofac.Test.CodeGen/Helpers/ModuleInitializer.cs
@@ -24,7 +24,7 @@ public static class ModuleInitializer
         var targets = new List<Target>();
         foreach (var result in target.Results)
         {
-            if (result.Exception != null)
+            if (result.Exception is not null)
             {
                 exceptions.Add(result.Exception);
             }

--- a/test/Autofac.Test/Assertions.cs
+++ b/test/Autofac.Test/Assertions.cs
@@ -115,6 +115,6 @@ internal static class Assertions
     {
         return registrations
             .Select(registration => types.FirstOrDefault(type => registration.Activator.LimitType == type))
-            .Where(foundType => foundType != null);
+            .Where(foundType => foundType is not null);
     }
 }

--- a/test/Autofac.Test/ContainerBuilderTests.cs
+++ b/test/Autofac.Test/ContainerBuilderTests.cs
@@ -53,11 +53,11 @@ public class ContainerBuilderTests
         builder.RegisterCallback(x => x.Registered += (o, registration) =>
         {
             registration.ComponentRegistration.ConfigurePipeline(builder =>
-                builder.Use(PipelinePhase.Activation, (ctxt, next) =>
+                builder.Use(PipelinePhase.Activation, (context, next) =>
                 {
-                    next(ctxt);
+                    next(context);
 
-                    activatedInstances.Add(ctxt.Instance);
+                    activatedInstances.Add(context.Instance);
                 }));
         });
 

--- a/test/Autofac.Test/Core/ContainerTests.cs
+++ b/test/Autofac.Test/Core/ContainerTests.cs
@@ -32,7 +32,7 @@ public class ContainerTests
     }
 
     [Fact]
-    public void RegisterParameterisedWithDelegate()
+    public void RegisterParameterizedWithDelegate()
     {
         var cb = new ContainerBuilder();
         cb.Register((c, p) => new Parameterised(p.Named<string>("a"), p.Named<int>("b")));
@@ -48,7 +48,7 @@ public class ContainerTests
     }
 
     [Fact]
-    public void RegisterParameterisedWithReflection()
+    public void RegisterParameterizedWithReflection()
     {
         var cb = new ContainerBuilder();
         cb.RegisterType<Parameterised>();
@@ -205,9 +205,9 @@ public class ContainerTests
     {
         protected override void AttachToComponentRegistration(IComponentRegistryBuilder componentRegistry, IComponentRegistration registration)
         {
-            registration.ConfigurePipeline(builder => builder.Use(PipelinePhase.Activation, (ctxt, next) =>
+            registration.ConfigurePipeline(builder => builder.Use(PipelinePhase.Activation, (context, next) =>
             {
-                ctxt.Instance = new ReplaceableComponent { IsReplaced = true };
+                context.Instance = new ReplaceableComponent { IsReplaced = true };
             }));
         }
     }

--- a/test/Autofac.Test/Core/ContainerTests.cs
+++ b/test/Autofac.Test/Core/ContainerTests.cs
@@ -4,7 +4,7 @@
 using Autofac.Core;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Test.Scenarios.Parameterisation;
+using Autofac.Test.Scenarios.Parameterization;
 using Autofac.Test.Util;
 
 namespace Autofac.Test.Core;
@@ -35,11 +35,11 @@ public class ContainerTests
     public void RegisterParameterizedWithDelegate()
     {
         var cb = new ContainerBuilder();
-        cb.Register((c, p) => new Parameterised(p.Named<string>("a"), p.Named<int>("b")));
+        cb.Register((c, p) => new Parameterized(p.Named<string>("a"), p.Named<int>("b")));
         var container = cb.Build();
         var aVal = "Hello";
         var bVal = 42;
-        var result = container.Resolve<Parameterised>(
+        var result = container.Resolve<Parameterized>(
             new NamedParameter("a", aVal),
             new NamedParameter("b", bVal));
         Assert.NotNull(result);
@@ -51,11 +51,11 @@ public class ContainerTests
     public void RegisterParameterizedWithReflection()
     {
         var cb = new ContainerBuilder();
-        cb.RegisterType<Parameterised>();
+        cb.RegisterType<Parameterized>();
         var container = cb.Build();
         var aVal = "Hello";
         var bVal = 42;
-        var result = container.Resolve<Parameterised>(
+        var result = container.Resolve<Parameterized>(
             new NamedParameter("a", aVal),
             new NamedParameter("b", bVal));
         Assert.NotNull(result);

--- a/test/Autofac.Test/Core/Pipeline/PipelineBuilderTests.cs
+++ b/test/Autofac.Test/Core/Pipeline/PipelineBuilderTests.cs
@@ -19,10 +19,10 @@ public class PipelineBuilderTests
     {
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
         var order = new List<string>();
-        pipelineBuilder.Use(PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+        pipelineBuilder.Use(PipelinePhase.ResolveRequestStart, (context, next) =>
         {
             order.Add("1");
-            next(ctxt);
+            next(context);
         });
 
         var built = pipelineBuilder.Build();
@@ -39,20 +39,20 @@ public class PipelineBuilderTests
     {
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
         var order = new List<string>();
-        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (context, next) =>
         {
             order.Add("1");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (context, next) =>
         {
             order.Add("2");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("3", PipelinePhase.Sharing, (ctxt, next) =>
+        pipelineBuilder.Use("3", PipelinePhase.Sharing, (context, next) =>
         {
             order.Add("3");
-            next(ctxt);
+            next(context);
         });
 
         var built = pipelineBuilder.Build();
@@ -72,20 +72,20 @@ public class PipelineBuilderTests
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
 
         var order = new List<string>();
-        pipelineBuilder.Use("3", PipelinePhase.Sharing, (ctxt, next) =>
+        pipelineBuilder.Use("3", PipelinePhase.Sharing, (context, next) =>
         {
             order.Add("3");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (context, next) =>
         {
             order.Add("2");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (context, next) =>
         {
             order.Add("1");
-            next(ctxt);
+            next(context);
         });
 
         var built = pipelineBuilder.Build();
@@ -105,25 +105,25 @@ public class PipelineBuilderTests
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
 
         var order = new List<string>();
-        pipelineBuilder.Use("3", PipelinePhase.Decoration, (ctxt, next) =>
+        pipelineBuilder.Use("3", PipelinePhase.Decoration, (context, next) =>
         {
             order.Add("3");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("4", PipelinePhase.Sharing, (ctxt, next) =>
+        pipelineBuilder.Use("4", PipelinePhase.Sharing, (context, next) =>
         {
             order.Add("4");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (context, next) =>
         {
             order.Add("1");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (context, next) =>
         {
             order.Add("2");
-            next(ctxt);
+            next(context);
         });
 
         var built = pipelineBuilder.Build();
@@ -143,20 +143,20 @@ public class PipelineBuilderTests
     {
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
         var order = new List<string>();
-        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, (context, next) =>
         {
             order.Add("2");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("1", PipelinePhase.ScopeSelection, MiddlewareInsertionMode.StartOfPhase, (ctxt, next) =>
+        pipelineBuilder.Use("1", PipelinePhase.ScopeSelection, MiddlewareInsertionMode.StartOfPhase, (context, next) =>
         {
             order.Add("1");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("3", PipelinePhase.ScopeSelection, (ctxt, next) =>
+        pipelineBuilder.Use("3", PipelinePhase.ScopeSelection, (context, next) =>
         {
             order.Add("3");
-            next(ctxt);
+            next(context);
         });
 
         var built = pipelineBuilder.Build();
@@ -176,20 +176,20 @@ public class PipelineBuilderTests
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
 
         var order = new List<string>();
-        pipelineBuilder.Use("3", PipelinePhase.ScopeSelection, (ctxt, next) =>
+        pipelineBuilder.Use("3", PipelinePhase.ScopeSelection, (context, next) =>
         {
             order.Add("3");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+        pipelineBuilder.Use("1", PipelinePhase.ResolveRequestStart, (context, next) =>
         {
             order.Add("1");
-            next(ctxt);
+            next(context);
         });
-        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, MiddlewareInsertionMode.StartOfPhase, (ctxt, next) =>
+        pipelineBuilder.Use("2", PipelinePhase.ScopeSelection, MiddlewareInsertionMode.StartOfPhase, (context, next) =>
         {
             order.Add("2");
-            next(ctxt);
+            next(context);
         });
 
         var built = pipelineBuilder.Build();
@@ -211,20 +211,20 @@ public class PipelineBuilderTests
 
         pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) =>
             {
                 order.Add("1");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (context, next) =>
             {
                 order.Add("2");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("3", PipelinePhase.Sharing, (ctxt, next) =>
+            new DelegateMiddleware("3", PipelinePhase.Sharing, (context, next) =>
             {
                 order.Add("3");
-                next(ctxt);
+                next(context);
             }),
         });
 
@@ -247,39 +247,39 @@ public class PipelineBuilderTests
 
         pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) =>
             {
                 order.Add("1");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (context, next) =>
             {
                 order.Add("2");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("4", PipelinePhase.ServicePipelineEnd, (ctxt, next) =>
+            new DelegateMiddleware("4", PipelinePhase.ServicePipelineEnd, (context, next) =>
             {
                 order.Add("3");
-                next(ctxt);
+                next(context);
             }),
         });
 
         Assert.Throws<InvalidOperationException>(() => pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) =>
             {
                 order.Add("1");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("4", PipelinePhase.ServicePipelineEnd, (ctxt, next) =>
+            new DelegateMiddleware("4", PipelinePhase.ServicePipelineEnd, (context, next) =>
             {
                 order.Add("4");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (context, next) =>
             {
                 order.Add("2");
-                next(ctxt);
+                next(context);
             }),
         }));
     }
@@ -292,20 +292,20 @@ public class PipelineBuilderTests
 
         Assert.Throws<InvalidOperationException>(() => pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) =>
             {
                 order.Add("1");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("4", PipelinePhase.ServicePipelineEnd, (ctxt, next) =>
+            new DelegateMiddleware("4", PipelinePhase.ServicePipelineEnd, (context, next) =>
             {
                 order.Add("4");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (ctxt, next) =>
+            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (context, next) =>
             {
                 order.Add("2");
-                next(ctxt);
+                next(context);
             }),
         }));
     }
@@ -318,39 +318,39 @@ public class PipelineBuilderTests
 
         pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) =>
             {
                 order.Add("1");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("3", PipelinePhase.ScopeSelection, (ctxt, next) =>
+            new DelegateMiddleware("3", PipelinePhase.ScopeSelection, (context, next) =>
             {
                 order.Add("3");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("5", PipelinePhase.ServicePipelineEnd, (ctxt, next) =>
+            new DelegateMiddleware("5", PipelinePhase.ServicePipelineEnd, (context, next) =>
             {
                 order.Add("5");
-                next(ctxt);
+                next(context);
             }),
         });
 
         pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("2", PipelinePhase.ResolveRequestStart, (ctxt, next) =>
+            new DelegateMiddleware("2", PipelinePhase.ResolveRequestStart, (context, next) =>
             {
                 order.Add("2");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("4", PipelinePhase.ScopeSelection, (ctxt, next) =>
+            new DelegateMiddleware("4", PipelinePhase.ScopeSelection, (context, next) =>
             {
                 order.Add("4");
-                next(ctxt);
+                next(context);
             }),
-            new DelegateMiddleware("6", PipelinePhase.ServicePipelineEnd, (ctxt, next) =>
+            new DelegateMiddleware("6", PipelinePhase.ServicePipelineEnd, (context, next) =>
             {
                 order.Add("6");
-                next(ctxt);
+                next(context);
             }),
         });
 
@@ -373,7 +373,7 @@ public class PipelineBuilderTests
     {
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Registration);
         var order = new List<string>();
-        Assert.Throws<InvalidOperationException>(() => pipelineBuilder.Use(PipelinePhase.ResolveRequestStart, (ctxt, next) => { }));
+        Assert.Throws<InvalidOperationException>(() => pipelineBuilder.Use(PipelinePhase.ResolveRequestStart, (context, next) => { }));
     }
 
     [Fact]
@@ -381,7 +381,7 @@ public class PipelineBuilderTests
     {
         var pipelineBuilder = new ResolvePipelineBuilder(PipelineType.Service);
         var order = new List<string>();
-        Assert.Throws<InvalidOperationException>(() => pipelineBuilder.Use(PipelinePhase.RegistrationPipelineStart, (ctxt, next) => { }));
+        Assert.Throws<InvalidOperationException>(() => pipelineBuilder.Use(PipelinePhase.RegistrationPipelineStart, (context, next) => { }));
     }
 
     [Fact]
@@ -391,9 +391,9 @@ public class PipelineBuilderTests
         var order = new List<string>();
         Assert.Throws<InvalidOperationException>(() => pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) => { }),
-            new DelegateMiddleware("4", PipelinePhase.Activation, (ctxt, next) => { }),
-            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (ctxt, next) => { }),
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) => { }),
+            new DelegateMiddleware("4", PipelinePhase.Activation, (context, next) => { }),
+            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (context, next) => { }),
         }));
     }
 
@@ -404,7 +404,7 @@ public class PipelineBuilderTests
         var order = new List<string>();
 
         var ex = Assert.Throws<InvalidOperationException>(() => pipelineBuilder.Use(
-                        new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) => { })));
+                        new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) => { })));
 
         // Confirm phase content.
         Assert.Contains("[RegistrationPipelineStart, ParameterSelection, Activation]", ex.Message);
@@ -418,16 +418,16 @@ public class PipelineBuilderTests
 
         pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart,  (ctxt, next) => { }),
-            new DelegateMiddleware("3", PipelinePhase.ScopeSelection,  (ctxt, next) => { }),
-            new DelegateMiddleware("5", PipelinePhase.ServicePipelineEnd,  (ctxt, next) => { }),
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart,  (context, next) => { }),
+            new DelegateMiddleware("3", PipelinePhase.ScopeSelection,  (context, next) => { }),
+            new DelegateMiddleware("5", PipelinePhase.ServicePipelineEnd,  (context, next) => { }),
         });
 
         Assert.Throws<InvalidOperationException>(() => pipelineBuilder.UseRange(new[]
         {
-            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (ctxt, next) => { }),
-            new DelegateMiddleware("4", PipelinePhase.Activation, (ctxt, next) => { }),
-            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (ctxt, next) => { }),
+            new DelegateMiddleware("1", PipelinePhase.ResolveRequestStart, (context, next) => { }),
+            new DelegateMiddleware("4", PipelinePhase.Activation, (context, next) => { }),
+            new DelegateMiddleware("2", PipelinePhase.ScopeSelection, (context, next) => { }),
         }));
     }
 

--- a/test/Autofac.Test/Core/PropertyInjectionInitOnlyTests.cs
+++ b/test/Autofac.Test/Core/PropertyInjectionInitOnlyTests.cs
@@ -17,7 +17,7 @@ public class PropertyInjectionInitOnlyTests
     {
         var builder = new ContainerBuilder();
         builder.RegisterType<HasInitOnlyProperties>().PropertiesAutowired();
-        builder.Register(ctxt => "hello world");
+        builder.Register(context => "hello world");
         var container = builder.Build();
 
         var instance = container.Resolve<HasInitOnlyProperties>();

--- a/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
+++ b/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
@@ -24,7 +24,7 @@ public class ResolveOperationTests
     }
 
     [Fact]
-    public void EmptyInProgessRequestWhenInitializing()
+    public void EmptyInProgressRequestWhenInitializing()
     {
         var resolveOperation = new ResolveOperation(Mock.Of<ISharingLifetimeScope>(), new DiagnosticListener("SomeName"));
 
@@ -80,33 +80,33 @@ public class ResolveOperationTests
 
         mockTracer.OperationStarting += (op, req) =>
         {
-            raisedEvents.Add("opstart");
+            raisedEvents.Add("op-start");
             Assert.Equal(resolveOp, op);
             Assert.Equal(request, req);
         };
 
-        mockTracer.RequestStarting += (op, ctxt) =>
+        mockTracer.RequestStarting += (op, context) =>
         {
-            raisedEvents.Add("reqstart");
+            raisedEvents.Add("req-start");
             Assert.Equal(resolveOp, op);
-            Assert.Equal(request.Service, ctxt.Service);
+            Assert.Equal(request.Service, context.Service);
         };
 
-        mockTracer.RequestSucceeding += (op, ctxt) =>
+        mockTracer.RequestSucceeding += (op, context) =>
         {
-            raisedEvents.Add("reqsuccess");
+            raisedEvents.Add("req-success");
             Assert.Equal(resolveOp, op);
         };
 
         mockTracer.OperationSucceeding += (op, instance) =>
         {
-            raisedEvents.Add("opsuccess");
+            raisedEvents.Add("op-success");
             Assert.Equal("Hello", instance);
         };
 
         resolveOp.Execute(request);
 
-        Assert.Equal(new[] { "opstart", "reqstart", "reqsuccess", "opsuccess" }, raisedEvents);
+        Assert.Equal(new[] { "op-start", "req-start", "req-success", "op-success" }, raisedEvents);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class ResolveOperationTests
     {
         var builder = new ContainerBuilder();
 
-        builder.Register<string>(ctxt => throw new InvalidOperationException());
+        builder.Register<string>(context => throw new InvalidOperationException());
 
         var container = builder.Build();
         var mockTracer = Mocks.GetTracer();
@@ -130,28 +130,28 @@ public class ResolveOperationTests
 
         mockTracer.OperationStarting += (op, req) =>
         {
-            raisedEvents.Add("opstart");
+            raisedEvents.Add("op-start");
             Assert.Equal(resolveOp, op);
             Assert.Equal(request, req);
         };
 
-        mockTracer.RequestStarting += (op, ctxt) =>
+        mockTracer.RequestStarting += (op, context) =>
         {
-            raisedEvents.Add("reqstart");
+            raisedEvents.Add("req-start");
             Assert.Equal(resolveOp, op);
-            Assert.Equal(request.Service, ctxt.Service);
+            Assert.Equal(request.Service, context.Service);
         };
 
-        mockTracer.RequestFailing += (op, ctxt, ex) =>
+        mockTracer.RequestFailing += (op, context, ex) =>
         {
-            raisedEvents.Add("reqfail");
+            raisedEvents.Add("req-fail");
             Assert.Equal(resolveOp, op);
             Assert.IsType<DependencyResolutionException>(ex);
         };
 
         mockTracer.OperationFailing += (op, ex) =>
         {
-            raisedEvents.Add("opfail");
+            raisedEvents.Add("op-fail");
             Assert.IsType<DependencyResolutionException>(ex);
         };
 
@@ -163,6 +163,6 @@ public class ResolveOperationTests
         {
         }
 
-        Assert.Equal(new[] { "opstart", "reqstart", "reqfail", "opfail" }, raisedEvents);
+        Assert.Equal(new[] { "op-start", "req-start", "req-fail", "op-fail" }, raisedEvents);
     }
 }

--- a/test/Autofac.Test/Features/Decorators/DecoratorTests.cs
+++ b/test/Autofac.Test/Features/Decorators/DecoratorTests.cs
@@ -31,7 +31,7 @@ public class DecoratorTests
 
         public bool NestedServiceIsNotNull()
         {
-            return NestedService != null;
+            return NestedService is not null;
         }
     }
 

--- a/test/Autofac.Test/Features/OwnedInstances/InstancePerOwnedKeyTests.cs
+++ b/test/Autofac.Test/Features/OwnedInstances/InstancePerOwnedKeyTests.cs
@@ -20,7 +20,7 @@ public class InstancePerOwnedKeyTests
         var dependencyService = new TypedService(dependencyType);
         var instancePerOwnedKey = new InstancePerOwnedKey(dependencyService);
 
-        var ownedService = ownedKey != null
+        var ownedService = ownedKey is not null
             ? (IServiceWithType)new KeyedService(ownedKey, ownedType)
             : new TypedService(ownedType);
 

--- a/test/Autofac.Test/ResolutionExtensionsTests.cs
+++ b/test/Autofac.Test/ResolutionExtensionsTests.cs
@@ -4,7 +4,7 @@
 using Autofac.Core;
 using Autofac.Core.Activators.ProvidedInstance;
 using Autofac.Core.Registration;
-using Autofac.Test.Scenarios.Parameterisation;
+using Autofac.Test.Scenarios.Parameterization;
 using Autofac.Test.Scenarios.WithProperty;
 
 namespace Autofac.Test;
@@ -61,11 +61,11 @@ public class ResolutionExtensionsTests
     public void WhenParametersProvided_ResolveOptionalSuppliesThemToComponent()
     {
         var cb = new ContainerBuilder();
-        cb.RegisterType<Parameterised>();
+        cb.RegisterType<Parameterized>();
         var container = cb.Build();
         const string param1 = "Hello";
         const int param2 = 42;
-        var result = container.ResolveOptional<Parameterised>(
+        var result = container.ResolveOptional<Parameterized>(
             new NamedParameter("a", param1),
             new NamedParameter("b", param2));
         Assert.NotNull(result);
@@ -80,7 +80,7 @@ public class ResolutionExtensionsTests
         const int b = 42;
         var builder = new ContainerBuilder();
 
-        builder.RegisterType<Parameterised>()
+        builder.RegisterType<Parameterized>()
             .WithParameter(
                 (pi, c) => pi.Name == "a",
                 (pi, c) => a)
@@ -89,7 +89,7 @@ public class ResolutionExtensionsTests
                 (pi, c) => b);
 
         var container = builder.Build();
-        var result = container.Resolve<Parameterised>();
+        var result = container.Resolve<Parameterized>();
 
         Assert.Equal(a, result.A);
         Assert.Equal(b, result.B);

--- a/test/Autofac.Test/Scenarios/Parameterization/Parameterized.cs
+++ b/test/Autofac.Test/Scenarios/Parameterization/Parameterized.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-namespace Autofac.Test.Scenarios.Parameterisation;
+namespace Autofac.Test.Scenarios.Parameterization;
 
-public class Parameterised
+public class Parameterized
 {
     public string A { get; private set; }
 
     public int B { get; private set; }
 
-    public Parameterised(string a, int b)
+    public Parameterized(string a, int b)
     {
         A = a;
         B = b;


### PR DESCRIPTION
- Fixes #1388 - puts back the type filtering that was on `RegisterTypes` so if "invalid" types (types that generally can't be created via reflection - interfaces, abstract classes, etc.) get passed in, they will be ignored and not registered.
- Refactored some of the methods in the scanning namespace so they are in more appropriately named classes and have better/more descriptive names themselves. That way it's easier to see what they're for and who is using them.
- Adds more up-front error handling for `RegisterType(Type t)` and `RegisterType<T>()` calls so if someone tries to use a type in there that generally can't be created via reflection, an `ArgumentException` will come up and explain the issue rather than waiting for the container build to occur and hitting a "no constructors found" exception.
- Centralized the "check" for what may be generally registerable so it can be shared between assembly scanning and ACTNARS.
- Housekeeping:
  - Fix `parameterised` => `parameterized`. Given the fallback language on the assemblies is `en-US` it seemed like fixing up docs and internal naming to also be `en-US` was reasonable. Also allows spell checkers set to that dictionary to find fewer things.
  - Fix `ctxt` => `context`. Another spell checker issue. Community practice generally either uses `ctx` or `context`, with most .NET code in the framework being a fully spelled-out `context`. Updated references to go with the fully spelled-out version.

I'll add some comments to the important bits for extra attention.