### PR TITLE
Optimization: convert `ResolveRequest` into readonly struct

### DIFF
--- a/src/Autofac/Core/Container.cs
+++ b/src/Autofac/Core/Container.cs
@@ -140,7 +140,7 @@ public class Container : Disposable, IContainer, IServiceProvider
     public IComponentRegistry ComponentRegistry { get; }
 
     /// <inheritdoc />
-    public object ResolveComponent(ResolveRequest request)
+    public object ResolveComponent(in ResolveRequest request)
     {
         return _rootLifetimeScope.ResolveComponent(request);
     }

--- a/src/Autofac/Core/ImplicitRegistrationSource.cs
+++ b/src/Autofac/Core/ImplicitRegistrationSource.cs
@@ -86,7 +86,7 @@ public abstract class ImplicitRegistrationSource : IRegistrationSource
     /// <param name="ctx">A component context to resolve services.</param>
     /// <param name="request">A resolve request.</param>
     /// <returns>An implicit type instance.</returns>
-    protected abstract object ResolveInstance<T>(IComponentContext ctx, ResolveRequest request)
+    protected abstract object ResolveInstance<T>(IComponentContext ctx, in ResolveRequest request)
         where T : notnull;
 
     /// <summary>

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -323,13 +323,8 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
     }
 
     /// <inheritdoc />
-    public object ResolveComponent(ResolveRequest request)
+    public object ResolveComponent(in ResolveRequest request)
     {
-        if (request == null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
-
         CheckNotDisposed();
 
         var operation = new ResolveOperation(this, DiagnosticSource);

--- a/src/Autofac/Core/Resolving/IResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/IResolveOperation.cs
@@ -59,5 +59,5 @@ public interface IResolveOperation
     /// <param name="currentOperationScope">The scope in the hierarchy in which the operation will begin.</param>
     /// <param name="request">The resolve request.</param>
     /// <returns>The component instance.</returns>
-    object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request);
+    object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, in ResolveRequest request);
 }

--- a/src/Autofac/Core/Resolving/Pipeline/DefaultResolveRequestContext.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/DefaultResolveRequestContext.cs
@@ -25,14 +25,14 @@ internal sealed class DefaultResolveRequestContext : ResolveRequestContext
     /// </param>
     internal DefaultResolveRequestContext(
         IResolveOperation owningOperation,
-        ResolveRequest request,
+        in ResolveRequest request,
         ISharingLifetimeScope scope,
         DiagnosticListener diagnosticSource)
     {
         Operation = owningOperation;
         ActivationScope = scope;
         Parameters = request.Parameters;
-        _resolveRequest = request ?? throw new ArgumentNullException(nameof(request));
+        _resolveRequest = request;
         PhaseReached = PipelinePhase.ResolveRequestStart;
         DiagnosticSource = diagnosticSource;
     }
@@ -90,7 +90,7 @@ internal sealed class DefaultResolveRequestContext : ResolveRequestContext
         Parameters = newParameters ?? throw new ArgumentNullException(nameof(newParameters));
 
     /// <inheritdoc />
-    public override object ResolveComponent(ResolveRequest request) =>
+    public override object ResolveComponent(in ResolveRequest request) =>
         Operation.GetOrCreateInstance(ActivationScope, request);
 
     /// <summary>

--- a/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContext.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolveRequestContext.cs
@@ -95,5 +95,5 @@ public abstract class ResolveRequestContext : IComponentContext
     public abstract IComponentRegistry ComponentRegistry { get; }
 
     /// <inheritdoc/>
-    public abstract object ResolveComponent(ResolveRequest request);
+    public abstract object ResolveComponent(in ResolveRequest request);
 }

--- a/src/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperation.cs
@@ -42,7 +42,7 @@ internal sealed class ResolveOperation : IDependencyTrackingResolveOperation
     /// Execute the complete resolve operation.
     /// </summary>
     /// <param name="request">The resolution context.</param>
-    public object Execute(ResolveRequest request)
+    public object Execute(in ResolveRequest request)
     {
         return ExecuteOperation(request);
     }
@@ -93,13 +93,8 @@ internal sealed class ResolveOperation : IDependencyTrackingResolveOperation
     public SegmentedStack<ResolveRequestContext> RequestStack { get; } = new SegmentedStack<ResolveRequestContext>();
 
     /// <inheritdoc />
