### PR TITLE
Skip assignability check for COM objects

### DIFF
--- a/src/Autofac/Builder/RegistrationBuilder.cs
+++ b/src/Autofac/Builder/RegistrationBuilder.cs
@@ -196,7 +196,7 @@ public static class RegistrationBuilder
         }
 
         var limitType = activator.LimitType;
-        if (limitType != typeof(object))
+        if (limitType != typeof(object) && !limitType.IsCOMObject)
         {
             foreach (var ts in services)
             {

--- a/test/Autofac.Test/Autofac.Test.csproj
+++ b/test/Autofac.Test/Autofac.Test.csproj
@@ -36,6 +36,10 @@
     <None Remove="TestResults\**" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
+    <Compile Remove="ComObjectRegistrationTest.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\Shims\required\*.cs" Link="Util\shims\required\%(FileName).cs" />
     <None Include="..\Shims\required\README.md" Link="Util\shims\required\README.md" />

--- a/test/Autofac.Test/ComObjectRegistrationTest.cs
+++ b/test/Autofac.Test/ComObjectRegistrationTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Test;
+
+public class ComObjectRegistrationTest
+{
+    private const string WindowsScriptingFileSystemObjectProgramId = "Scripting.FileSystemObject";
+
+    [Fact]
+    [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "File is excluded from non-Windows platforms.")]
+    public void AsTest()
+    {
+        var fsoType = Type.GetTypeFromProgID(WindowsScriptingFileSystemObjectProgramId);
+        var fso = Activator.CreateInstance(fsoType);
+
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(fso).As<string>();
+        _ = builder.Build();
+    }
+}


### PR DESCRIPTION
This PR skip the assignability check of singleton registrations (`ServiceType.IsAssignableFrom(limitType)`) in case the registered instance is a COM object. This check makes it currently impossible to introduce COM object as single instances, as the .NET Runtime handles COM objects specially.

The changes are tested, but the test is not executed on non-Windows platforms due to the nature of COM. The manufactured scenario isn't a completely fair representation of the issue but demonstrates the effect of the productive changes. A full featured example would require an environment with a type library, a working registration for the runtime of the tests, etc., which was deemed too complicated for the proposed changes. 

It also looks like people ran into this issue in the past, as demonstrated by this [poor guy on a Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/624191/autofac-throws-exception-for-microsoft-office-inte).