### PR TITLE
check if generic type assembly has been added to set

### DIFF
--- a/src/Autofac/Util/Cache/TypeAssemblyReferenceProvider.cs
+++ b/src/Autofac/Util/Cache/TypeAssemblyReferenceProvider.cs
@@ -68,6 +68,11 @@ internal static class TypeAssemblyReferenceProvider
 
         foreach (var genericArgumentType in genericArguments)
         {
+            if (holdingSet.Any(a => a.DefinedTypes.Contains(genericArgumentType)))
+            {
+                continue;
+            }
+
             PopulateAllReferencedAssemblies(genericArgumentType, holdingSet);
         }
 

--- a/test/Autofac.Test/Util/Cache/TypeAssemblyReferenceProviderTests.cs
+++ b/test/Autofac.Test/Util/Cache/TypeAssemblyReferenceProviderTests.cs
@@ -18,6 +18,7 @@ public class TypeAssemblyReferenceProviderTests
     [InlineData(typeof(IEnumerable<IIndex<int, Assert>>), new[] { typeof(IEnumerable<>), typeof(IIndex<,>), typeof(Assert) })]
     [InlineData(typeof(DerivedClass), new[] { typeof(DerivedClass), typeof(RegistrationBuilder<,,>), typeof(Assert) })]
     [InlineData(typeof(GenericDerivedClass<Assert>), new[] { typeof(DerivedClass), typeof(RegistrationBuilder<,,>), typeof(Assert), typeof(object) })]
+    [InlineData(typeof(DerivedClassFromGenericAbstract), new[] { typeof(DerivedClassFromGenericAbstract) })]
     public void TypeReferencesCanBeDetermined(Type inputType, Type[] expandedTypeAssemblies)
     {
         Assert.NotNull(expandedTypeAssemblies);
@@ -48,6 +49,16 @@ public class TypeAssemblyReferenceProviderTests
         {
             Assert.Contains(item, expectedResults);
         }
+    }
+
+    private abstract class GenericAbstractClass<T> where T : class
+    {
+
+    }
+
+    private class DerivedClassFromGenericAbstract : GenericAbstractClass<DerivedClassFromGenericAbstract>
+    {
+
     }
 
     private class DerivedClass

--- a/test/Autofac.Test/Util/Cache/TypeAssemblyReferenceProviderTests.cs
+++ b/test/Autofac.Test/Util/Cache/TypeAssemblyReferenceProviderTests.cs
@@ -51,14 +51,13 @@ public class TypeAssemblyReferenceProviderTests
         }
     }
 
-    private abstract class GenericAbstractClass<T> where T : class
+    private abstract class GenericAbstractClass<T>
+        where T : class
     {
-
     }
 
     private class DerivedClassFromGenericAbstract : GenericAbstractClass<DerivedClassFromGenericAbstract>
     {
-
     }
 
     private class DerivedClass


### PR DESCRIPTION
Check the holding set to see if the type assembly has already been added to avoid the stack overflow.
https://github.com/autofac/Autofac/issues/1437