### PR TITLE
Register service with Interceptor, then register multiple decorator, auto apply Interceptor to the outermost decorator

### DIFF
--- a/src/Autofac/ServiceMiddlewareRegistrationExtensions.cs
+++ b/src/Autofac/ServiceMiddlewareRegistrationExtensions.cs
@@ -110,6 +110,57 @@ public static class ServiceMiddlewareRegistrationExtensions
     /// </summary>
     /// <param name="builder">The container builder.</param>
     /// <param name="serviceType">The service type.</param>
+    /// <param name="phase">The phase of the pipeline the middleware should run at.</param>
+    /// <param name="callback">
+    /// A callback invoked to run your middleware.
+    /// This callback takes a <see cref="ResolveRequestContext"/>, containing the context for the resolve request, plus
+    /// a callback to invoke to continue the pipeline.
+    /// </param>
+    public static void RegisterServiceMiddleware(this ContainerBuilder builder, Type serviceType, PipelinePhase phase, Action<ResolveRequestContext, Action<ResolveRequestContext>> callback)
+    {
+        builder.RegisterServiceMiddleware(serviceType, AnonymousDescriptor, phase, MiddlewareInsertionMode.EndOfPhase, callback);
+    }
+
+    /// <summary>
+    /// Register a resolve middleware for services providing a particular type.
+    /// </summary>
+    /// <param name="builder">The container builder.</param>
+    /// <param name="serviceType">The service type.</param>
+    /// <param name="descriptor">A description for the middleware; this will show up in any resolve tracing.</param>
+    /// <param name="phase">The phase of the pipeline the middleware should run at.</param>
+    /// <param name="callback">
+    /// A callback invoked to run your middleware.
+    /// This callback takes a <see cref="ResolveRequestContext"/>, containing the context for the resolve request, plus
+    /// a callback to invoke to continue the pipeline.
+    /// </param>
+    public static void RegisterServiceMiddleware(this ContainerBuilder builder, Type serviceType, string descriptor, PipelinePhase phase, Action<ResolveRequestContext, Action<ResolveRequestContext>> callback)
+    {
+        builder.RegisterServiceMiddleware(serviceType, descriptor, phase, MiddlewareInsertionMode.EndOfPhase, callback);
+    }
+
+    /// <summary>
+    /// Register a resolve middleware for services providing a particular type.
+    /// </summary>
+    /// <param name="builder">The container builder.</param>
+    /// <param name="serviceType">The service type.</param>
+    /// <param name="descriptor">A description for the middleware; this will show up in any resolve tracing.</param>
+    /// <param name="phase">The phase of the pipeline the middleware should run at.</param>
+    /// <param name="callback">
+    /// A callback invoked to run your middleware.
+    /// This callback takes a <see cref="ResolveRequestContext"/>, containing the context for the resolve request, plus
+    /// a callback to invoke to continue the pipeline.
+    /// </param>
+    /// <param name="insertionMode">The insertion mode of the middleware (start or end of phase).</param>
+    public static void RegisterServiceMiddleware(this ContainerBuilder builder, Type serviceType, string descriptor, PipelinePhase phase, MiddlewareInsertionMode insertionMode, Action<ResolveRequestContext, Action<ResolveRequestContext>> callback)
+    {
+        builder.RegisterServiceMiddleware(serviceType, new DelegateMiddleware(descriptor, phase, callback), insertionMode);
+    }
+
+    /// <summary>
+    /// Register a resolve middleware for services providing a particular type.
+    /// </summary>
+    /// <param name="builder">The container builder.</param>
+    /// <param name="serviceType">The service type.</param>
     /// <param name="middleware">The middleware to register.</param>
     /// <param name="insertionMode">The insertion mode of the middleware (start or end of phase).</param>
     public static void RegisterServiceMiddleware(this ContainerBuilder builder, Type serviceType, IResolveMiddleware middleware, MiddlewareInsertionMode insertionMode = MiddlewareInsertionMode.EndOfPhase)

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -125,6 +125,25 @@ public class RegistrationOnlyIfTests
     }
 
     [Fact]
+    public void IfNotRegistered_EvaluatesServiceMiddleware()
+    {
+        var builder = new ContainerBuilder();
+        var middlewareInvoked = false;
+
+        builder.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
+
+        builder.RegisterServiceMiddleware(typeof(IService), PipelinePhase.ResolveRequestStart, (context, next) =>
+        {
+            next(context);
+            middlewareInvoked = true;
+        });
+
+        var container = builder.Build();
+        var result = container.Resolve<IService>();
+        Assert.True(middlewareInvoked);
+    }
+
+    [Fact]
     public void IfNotRegistered_CanBeDecoratedByModuleWhenModuleRegistered1st()
     {
         var builder = new ContainerBuilder();

--- a/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
+++ b/test/Autofac.Specification.Test/Registration/RegistrationOnlyIfTests.cs
@@ -144,6 +144,27 @@ public class RegistrationOnlyIfTests
     }
 
     [Fact]
+    public void IfNotRegistered_EvaluatesServiceMiddleware_WithDescriptor()
+    {
+        var builder = new ContainerBuilder();
+        var middlewareInvoked = false;
+
+        builder.RegisterType<ServiceA>().As<IService>().IfNotRegistered(typeof(IService));
+
+        const string descriptor = "custom-middleware";
+        builder.RegisterServiceMiddleware(typeof(IService), descriptor, PipelinePhase.ResolveRequestStart, (context, next) =>
+            {
+                next(context);
+                middlewareInvoked = true;
+            });
+
+        var container = builder.Build();
+
+        var result = container.Resolve<IService>();
+        Assert.True(middlewareInvoked);
+    }
+
+    [Fact]
     public void IfNotRegistered_CanBeDecoratedByModuleWhenModuleRegistered1st()
     {
         var builder = new ContainerBuilder();


### PR DESCRIPTION
Register service with Interceptor, then register multiple decorator, auto apply Interceptor to the outermost decorator
Actually this is the default behaviors when I use autofac 4.x. after upgrade version 8.0.0, this not working any more.
I know explicit configure interceptor on the outermost decorator make it more clarity and flexibility. but I thinks we should keep the original behaviors some how, even it not the default behaviors.
This behaviors will benefit in case when add new decorator, we don't need remove the interceptor and add the interceptor to the new decorator.