### PR TITLE
Allow Keyed Composites

### DIFF
--- a/src/Autofac/Core/Activators/Reflection/AutowiringParameter.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringParameter.cs
@@ -42,7 +42,7 @@ public class AutowiringParameter : Parameter
             return type.IsGenericType && type.GenericTypeArguments.Any(genericType => genericType == serviceType || HasService(genericType, serviceType));
         }
 
-        if (context is DefaultResolveRequestContext ctx)
+        if (context is ResolveRequestContext ctx)
         {
             if ((ctx.Registration.Options & Registration.RegistrationOptions.Composite) == Registration.RegistrationOptions.Composite
                 && ctx.Service is KeyedService keyedService

--- a/src/Autofac/Core/InternalReflectionCaches.cs
+++ b/src/Autofac/Core/InternalReflectionCaches.cs
@@ -35,6 +35,11 @@ internal class InternalReflectionCaches
     public ReflectionCacheTupleDictionary<Type, bool> IsGenericTypeDefinedBy { get; }
 
     /// <summary>
+    /// Gets the cache used by <see cref="InternalTypeExtensions.IsGenericTypeContainingType"/>.
+    /// </summary>
+    public ReflectionCacheTupleDictionary<Type, bool> IsGenericTypeContainingType { get; }
+
+    /// <summary>
     /// Gets the cache used by <see cref="ConstructorBinder"/>.
     /// </summary>
     public ReflectionCacheDictionary<ConstructorInfo, Func<object?[], object>> ConstructorBinderFactory { get; }
@@ -78,6 +83,7 @@ internal class InternalReflectionCaches
         IsGenericEnumerableInterface = set.GetOrCreateCache<ReflectionCacheDictionary<Type, bool>>(nameof(IsGenericEnumerableInterface));
         IsGenericListOrCollectionInterfaceType = set.GetOrCreateCache<ReflectionCacheDictionary<Type, bool>>(nameof(IsGenericListOrCollectionInterfaceType));
         IsGenericTypeDefinedBy = set.GetOrCreateCache<ReflectionCacheTupleDictionary<Type, bool>>(nameof(IsGenericTypeDefinedBy));
+        IsGenericTypeContainingType = set.GetOrCreateCache<ReflectionCacheTupleDictionary<Type, bool>>(nameof(IsGenericTypeContainingType));
         ConstructorBinderFactory = set.GetOrCreateCache<ReflectionCacheDictionary<ConstructorInfo, Func<object?[], object>>>(nameof(ConstructorBinderFactory));
         AutowiringPropertySetters = set.GetOrCreateCache<ReflectionCacheDictionary<PropertyInfo, Action<object, object?>>>(nameof(AutowiringPropertySetters));
         AutowiringInjectableProperties = set.GetOrCreateCache<ReflectionCacheDictionary<Type, IReadOnlyList<PropertyInfo>>>(nameof(AutowiringInjectableProperties));

--- a/src/Autofac/RegistrationExtensions.Composite.cs
+++ b/src/Autofac/RegistrationExtensions.Composite.cs
@@ -178,8 +178,8 @@ public static partial class RegistrationExtensions
 
         builder.RegisterCallback(crb =>
         {
-            // Validate that we are only behaving as a composite for a single service.
-            if (registration.RegistrationData.Services.Count(s => s is TypedService) > 1)
+            // Validate that we are only behaving as a composite for a single typed service, allows more keyed services.
+            if (registration.RegistrationData.Services.Count(s => s is TypedService) > 1 && registration.RegistrationData.Services.Count(s => s is KeyedService) < registration.RegistrationData.Services.Count() - 1)
             {
                 // Cannot have a multi-service composite.
                 throw new InvalidOperationException(

--- a/src/Autofac/RegistrationExtensions.Composite.cs
+++ b/src/Autofac/RegistrationExtensions.Composite.cs
@@ -179,7 +179,7 @@ public static partial class RegistrationExtensions
         builder.RegisterCallback(crb =>
         {
             // Validate that we are only behaving as a composite for a single service.
-            if (registration.RegistrationData.Services.Count() > 1)
+            if (registration.RegistrationData.Services.Count(s => s is TypedService) > 1)
             {
                 // Cannot have a multi-service composite.
                 throw new InvalidOperationException(

--- a/src/Autofac/Util/InternalTypeExtensions.cs
+++ b/src/Autofac/Util/InternalTypeExtensions.cs
@@ -187,6 +187,25 @@ internal static class InternalTypeExtensions
     }
 
     /// <summary>
+    /// Checks whether this type is a generic containing the given type.
+    /// </summary>
+    /// <param name="this">The type to check.</param>
+    /// <param name="type">The type to validate against.</param>
+    /// <returns>True if the <paramref name="this"/> is a generic containing <paramref name="type"/>; false otherwise.</returns>
+    /// <remarks>Recursively moves through generic type arguments looking for <paramref name="type"/>.</remarks>
+    public static bool IsGenericTypeContainingType(this Type @this, Type type)
+    {
+        static bool Uncached(Type @this, Type type)
+        {
+            return @this.IsGenericType && @this.GenericTypeArguments.Any(genericType => genericType == type || genericType.IsGenericTypeContainingType(type));
+        }
+
+        return ReflectionCacheSet.Shared.Internal.IsGenericTypeContainingType.GetOrAdd(
+            (@this, type),
+            key => Uncached(key.Item1, key.Item2));
+    }
+
+    /// <summary>
     /// Checks whether this type is an open generic type of a given type.
     /// </summary>
     /// <param name="this">The type we are checking.</param>

--- a/test/Autofac.Specification.Test/Features/CompositeTests.cs
+++ b/test/Autofac.Specification.Test/Features/CompositeTests.cs
@@ -50,7 +50,7 @@ public class CompositeTests
 
         var container = builder.Build();
 
-        var comp = container.Resolve<I1>(); // gets all I1
+        var comp = container.Resolve<I1>(); // gets all I1 non keyed
 
         Assert.IsType<MyComposite>(comp);
 
@@ -63,7 +63,7 @@ public class CompositeTests
             i => Assert.IsType<S3>(i),
             i => Assert.IsType<S4>(i));
 
-        comp = container.ResolveKeyed<I1>("1"); // gets only 11 keyed to "1"
+        comp = container.ResolveKeyed<I1>("1"); // gets only I1 keyed to "1"
 
         Assert.IsType<MyComposite>(comp);
 
@@ -74,7 +74,7 @@ public class CompositeTests
             i => Assert.IsType<S1>(i),
             i => Assert.IsType<S2>(i));
 
-        comp = container.ResolveKeyed<I1>("2"); // gets only 11 keyed to "2"
+        comp = container.ResolveKeyed<I1>("2"); // gets only I1 keyed to "2"
 
         Assert.IsType<MyComposite>(comp);
 

--- a/test/Autofac.Specification.Test/Features/CompositeTests.cs
+++ b/test/Autofac.Specification.Test/Features/CompositeTests.cs
@@ -101,7 +101,7 @@ public class CompositeTests
 
         var container = builder.Build();
 
-        var comp = container.Resolve<I1>(); // gets all I1 non keyed
+        var comp = container.Resolve<I1>(); // gets composite with all I1 non keyed
 
         Assert.IsType<MyComplexComposite>(comp);
 
@@ -114,7 +114,7 @@ public class CompositeTests
             i => Assert.IsType<S3>(i),
             i => Assert.IsType<S4>(i));
 
-        comp = container.ResolveKeyed<I1>("1"); // gets only I1 keyed to "1"
+        comp = container.ResolveKeyed<I1>("1"); // gets composite with only I1 keyed to "1"
 
         Assert.IsType<MyComplexComposite>(comp);
 
@@ -125,7 +125,7 @@ public class CompositeTests
             i => Assert.IsType<S1>(i),
             i => Assert.IsType<S2>(i));
 
-        comp = container.ResolveKeyed<I1>("2"); // gets only I1 keyed to "2"
+        comp = container.ResolveKeyed<I1>("2"); // gets composite with only I1 keyed to "2"
 
         Assert.IsType<MyComplexComposite>(comp);
 

--- a/test/Autofac.Specification.Test/Features/CompositeTests.cs
+++ b/test/Autofac.Specification.Test/Features/CompositeTests.cs
@@ -87,7 +87,7 @@ public class CompositeTests
     }
 
     [Fact]
-    public void CanRegisterCompositeOfKeyedServicesMeta()
+    public void CanRegisterCompositeOfKeyedServicesComplexList()
     {
         var builder = new ContainerBuilder();
         builder.Register(ctx => new S1()).As<I1>().Keyed<I1>("1");

--- a/test/Autofac.Specification.Test/Features/CompositeTests.cs
+++ b/test/Autofac.Specification.Test/Features/CompositeTests.cs
@@ -36,6 +36,57 @@ public class CompositeTests
     }
 
     [Fact]
+    public void CanRegisterCompositeOfKeyedServices()
+    {
+        var builder = new ContainerBuilder();
+        builder.Register(ctx => new S1()).As<I1>().Keyed<I1>("1");
+        builder.Register(ctx => new S2()).As<I1>().Keyed<I1>("1");
+        builder.Register(ctx => new S3()).As<I1>().Keyed<I1>("2");
+        builder.Register(ctx => new S4()).As<I1>().Keyed<I1>("2");
+
+        builder.RegisterComposite<MyComposite, I1>()
+            .Keyed<I1>("1")
+            .Keyed<I1>("2");
+
+        var container = builder.Build();
+
+        var comp = container.Resolve<I1>(); // gets all I1
+
+        Assert.IsType<MyComposite>(comp);
+
+        var actualComp = (MyComposite)comp;
+
+        Assert.Collection(
+            actualComp.Implementations,
+            i => Assert.IsType<S1>(i),
+            i => Assert.IsType<S2>(i),
+            i => Assert.IsType<S3>(i),
+            i => Assert.IsType<S4>(i));
+
+        comp = container.ResolveKeyed<I1>("1"); // gets only 11 keyed to "1"
+
+        Assert.IsType<MyComposite>(comp);
+
+        actualComp = (MyComposite)comp;
+
+        Assert.Collection(
+            actualComp.Implementations,
+            i => Assert.IsType<S1>(i),
+            i => Assert.IsType<S2>(i));
+
+        comp = container.ResolveKeyed<I1>("2"); // gets only 11 keyed to "2"
+
+        Assert.IsType<MyComposite>(comp);
+
+        actualComp = (MyComposite)comp;
+
+        Assert.Collection(
+            actualComp.Implementations,
+            i => Assert.IsType<S3>(i),
+            i => Assert.IsType<S4>(i));
+    }
+
+    [Fact]
     public void CompositeRegistrationOrderIrrelevant()
     {
         var builder = new ContainerBuilder();


### PR DESCRIPTION
I encountered a situation where multiple implementations of a service were registered with the same keys. A composite currently only wraps all implementations of that service that do not have a key.

The workaround involves creating the composite manually, instead of resolving it.
```csharp
var comp = new MyComposite(container.ResolveKeyed<IEnumerable<I1>>("2")) as I1;
```
```csharp
var comp = container.ResolveKeyed<I1>("1");
```
Currently the above line resolves only the last instance of `I1` registered with `"1"`. I needed this to resolve a composite containing just the registrations with a specific key.

This PR allows for that functionality. All behavior remains the same unless the composite is additionally registered with `.Keyed<I1>(...)`, then the above line will resolve an appropriate composite.

Example from added unit test.
```csharp
var builder = new ContainerBuilder();
builder.Register(ctx => new S1()).As<I1>().Keyed<I1>("1");
builder.Register(ctx => new S2()).As<I1>().Keyed<I1>("1");
builder.Register(ctx => new S3()).As<I1>().Keyed<I1>("2");
builder.Register(ctx => new S4()).As<I1>().Keyed<I1>("2");

builder.RegisterComposite<MyComposite, I1>()
    .Keyed<I1>("1")
    .Keyed<I1>("2");

var container = builder.Build();

var comp = container.Resolve<I1>(); // gets composite with all I1 without a key (all)
var comp1 = container.ResolveKeyed<I1>("1"); // gets composite with only I1 keyed to "1"
var comp2 = container.ResolveKeyed<I1>("2"); // gets composite with only I1 keyed to "2"
```
Still only one non-keyed service registration is allowed. Keyed registrations must be added to enable this feature.

It works by determining: the resolving service is a composite, it is resolving a parameter of an `IEnumerable<>`, `IList<>`, or `ICollection<>` of the same service type, or the service type is nested in relationship types. Then it does a keyed service resolution using the composites key, else a normal typed resolution.
```csharp
builder.RegisterComposite<MyComplexComposite, I1>()
    .Keyed<I1>("1")
    .Keyed<I1>("2");

var comp2 = container.ResolveKeyed<I1>("2"); // gets composite with only I1 keyed to "2"

private class MyComplexComposite : I1
{
    public MyComplexComposite(IEnumerable<Lazy<Func<int, Owned<Meta<I1>>>>> implementations)
    {
    }
}
```
Will resolve Lazies of a Function that takes an int argument (for demonstration only in this example) that returns an Owned Meta object for `S3` or `S4` only.