-    public object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request)
+    public object GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, in ResolveRequest request)
     {
-        if (request is null)
-        {
-            throw new ArgumentNullException(nameof(request));
-        }
-
         if (_ended)
         {
             throw new ObjectDisposedException(ResolveOperationResources.TemporaryContextDisposed, innerException: null);
@@ -170,7 +165,7 @@ internal sealed class ResolveOperation : IDependencyTrackingResolveOperation
     /// </summary>
     /// <param name="request">The resolve request.</param>
     /// <returns>The resolved instance.</returns>
-    private object ExecuteOperation(ResolveRequest request)
+    private object ExecuteOperation(in ResolveRequest request)
     {
         object result;
 
@@ -233,7 +228,7 @@ internal sealed class ResolveOperation : IDependencyTrackingResolveOperation
     /// to enable it to be optionally surrounded with diagnostics.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void InvokePipeline(ResolveRequest request, DefaultResolveRequestContext requestContext)
+    private void InvokePipeline(in ResolveRequest request, DefaultResolveRequestContext requestContext)
     {
         request.ResolvePipeline.Invoke(requestContext);
         if (requestContext.Instance == null)

--- a/src/Autofac/Diagnostics/DiagnosticSourceExtensions.cs
+++ b/src/Autofac/Diagnostics/DiagnosticSourceExtensions.cs
@@ -60,7 +60,7 @@ internal static class DiagnosticSourceExtensions
     /// <param name="diagnosticSource">The diagnostic source to which events will be written.</param>
     /// <param name="operation">The pipeline resolve operation that is about to run.</param>
     /// <param name="initiatingRequest">The request that is responsible for starting this operation.</param>
-    public static void OperationStart(this DiagnosticListener diagnosticSource, IResolveOperation operation, ResolveRequest initiatingRequest)
+    public static void OperationStart(this DiagnosticListener diagnosticSource, IResolveOperation operation, in ResolveRequest initiatingRequest)
     {
         if (diagnosticSource.IsEnabled(DiagnosticEventKeys.OperationStart))
         {

--- a/src/Autofac/Diagnostics/OperationStartDiagnosticData.cs
+++ b/src/Autofac/Diagnostics/OperationStartDiagnosticData.cs
@@ -15,7 +15,7 @@ public class OperationStartDiagnosticData
     /// </summary>
     /// <param name="operation">The pipeline resolve operation that is about to run.</param>
     /// <param name="initiatingRequest">The request that is responsible for starting this operation.</param>
-    public OperationStartDiagnosticData(IResolveOperation operation, ResolveRequest initiatingRequest)
+    public OperationStartDiagnosticData(IResolveOperation operation, in ResolveRequest initiatingRequest)
     {
         Operation = operation;
         InitiatingRequest = initiatingRequest;

--- a/src/Autofac/Features/Decorators/DecoratorContext.cs
+++ b/src/Autofac/Features/Decorators/DecoratorContext.cs
@@ -78,5 +78,5 @@ public sealed class DecoratorContext : IDecoratorContext
     }
 
     /// <inheritdoc />
-    public object ResolveComponent(ResolveRequest request) => _componentContext.ResolveComponent(request);
+    public object ResolveComponent(in ResolveRequest request) => _componentContext.ResolveComponent(request);
 }

--- a/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
+++ b/src/Autofac/Features/LazyDependencies/LazyRegistrationSource.cs
@@ -25,9 +25,10 @@ internal class LazyRegistrationSource : ImplicitRegistrationSource
     public override string Description => LazyRegistrationSourceResources.LazyRegistrationSourceDescription;
 
     /// <inheritdoc/>
-    protected override object ResolveInstance<T>(IComponentContext context, ResolveRequest request)
+    protected override object ResolveInstance<T>(IComponentContext context, in ResolveRequest request)
     {
         var capturedContext = context.Resolve<IComponentContext>();
-        return new Lazy<T>(() => (T)capturedContext.ResolveComponent(request));
+        ResolveRequest requestCopy = request;
+        return new Lazy<T>(() => (T)capturedContext.ResolveComponent(requestCopy));
     }
 }

--- a/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
+++ b/src/Autofac/Features/Metadata/MetaRegistrationSource.cs
@@ -24,6 +24,6 @@ internal class MetaRegistrationSource : ImplicitRegistrationSource
     public override string Description => MetaRegistrationSourceResources.MetaRegistrationSourceDescription;
 
     /// <inheritdoc/>
-    protected override object ResolveInstance<T>(IComponentContext ctx, ResolveRequest request)
+    protected override object ResolveInstance<T>(IComponentContext ctx, in ResolveRequest request)
         => new Meta<T>((T)ctx.ResolveComponent(request), request.Registration.Target.Metadata);
 }

--- a/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
+++ b/src/Autofac/Features/OwnedInstances/OwnedInstanceRegistrationSource.cs
@@ -21,7 +21,7 @@ internal class OwnedInstanceRegistrationSource : ImplicitRegistrationSource
     }
 
     /// <inheritdoc/>
-    protected override object ResolveInstance<T>(IComponentContext ctx, ResolveRequest request)
+    protected override object ResolveInstance<T>(IComponentContext ctx, in ResolveRequest request)
     {
         var lifetime = ctx.Resolve<ILifetimeScope>().BeginLifetimeScope(request.Service);
         try

--- a/src/Autofac/IComponentContext.cs
+++ b/src/Autofac/IComponentContext.cs
@@ -27,5 +27,5 @@ public interface IComponentContext
     /// </returns>
     /// <exception cref="ComponentNotRegisteredException"/>
     /// <exception cref="DependencyResolutionException"/>
-    object ResolveComponent(ResolveRequest request);
+    object ResolveComponent(in ResolveRequest request);
 }

--- a/src/Autofac/ResolveRequest.cs
+++ b/src/Autofac/ResolveRequest.cs
@@ -9,7 +9,7 @@ namespace Autofac;
 /// <summary>
 /// The details of an individual request to resolve a service.
 /// </summary>
-public class ResolveRequest
+public readonly struct ResolveRequest : IEquatable<ResolveRequest>
 {
     /// <summary>
     /// Shared constant value defining an empty set of parameters.
@@ -17,7 +17,7 @@ public class ResolveRequest
     internal static readonly IEnumerable<Parameter> NoParameters = Enumerable.Empty<Parameter>();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ResolveRequest"/> class.
+    /// Initializes a new instance of the <see cref="ResolveRequest"/> struct.
     /// </summary>
     /// <param name="service">The service being resolved.</param>
     /// <param name="serviceRegistration">The component registration for the service.</param>
@@ -56,4 +56,33 @@ public class ResolveRequest
     /// Gets the component registration for the decorator target if configured.
     /// </summary>
     public IComponentRegistration? DecoratorTarget { get; }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) =>
+        obj is ResolveRequest other && Equals(other);
+
+    /// <inheritdoc/>
+    public bool Equals(ResolveRequest other) =>
+        Service == other.Service && Registration == other.Registration && ResolvePipeline == other.ResolvePipeline && Parameters == other.Parameters && DecoratorTarget == other.DecoratorTarget;
+
+    /// <summary>
+    /// Implements the operator ==.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>The result of the operator.</returns>
+    public static bool operator ==(ResolveRequest left, ResolveRequest right) => Equals(left, right);
+
+    /// <summary>
+    /// Implements the operator !=.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>The result of the operator.</returns>
+    public static bool operator !=(ResolveRequest left, ResolveRequest right) =>
+        !(left == right);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() =>
+        Service.GetHashCode() ^ Registration.GetHashCode() ^ ResolvePipeline.GetHashCode() ^ Parameters.GetHashCode() ^ (DecoratorTarget?.GetHashCode() ?? 0);
 }

--- a/test/Autofac.Test/Core/ImplicitRegistrationSourceTests.cs
+++ b/test/Autofac.Test/Core/ImplicitRegistrationSourceTests.cs
@@ -109,7 +109,7 @@ public class ImplicitRegistrationSourceTests
         {
         }
 
-        protected override object ResolveInstance<T>(IComponentContext ctx, ResolveRequest request) => throw new NotImplementedException();
+        protected override object ResolveInstance<T>(IComponentContext ctx, in ResolveRequest request) => throw new NotImplementedException();
     }
 
     private class Mapped<T>
