### PR TITLE
Fix boxing in `ResolveRequest.operator==()`

### DIFF
--- a/src/Autofac/ResolveRequest.cs
+++ b/src/Autofac/ResolveRequest.cs
@@ -71,7 +71,7 @@ public readonly struct ResolveRequest : IEquatable<ResolveRequest>
     /// <param name="left">The left operand.</param>
     /// <param name="right">The right operand.</param>
     /// <returns>The result of the operator.</returns>
-    public static bool operator ==(ResolveRequest left, ResolveRequest right) => Equals(left, right);
+    public static bool operator ==(ResolveRequest left, ResolveRequest right) => left.Equals(right);
 
     /// <summary>
     /// Implements the operator !=.


### PR DESCRIPTION
`ResolveRequest` is Value type and calling `Equals(object, object)` in `operator==()`  boxes arguments

But this operator is not used anyway.