### PR TITLE
`FastGuid.NewGuid()` helper

### DIFF
--- a/bench/Autofac.Benchmarks/Benchmarks.cs
+++ b/bench/Autofac.Benchmarks/Benchmarks.cs
@@ -29,5 +29,6 @@ public static class Benchmarks
         typeof(MultiConstructorBenchmark),
         typeof(LambdaResolveBenchmark),
         typeof(RequiredPropertyBenchmark),
+        typeof(RegistrationBenchmark),
     };
 }

--- a/bench/Autofac.Benchmarks/RegistrationBenchmark.cs
+++ b/bench/Autofac.Benchmarks/RegistrationBenchmark.cs
@@ -1,0 +1,46 @@
+﻿namespace Autofac.Benchmarks;
+
+public class RegistrationBenchmark
+{
+    [Benchmark]
+    public void Register()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<A>();
+        builder.RegisterType<B1>();
+        builder.RegisterType<B2>().InstancePerMatchingLifetimeScope("request");
+        builder.RegisterType<C2>().InstancePerLifetimeScope();
+        builder.RegisterType<D1>().SingleInstance();
+        builder.RegisterType<D2>().SingleInstance();
+        var _container = builder.Build();
+    }
+
+    internal class A
+    {
+        public A(B1 b1, B2 b2) { }
+    }
+
+    internal class B1
+    {
+        public B1(B2 b2, C1 c1, C2 c2) { }
+    }
+
+    internal class B2
+    {
+        public B2(C1 c1, C2 c2) { }
+    }
+
+    internal class C1
+    {
+        public C1(C2 c2, D1 d1, D2 d2) { }
+    }
+
+    internal class C2
+    {
+        public C2(D1 d1, D2 d2) { }
+    }
+
+    internal class D1 { }
+
+    internal class D2 { }
+}

--- a/src/Autofac/Builder/DeferredCallback.cs
+++ b/src/Autofac/Builder/DeferredCallback.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core.Registration;
+using Autofac.Util;
 
 namespace Autofac.Builder;
 
@@ -25,7 +26,7 @@ public class DeferredCallback
     /// </exception>
     public DeferredCallback(Action<IComponentRegistryBuilder> callback)
     {
-        Id = Guid.NewGuid();
+        Id = FastGuid.NewGuid();
         Callback = callback ?? throw new ArgumentNullException(nameof(callback));
     }
 

--- a/src/Autofac/Builder/SingleRegistrationStyle.cs
+++ b/src/Autofac/Builder/SingleRegistrationStyle.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core;
+using Autofac.Util;
 
 namespace Autofac.Builder;
 
@@ -13,7 +14,7 @@ public class SingleRegistrationStyle
     /// <summary>
     /// Gets or sets the ID used for the registration.
     /// </summary>
-    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid Id { get; set; } = FastGuid.NewGuid();
 
     /// <summary>
     /// Gets the handlers to notify of the component registration event.