@@ -129,7 +129,7 @@ public class ImplicitRegistrationSourceTests
         {
         }
 
-        protected override object ResolveInstance<T>(IComponentContext ctx, ResolveRequest request)
+        protected override object ResolveInstance<T>(IComponentContext ctx, in ResolveRequest request)
         {
             return new Mapped<T>((T)ctx.ResolveComponent(request));
         }

--- a/test/Autofac.Test/Core/Pipeline/PipelineBuilderTests.cs
+++ b/test/Autofac.Test/Core/Pipeline/PipelineBuilderTests.cs
@@ -483,7 +483,7 @@ public class PipelineBuilderTests
 
         public override IComponentRegistry ComponentRegistry => ActivationScope.ComponentRegistry;
 
-        public override object ResolveComponent(ResolveRequest request) => throw new NotImplementedException();
+        public override object ResolveComponent(in ResolveRequest request) => throw new NotImplementedException();
     }
 
     private class LifetimeScopeStub : ISharingLifetimeScope
@@ -566,7 +566,7 @@ public class PipelineBuilderTests
             throw new NotImplementedException();
         }
 
-        public object ResolveComponent(ResolveRequest request)
+        public object ResolveComponent(in ResolveRequest request)
         {
             throw new NotImplementedException();
         }

--- a/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
+++ b/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
@@ -34,15 +34,6 @@ public class ResolveOperationTests
     }
 
     [Fact]
