### PR TITLE
Fix #1427: Ensure WithProperty registrations consistently allow null values; update nullable annotations

### DIFF
--- a/src/Autofac/Core/NamedPropertyParameter.cs
+++ b/src/Autofac/Core/NamedPropertyParameter.cs
@@ -22,7 +22,7 @@ public class NamedPropertyParameter : ConstantParameter
     /// </summary>
     /// <param name="name">The name of the property.</param>
     /// <param name="value">The property value.</param>
-    public NamedPropertyParameter(string name, object value)
+    public NamedPropertyParameter(string name, object? value)
         : base(value, pi =>
         {
             return pi.TryGetDeclaringProperty(out PropertyInfo? prop) &&

--- a/src/Autofac/NamedParameter.cs
+++ b/src/Autofac/NamedParameter.cs
@@ -45,7 +45,7 @@ public class NamedParameter : ConstantParameter
     /// </summary>
     /// <param name="name">The name of the parameter.</param>
     /// <param name="value">The parameter value.</param>
-    public NamedParameter(string name, object value)
+    public NamedParameter(string name, object? value)
         : base(value, pi => pi.Name == name) =>
             Name = Enforce.ArgumentNotNullOrEmpty(name, "name");
 }

--- a/src/Autofac/PositionalParameter.cs
+++ b/src/Autofac/PositionalParameter.cs
@@ -46,7 +46,7 @@ public class PositionalParameter : ConstantParameter
     /// </summary>
     /// <param name="position">The zero-based position of the parameter.</param>
     /// <param name="value">The parameter value.</param>
-    public PositionalParameter(int position, object value)
+    public PositionalParameter(int position, object? value)
         : base(value, pi => pi.Position == position && (pi.Member is ConstructorInfo))
     {
         if (position < 0)

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -621,7 +621,7 @@ public static partial class RegistrationExtensions
         WithProperty<TLimit, TReflectionActivatorData, TStyle>(
             this IRegistrationBuilder<TLimit, TReflectionActivatorData, TStyle> registration,
             string propertyName,
-            object propertyValue)
+            object? propertyValue)
         where TReflectionActivatorData : ReflectionActivatorData
     {
         return registration.WithProperty(new NamedPropertyParameter(propertyName, propertyValue));
@@ -682,11 +682,6 @@ public static partial class RegistrationExtensions
         if (propertyExpression == null)
         {
             throw new ArgumentNullException(nameof(propertyExpression));
-        }
-
-        if (propertyValue == null)
-        {
-            throw new ArgumentNullException(nameof(propertyValue));
         }
 
         var propertyInfo = (propertyExpression.Body as MemberExpression)?.Member as PropertyInfo ?? throw new ArgumentOutOfRangeException(nameof(propertyExpression), RegistrationExtensionsResources.ExpressionDoesNotReferToProperty);

--- a/test/Autofac.Specification.Test/Features/PropertyInjectionTests.cs
+++ b/test/Autofac.Specification.Test/Features/PropertyInjectionTests.cs
@@ -398,6 +398,39 @@ public class PropertyInjectionTests
         instance.AssertProp();
     }
 
+    [Fact]
+    public void WithPropertyDelegateAllowsNullValue()
+    {
+        // Issue 1427: WithProperty should consistently allow null values.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasPublicSetter>().WithProperty(t => t.Val, null);
+        var container = builder.Build();
+        var instance = container.Resolve<HasPublicSetter>();
+        Assert.Null(instance.Val);
+    }
+
+    [Fact]
+    public void WithPropertyNamedAllowsNullValue()
+    {
+        // Issue 1427: WithProperty should consistently allow null values.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasPublicSetter>().WithProperty(nameof(HasPublicSetter.Val), null);
+        var container = builder.Build();
+        var instance = container.Resolve<HasPublicSetter>();
+        Assert.Null(instance.Val);
+    }
+
+    [Fact]
+    public void WithPropertyTypedAllowsNullValue()
+    {
+        // Issue 1427: WithProperty should consistently allow null values.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<HasPublicSetter>().WithProperty(TypedParameter.From<string>(null));
+        var container = builder.Build();
+        var instance = container.Resolve<HasPublicSetter>();
+        Assert.Null(instance.Val);
+    }
+
     private class ConstructorParamNotAttachedToProperty
     {
         [SuppressMessage("SA1401", "SA1401")]


### PR DESCRIPTION
Resolves #1427 by removing the exception check for null when registering a property value using `WithProperty(Expression, Value)`.

As part of this, I found that the base `ConstantParameter` class used by both constructor and property parameters does allow `null` as a value to be injected but not all the derived classes had the proper nullable type annotations. I updated the derived classes to consistently annotate the value as allowing null.