--- a/src/Autofac/Core/ImplicitRegistrationSource.cs
+++ b/src/Autofac/Core/ImplicitRegistrationSource.cs
@@ -28,7 +28,7 @@ public abstract class ImplicitRegistrationSource : IRegistrationSource
     protected ImplicitRegistrationSource(Type type)
     {
         _type = type ?? throw new ArgumentNullException(nameof(type));
-        _cacheKey = $"{nameof(ImplicitRegistrationSource)}.{Guid.NewGuid()}";
+        _cacheKey = $"{nameof(ImplicitRegistrationSource)}.{FastGuid.NewGuid()}";
 
         if (!type.IsGenericType)
         {

--- a/src/Autofac/Core/UniqueService.cs
+++ b/src/Autofac/Core/UniqueService.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Autofac.Util;
+
 namespace Autofac.Core;
 
 /// <summary>
@@ -14,7 +16,7 @@ public sealed class UniqueService : Service
     /// Initializes a new instance of the <see cref="UniqueService"/> class.
     /// </summary>
     public UniqueService()
-        : this(Guid.NewGuid())
+        : this(FastGuid.NewGuid())
     {
     }
 

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -143,7 +143,7 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
             });
 
         var registration = new ComponentRegistration(
-            Guid.NewGuid(),
+            FastGuid.NewGuid(),
             activator,
             CurrentScopeLifetime.Instance,
             InstanceSharing.None,

--- a/src/Autofac/Features/Decorators/OpenGenericDecoratorMiddlewareSource.cs
+++ b/src/Autofac/Features/Decorators/OpenGenericDecoratorMiddlewareSource.cs
@@ -7,6 +7,7 @@ using Autofac.Core.Activators.Reflection;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Features.OpenGenerics;
+using Autofac.Util;
 
 namespace Autofac.Features.Decorators;
 
@@ -46,7 +47,7 @@ internal class OpenGenericDecoratorMiddlewareSource : IServiceMiddlewareSource
             {
                 // Create a new closed-generic registration.
                 var registration = new ComponentRegistration(
-                    Guid.NewGuid(),
+                    FastGuid.NewGuid(),
                     new ReflectionActivator(constructedImplementationType, _activatorData.ConstructorFinder, _activatorData.ConstructorSelector, _activatorData.ConfiguredParameters, _activatorData.ConfiguredProperties),
                     _registrationData.Lifetime,
                     _registrationData.Sharing,

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDecoratorRegistrationSource.cs
@@ -6,6 +6,7 @@ using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Util;
 
 namespace Autofac.Features.OpenGenerics;
 
@@ -75,7 +76,7 @@ internal class OpenGenericDecoratorRegistrationSource : IRegistrationSource
 
             return registrationAccessor(fromService)
                 .Select(cr => RegistrationBuilder.CreateRegistration(
-                        Guid.NewGuid(),
+                        FastGuid.NewGuid(),
                         _registrationData,
                         new ReflectionActivator(constructedImplementationType, _activatorData.ConstructorFinder, _activatorData.ConstructorSelector, AddDecoratedComponentParameter(fromService, swt.ServiceType, cr, _activatorData.ConfiguredParameters), _activatorData.ConfiguredProperties),
                         _existingPipeline,

--- a/src/Autofac/Features/OpenGenerics/OpenGenericDelegateRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericDelegateRegistrationSource.cs
@@ -6,6 +6,7 @@ using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Core.Activators.Delegate;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Util;
 
 namespace Autofac.Features.OpenGenerics;
 
@@ -57,7 +58,7 @@ internal class OpenGenericDelegateRegistrationSource : IRegistrationSource
             // Pass the pipeline builder from the original registration to the 'CreateRegistration'.
             // So the original registration will contain all of the pipeline stages originally added, plus anything we want to add.
             yield return RegistrationBuilder.CreateRegistration(
-                Guid.NewGuid(),
+                FastGuid.NewGuid(),
                 _registrationData,
                 new DelegateActivator(typeof(object), constructedFactory),
                 _existingPipelineBuilder,

--- a/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
+++ b/src/Autofac/Features/OpenGenerics/OpenGenericRegistrationSource.cs
@@ -6,6 +6,7 @@ using Autofac.Builder;
 using Autofac.Core;
 using Autofac.Core.Activators.Reflection;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Util;
 
 namespace Autofac.Features.OpenGenerics;
 
@@ -69,7 +70,7 @@ internal class OpenGenericRegistrationSource : IRegistrationSource
             // Pass the pipeline builder from the original registration to the 'CreateRegistration'.
             // So the original registration will contain all of the pipeline stages originally added, plus anything we want to add.
             yield return RegistrationBuilder.CreateRegistration(
-                Guid.NewGuid(),
+                FastGuid.NewGuid(),
                 _registrationData,
                 new ReflectionActivator(constructedImplementationType, _activatorData.ConstructorFinder, _activatorData.ConstructorSelector, _activatorData.ConfiguredParameters, _activatorData.ConfiguredProperties),
                 _existingPipelineBuilder,

--- a/src/Autofac/Util/FastGuid.cs
+++ b/src/Autofac/Util/FastGuid.cs
@@ -1,19 +1,32 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace Autofac.Util;
 
 /// <summary>Helper class to generate GUIDs fast way.</summary>
 internal static class FastGuid
 {
-    private static readonly byte[] BasePart = Guid.NewGuid().ToByteArray().Skip(8).ToArray();
-    private static long variablePart = BitConverter.ToInt64(Guid.NewGuid().ToByteArray(), 0);
+    private static readonly long BasePart;
+    private static long variablePart;
+
+#pragma warning disable CA1810
+    static FastGuid()
+#pragma warning restore CA1810
+    {
+        Span<byte> guidData = stackalloc byte[16];
+        ref byte reference = ref MemoryMarshal.GetReference(guidData);
+        Unsafe.WriteUnaligned(ref reference, Guid.NewGuid());
+        variablePart = Unsafe.ReadUnaligned<long>(ref reference);
+        BasePart = Unsafe.ReadUnaligned<long>(ref Unsafe.Add(ref reference, 8));
+    }
 
     /// <summary>Initializes a new instance of the Guid structure, but faster than Guid.NewGuid().</summary>
     /// <returns>A new GUID object.</returns>
     public static Guid NewGuid()
     {
-        var v = Interlocked.Increment(ref variablePart);
-        return new((int)v, (short)(v >> 32), (short)(v >> 48), BasePart);
+        return MemoryMarshal.Read<Guid>(MemoryMarshal.Cast<long, byte>([Interlocked.Increment(ref variablePart), BasePart]));
     }
 }

--- a/src/Autofac/Util/FastGuid.cs
+++ b/src/Autofac/Util/FastGuid.cs
@@ -14,6 +14,6 @@ internal static class FastGuid
     public static Guid NewGuid()
     {
         var v = Interlocked.Increment(ref variablePart);
-        return new((int)(v & 0xFFFFFFFF), (short)(v >> 32), (short)(v >> 48), BasePart);
+        return new((int)v, (short)(v >> 32), (short)(v >> 48), BasePart);
     }
 }

--- a/src/Autofac/Util/FastGuid.cs
+++ b/src/Autofac/Util/FastGuid.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Util;
+
+/// <summary>Helper class to generate GUIDs fast way.</summary>
+internal static class FastGuid
+{
+    private static readonly byte[] BasePart = Guid.NewGuid().ToByteArray().Skip(8).ToArray();
+    private static long variablePart = BitConverter.ToInt64(Guid.NewGuid().ToByteArray(), 0);
+
+    /// <summary>Initializes a new instance of the Guid structure, but faster than Guid.NewGuid().</summary>
+    /// <returns>A new GUID object.</returns>
+    public static Guid NewGuid()
+    {
+        var v = Interlocked.Increment(ref variablePart);
+        return new((int)(v & 0xFFFFFFFF), (short)(v >> 32), (short)(v >> 48), BasePart);
+    }
+}


### PR DESCRIPTION
It is well-known that standard `Guid.NewGuid()` is slow.
And even slower on Linux https://github.com/dotnet/runtime/issues/13628

If GUIDs are not published outside of process it is enough to use global 64-bit counter as part of GUID generator.