-    public void GetOrCreateInstanceThrowsArgumentNullExceptionWhenResolveRequestIsNull()
-    {
-        var lifetimeScope = Mock.Of<ISharingLifetimeScope>();
-        var resolveOperation = new ResolveOperation(lifetimeScope, new DiagnosticListener("SomeName"));
-
-        Assert.Throws<ArgumentNullException>(() => resolveOperation.GetOrCreateInstance(lifetimeScope, null!));
-    }
-
-    [Fact]
     public void AfterTheOperationIsFinished_ReusingTheTemporaryContextThrows()
     {
         IComponentContext ctx = null;

--- a/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
+++ b/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
@@ -76,7 +76,6 @@ public class ResolveOperationTests
             Assert.Equal(resolveOp, op);
             Assert.Equal(request, req);
             Assert.True(req != request2);
-            Assert.False(req == request2);
         };
 
         mockTracer.RequestStarting += (op, context) =>

--- a/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
+++ b/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
@@ -34,15 +34,6 @@ public class ResolveOperationTests
     }
 
     [Fact]
-    public void GetOrCreateInstanceThrowsArgumentNullExceptionWhenResolveRequestIsNull()
-    {
-        var lifetimeScope = Substitute.For<ISharingLifetimeScope>();
-        var resolveOperation = new ResolveOperation(lifetimeScope, new DiagnosticListener("SomeName"));
-
-        Assert.Throws<ArgumentNullException>(() => resolveOperation.GetOrCreateInstance(lifetimeScope, null!));
-    }
-
-    [Fact]
     public void AfterTheOperationIsFinished_ReusingTheTemporaryContextThrows()
     {
         IComponentContext ctx = null;

--- a/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
+++ b/test/Autofac.Test/Core/Resolving/ResolveOperationTests.cs
@@ -68,12 +68,15 @@ public class ResolveOperationTests
         var raisedEvents = new List<string>();
 
         var request = new ResolveRequest(new TypedService(typeof(string)), scope.ResolvableImplementationFor<string>(), Enumerable.Empty<Parameter>());
+        var request2 = new ResolveRequest(new TypedService(typeof(int)), scope.ResolvableImplementationFor<string>(), Enumerable.Empty<Parameter>());
 
         mockTracer.OperationStarting += (op, req) =>
         {
             raisedEvents.Add("op-start");
             Assert.Equal(resolveOp, op);
             Assert.Equal(request, req);
+            Assert.True(req != request2);
+            Assert.False(req == request2);
         };
 
         mockTracer.RequestStarting += (op, context) =>


### PR DESCRIPTION
This will save GC work (one allocation per resolving).
Also:
* No need for null-checking
* Remove `GetOrCreateInstanceThrowsArgumentNullExceptionWhenResolveRequestIsNull` test as not-applicable anymore
* Add `in` function argument specifier to pass pointer instead of struct contents.