### PR TITLE
Add metrics for easier benchmarking and performance monitoring

### DIFF
--- a/bench/Autofac.BenchmarkProfiling/Autofac.BenchmarkProfiling.csproj
+++ b/bench/Autofac.BenchmarkProfiling/Autofac.BenchmarkProfiling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PlatformTarget>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</PlatformTarget>
     <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
@@ -10,7 +10,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Autofac.Benchmarks\Autofac.Benchmarks.csproj" />

--- a/bench/Autofac.BenchmarkProfiling/Program.cs
+++ b/bench/Autofac.BenchmarkProfiling/Program.cs
@@ -1,5 +1,8 @@
-﻿using BenchmarkDotNet.Running;
+﻿using System.Diagnostics;
+using System.Reflection;
+using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+using Autofac.Core;
 
 namespace Autofac.BenchmarkProfiling;
 
@@ -10,6 +13,11 @@ class Program
 {
     static void Main(string[] args)
     {
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AUTOFAC_SCOPE_DIAGNOSTICS")))
+        {
+            AppContext.SetSwitch("Autofac.ScopeIsolatedDiagnostics", true);
+        }
+
         // Pick a benchmark.
         var availableBenchmarks = Benchmarks.BenchmarkSet.All;
 
@@ -98,6 +106,20 @@ class Program
         // Warmup.
         workloadAction(100);
 
+        if (int.TryParse(Environment.GetEnvironmentVariable("AUTOFAC_MEASURE_ITERATIONS"), out var measurementIterations) &&
+            measurementIterations > 0)
+        {
+            var sw = Stopwatch.StartNew();
+            workloadAction(measurementIterations);
+            sw.Stop();
+            var perIteration = sw.Elapsed.TotalMilliseconds / measurementIterations;
+            Console.WriteLine(
+                "[Profiling] Duration: {0} iterations took {1:F2} ms (avg {2:F4} ms)",
+                measurementIterations,
+                sw.Elapsed.TotalMilliseconds,
+                perIteration);
+        }
+
         // Now start a new thread.
         var runThread = new Thread(new ThreadStart(() =>
         {
@@ -112,6 +134,8 @@ class Program
         runThread.Join();
 
         cleanupAction.InvokeSingle();
+
+        LogScopeDiagnosticsIfEnabled();
     }
 
     private static void PrintBenchmarks(Type[] availableBenchmarks)
@@ -135,6 +159,38 @@ class Program
             {
                 Console.Error.WriteLine($" #{idx,-2} - {benchCase.Descriptor.DisplayInfo} ({benchCase.Parameters.DisplayInfo})");
             }
+        }
+    }
+
+    private static void LogScopeDiagnosticsIfEnabled()
+    {
+        if (!AppContext.TryGetSwitch("Autofac.ScopeIsolatedDiagnostics", out var enabled) || !enabled)
+        {
+            return;
+        }
+
+        var diagnosticsType = typeof(IComponentRegistry).Assembly.GetType("Autofac.Core.Registration.ScopeIsolatedServiceDiagnostics");
+        var snapshotProperty = diagnosticsType?.GetProperty(
+            "Snapshot",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
+
+        if (snapshotProperty?.GetValue(null) is object snapshot)
+        {
+            var cacheHits = (long)(snapshot.GetType().GetProperty("CacheHits")?.GetValue(snapshot) ?? 0L);
+            var cacheMisses = (long)(snapshot.GetType().GetProperty("CacheMisses")?.GetValue(snapshot) ?? 0L);
+            var cacheAdds = (long)(snapshot.GetType().GetProperty("CacheAdds")?.GetValue(snapshot) ?? 0L);
+            var cacheRemovals = (long)(snapshot.GetType().GetProperty("CacheRemovals")?.GetValue(snapshot) ?? 0L);
+            var cachedInitializations = (long)(snapshot.GetType().GetProperty("CachedInitializations")?.GetValue(snapshot) ?? 0L);
+            var discardedInfos = (long)(snapshot.GetType().GetProperty("ServiceInfoDiscarded")?.GetValue(snapshot) ?? 0L);
+
+            Console.WriteLine(
+                "[Profiling] Scope cache stats -> Hits={0}, Misses={1}, Adds={2}, Removes={3}, CachedInit={4}, Discarded={5}",
+                cacheHits,
+                cacheMisses,
+                cacheAdds,
+                cacheRemovals,
+                cachedInitializations,
+                discardedInfos);
         }
     }
 }

--- a/bench/Autofac.BenchmarkProfiling/Program.cs
+++ b/bench/Autofac.BenchmarkProfiling/Program.cs
@@ -1,8 +1,5 @@
-﻿using System.Diagnostics;
-using System.Reflection;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
-using Autofac.Core;
 
 namespace Autofac.BenchmarkProfiling;
 
@@ -13,11 +10,6 @@ class Program
 {
     static void Main(string[] args)
     {
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AUTOFAC_SCOPE_DIAGNOSTICS")))
-        {
-            AppContext.SetSwitch("Autofac.ScopeIsolatedDiagnostics", true);
-        }
-
         // Pick a benchmark.
         var availableBenchmarks = Benchmarks.BenchmarkSet.All;
 
@@ -106,20 +98,6 @@ class Program
         // Warmup.
         workloadAction(100);
 
-        if (int.TryParse(Environment.GetEnvironmentVariable("AUTOFAC_MEASURE_ITERATIONS"), out var measurementIterations) &&
-            measurementIterations > 0)
-        {
-            var sw = Stopwatch.StartNew();
-            workloadAction(measurementIterations);
-            sw.Stop();
-            var perIteration = sw.Elapsed.TotalMilliseconds / measurementIterations;
-            Console.WriteLine(
-                "[Profiling] Duration: {0} iterations took {1:F2} ms (avg {2:F4} ms)",
-                measurementIterations,
-                sw.Elapsed.TotalMilliseconds,
-                perIteration);
-        }
-
         // Now start a new thread.
         var runThread = new Thread(new ThreadStart(() =>
         {
@@ -134,8 +112,6 @@ class Program
         runThread.Join();
 
         cleanupAction.InvokeSingle();
-
-        LogScopeDiagnosticsIfEnabled();
     }
 
     private static void PrintBenchmarks(Type[] availableBenchmarks)
@@ -159,38 +135,6 @@ class Program
             {
                 Console.Error.WriteLine($" #{idx,-2} - {benchCase.Descriptor.DisplayInfo} ({benchCase.Parameters.DisplayInfo})");
             }
-        }
-    }
-
-    private static void LogScopeDiagnosticsIfEnabled()
-    {
-        if (!AppContext.TryGetSwitch("Autofac.ScopeIsolatedDiagnostics", out var enabled) || !enabled)
-        {
-            return;
-        }
-
-        var diagnosticsType = typeof(IComponentRegistry).Assembly.GetType("Autofac.Core.Registration.ScopeIsolatedServiceDiagnostics");
-        var snapshotProperty = diagnosticsType?.GetProperty(
-            "Snapshot",
-            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static);
-
-        if (snapshotProperty?.GetValue(null) is object snapshot)
-        {
-            var cacheHits = (long)(snapshot.GetType().GetProperty("CacheHits")?.GetValue(snapshot) ?? 0L);
-            var cacheMisses = (long)(snapshot.GetType().GetProperty("CacheMisses")?.GetValue(snapshot) ?? 0L);
-            var cacheAdds = (long)(snapshot.GetType().GetProperty("CacheAdds")?.GetValue(snapshot) ?? 0L);
-            var cacheRemovals = (long)(snapshot.GetType().GetProperty("CacheRemovals")?.GetValue(snapshot) ?? 0L);
-            var cachedInitializations = (long)(snapshot.GetType().GetProperty("CachedInitializations")?.GetValue(snapshot) ?? 0L);
-            var discardedInfos = (long)(snapshot.GetType().GetProperty("ServiceInfoDiscarded")?.GetValue(snapshot) ?? 0L);
-
-            Console.WriteLine(
-                "[Profiling] Scope cache stats -> Hits={0}, Misses={1}, Adds={2}, Removes={3}, CachedInit={4}, Discarded={5}",
-                cacheHits,
-                cacheMisses,
-                cacheAdds,
-                cacheRemovals,
-                cachedInitializations,
-                discardedInfos);
         }
     }
 }

--- a/bench/Autofac.Benchmarks/Autofac.Benchmarks.csproj
+++ b/bench/Autofac.Benchmarks/Autofac.Benchmarks.csproj
@@ -1,20 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <OutputType>Exe</OutputType>
     <GenerateProgramFile>false</GenerateProgramFile>
     <PlatformTarget>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</PlatformTarget>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyOriginatorKeyFile>../../Autofac.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
+    <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <CodeAnalysisRuleSet>../../build/Test.ruleset</CodeAnalysisRuleSet>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <IsPackable>false</IsPackable>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <UseProjectReference Condition="'$(UseProjectReference)' == ''">true</UseProjectReference>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="BenchmarkDotNet.Attributes" />
@@ -25,14 +26,17 @@
     <None Remove="BenchmarkDotNet.Artifacts\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseProjectReference)' == 'true'">
     <ProjectReference Include="..\..\src\Autofac\Autofac.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseProjectReference)' != 'true' and '$(BaselinePackageVersion)' != ''">
+    <PackageReference Include="Autofac" Version="$(BaselinePackageVersion)" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\build\stylecop.json" Link="stylecop.json" />

--- a/bench/Autofac.Benchmarks/ChildScopeResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/ChildScopeResolveBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class ChildScopeResolveBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [Benchmark]
     public void Resolve()

--- a/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
+++ b/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace Autofac.Benchmarks.Decorators;
 
 public abstract class DecoratorBenchmarkBase<TCommandHandler>
+    where TCommandHandler : notnull
 {
-    protected IContainer Container { get; set; }
+    protected IContainer Container { get; set; } = default!;
 
     [Benchmark(Baseline = true)]
     public virtual void Baseline()
@@ -25,7 +28,7 @@ public abstract class DecoratorBenchmarkBase<TCommandHandler>
         using (var scope = Container.BeginLifetimeScope())
         {
             var iteration = 0;
-            object item = null;
+            object? item = null;
             while (iteration++ < repetitions)
             {
                 item = scope.Resolve<IEnumerable<TCommandHandler>>();
@@ -43,7 +46,7 @@ public abstract class DecoratorBenchmarkBase<TCommandHandler>
         using (var scope = Container.BeginLifetimeScope())
         {
             var iteration = 0;
-            object item = null;
+            object? item = null;
             while (iteration++ < repetitions)
             {
                 item = scope.Resolve<TCommandHandler>();

--- a/bench/Autofac.Benchmarks/DeepGraphResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/DeepGraphResolveBenchmark.cs
@@ -8,7 +8,7 @@ namespace Autofac.Benchmarks;
 /// </summary>
 public class DeepGraphResolveBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/bench/Autofac.Benchmarks/EnumerableResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/EnumerableResolveBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class EnumerableResolveBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/bench/Autofac.Benchmarks/LambdaResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/LambdaResolveBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class LambdaResolveBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/bench/Autofac.Benchmarks/MultiConstructorBenchmark.cs
+++ b/bench/Autofac.Benchmarks/MultiConstructorBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class MultiConstructorBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/bench/Autofac.Benchmarks/OpenGenericBenchmark.cs
+++ b/bench/Autofac.Benchmarks/OpenGenericBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class OpenGenericBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/bench/Autofac.Benchmarks/Program.cs
+++ b/bench/Autofac.Benchmarks/Program.cs
@@ -23,7 +23,7 @@ internal static class Program
         var config = new BenchmarkConfig();
 
         config.AddJob(
-            Job.InProcess
+            Job.Default
                 .WithId("Source"));
 
         if (!string.IsNullOrWhiteSpace(baselineVersion))

--- a/bench/Autofac.Benchmarks/Program.cs
+++ b/bench/Autofac.Benchmarks/Program.cs
@@ -1,12 +1,97 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 
 namespace Autofac.Benchmarks;
 
 internal static class Program
 {
-    internal static void Main(string[] args) =>
-        new BenchmarkSwitcher(BenchmarkSet.All).Run(args, new BenchmarkConfig());
+    internal static void Main(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        var (filteredArgs, baselineVersion) = ExtractBaselineVersion(args);
+
+        // Usage:
+        //
+        // Just run the benchmark with the source code version of the project:
+        // dotnet run -c Release -p bench/Autofac.Benchmarks
+        //
+        // Run the benchmark comparing the source code version to a specific package version:
+        // dotnet run -c Release -p bench/Autofac.Benchmarks -- --baseline-version 9.0.0
+        var config = new BenchmarkConfig();
+
+        config.AddJob(
+            Job.InProcess
+                .WithId("Source"));
+
+        if (!string.IsNullOrWhiteSpace(baselineVersion))
+        {
+            config.AddJob(
+                Job.Default
+                    .WithId($"Package-{baselineVersion}")
+                    .AsBaseline()
+                    .WithMsBuildArguments(
+                        "/p:UseProjectReference=false",
+                        $"/p:BaselinePackageVersion={baselineVersion}"));
+        }
+
+        new BenchmarkSwitcher(BenchmarkSet.All).Run(filteredArgs, config);
+    }
+
+    private static (string[] RemainingArgs, string? BaselineVersion) ExtractBaselineVersion(string[] args)
+    {
+        var forwarded = new List<string>(args.Length);
+        string? baseline = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (TryMatchBaselineArg(arg, out var inlineVersion))
+            {
+                if (!string.IsNullOrWhiteSpace(inlineVersion))
+                {
+                    baseline = inlineVersion;
+                    continue;
+                }
+
+                if (i + 1 >= args.Length)
+                {
+                    throw new ArgumentException("Missing version value for baseline argument.", nameof(args));
+                }
+
+                baseline = args[++i];
+                continue;
+            }
+
+            forwarded.Add(arg);
+        }
+
+        return (forwarded.ToArray(), baseline);
+    }
+
+    private static bool TryMatchBaselineArg(string arg, out string? valueFromAssignment)
+    {
+        valueFromAssignment = null;
+
+        static bool Matches(string candidate) =>
+            candidate.Equals("--baseline-version", StringComparison.OrdinalIgnoreCase) ||
+            candidate.Equals("--baselineVersion", StringComparison.OrdinalIgnoreCase);
+
+        var equalsIndex = arg.AsSpan().IndexOf('=');
+        if (equalsIndex >= 0)
+        {
+            var prefix = arg[..equalsIndex];
+            if (Matches(prefix))
+            {
+                valueFromAssignment = arg[(equalsIndex + 1)..];
+                return true;
+            }
+
+            return false;
+        }
+
+        return Matches(arg);
+    }
 }

--- a/bench/Autofac.Benchmarks/Program.cs
+++ b/bench/Autofac.Benchmarks/Program.cs
@@ -20,6 +20,8 @@ internal static class Program
         //
         // Run the benchmark comparing the source code version to a specific package version:
         // dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.0.0 --filter *Benchmarks*
+        //
+        // Markdown tables are emitted by default; see BenchmarkDotNet.Artifacts/.../results/*.md.
         var config = new BenchmarkConfig();
 
         config.AddJob(

--- a/bench/Autofac.Benchmarks/Program.cs
+++ b/bench/Autofac.Benchmarks/Program.cs
@@ -16,10 +16,10 @@ internal static class Program
         // Usage:
         //
         // Just run the benchmark with the source code version of the project:
-        // dotnet run -c Release --project bench/Autofac.Benchmarks
+        // dotnet run -c Release --project bench/Autofac.Benchmarks -- --filter *Benchmarks*
         //
         // Run the benchmark comparing the source code version to a specific package version:
-        // dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.0.0
+        // dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.0.0 --filter *Benchmarks*
         var config = new BenchmarkConfig();
 
         config.AddJob(

--- a/bench/Autofac.Benchmarks/Program.cs
+++ b/bench/Autofac.Benchmarks/Program.cs
@@ -37,6 +37,7 @@ internal static class Program
                         $"/p:BaselinePackageVersion={baselineVersion}"));
         }
 
+        Console.WriteLine($"Benchmark types configured: {BenchmarkSet.All.Length}");
         new BenchmarkSwitcher(BenchmarkSet.All).Run(filteredArgs, config);
     }
 

--- a/bench/Autofac.Benchmarks/Program.cs
+++ b/bench/Autofac.Benchmarks/Program.cs
@@ -16,10 +16,10 @@ internal static class Program
         // Usage:
         //
         // Just run the benchmark with the source code version of the project:
-        // dotnet run -c Release -p bench/Autofac.Benchmarks
+        // dotnet run -c Release --project bench/Autofac.Benchmarks
         //
         // Run the benchmark comparing the source code version to a specific package version:
-        // dotnet run -c Release -p bench/Autofac.Benchmarks -- --baseline-version 9.0.0
+        // dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.0.0
         var config = new BenchmarkConfig();
 
         config.AddJob(

--- a/bench/Autofac.Benchmarks/PropertyInjectionBenchmark.cs
+++ b/bench/Autofac.Benchmarks/PropertyInjectionBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class PropertyInjectionBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()
@@ -30,29 +30,29 @@ public class PropertyInjectionBenchmark
 
     internal class A
     {
-        public B1 B1 { get; set; }
+        public B1? B1 { get; set; }
 
-        public B2 B2 { get; set; }
+        public B2? B2 { get; set; }
     }
 
     internal class B1
     {
-        public C1 C1 { get; set; }
+        public C1? C1 { get; set; }
     }
 
     internal class B2
     {
-        public C2 C2 { get; set; }
+        public C2? C2 { get; set; }
     }
 
     internal class C1
     {
-        public D1 D1 { get; set; }
+        public D1? D1 { get; set; }
     }
 
     internal class C2
     {
-        public D2 D2 { get; set; }
+        public D2? D2 { get; set; }
     }
 
     internal class D1

--- a/bench/Autofac.Benchmarks/RequiredPropertyBenchmark.cs
+++ b/bench/Autofac.Benchmarks/RequiredPropertyBenchmark.cs
@@ -5,7 +5,7 @@ namespace Autofac.Benchmarks;
 
 public class RequiredPropertyBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/bench/Autofac.Benchmarks/RootContainerResolveBenchmark.cs
+++ b/bench/Autofac.Benchmarks/RootContainerResolveBenchmark.cs
@@ -8,7 +8,7 @@ namespace Autofac.Benchmarks;
 /// </summary>
 public class RootContainerResolveBenchmark
 {
-    private IContainer _container;
+    private IContainer _container = default!;
 
     [GlobalSetup]
     public void Setup()

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -105,7 +105,7 @@ internal static class AutowiringPropertyInjector
                 instanceType,
                 injectableProperties.Count,
                 injectedProperties,
-                instrumentationTimer.ElapsedTicks);
+                instrumentationTimer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
+++ b/src/Autofac/Core/Activators/Reflection/AutowiringPropertyInjector.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Reflection;
+using Autofac.Diagnostics;
 using Autofac.Util;
 
 namespace Autofac.Core.Activators.Reflection;
@@ -49,11 +50,18 @@ internal static class AutowiringPropertyInjector
         }
 
         var resolveParameters = parameters as Parameter[] ?? parameters.ToArray();
+        var recordMetrics = AutofacMetrics.MetricsEnabled;
+        ValueStopwatch instrumentationTimer = default;
+        if (recordMetrics)
+        {
+            instrumentationTimer = ValueStopwatch.StartNew();
+        }
 
         var injectablePropertiesCache = ReflectionCacheSet.Shared.Internal.AutowiringInjectableProperties;
 
         var instanceType = instance.GetType();
         var injectableProperties = injectablePropertiesCache.GetOrAdd(instanceType, type => GetInjectableProperties(type).ToList());
+        var injectedProperties = 0;
 
         for (var index = 0; index < injectableProperties.Count; index++)
         {
@@ -77,6 +85,7 @@ internal static class AutowiringPropertyInjector
             {
                 var setter = ReflectionCacheSet.Shared.Internal.AutowiringPropertySetters.GetOrAdd(property, MakeFastPropertySetter);
                 setter(instance, valueProvider!());
+                injectedProperties++;
                 continue;
             }
 
@@ -86,7 +95,17 @@ internal static class AutowiringPropertyInjector
             {
                 var setter = ReflectionCacheSet.Shared.Internal.AutowiringPropertySetters.GetOrAdd(property, MakeFastPropertySetter);
                 setter(instance, propertyValue);
+                injectedProperties++;
             }
+        }
+
+        if (recordMetrics)
+        {
+            AutofacMetrics.RecordPropertyInjection(
+                instanceType,
+                injectableProperties.Count,
+                injectedProperties,
+                instrumentationTimer.ElapsedTicks);
         }
     }
 

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -234,7 +234,7 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
                 if (recordMetrics)
                 {
-                    AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.ElapsedTicks);
+                    AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.GetElapsedTime());
                 }
 
                 next(context);
@@ -270,7 +270,7 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
                 if (recordMetrics)
                 {
-                    AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.ElapsedTicks);
+                    AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.GetElapsedTime());
                 }
 
                 next(context);
@@ -329,7 +329,7 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
         if (recordMetrics)
         {
-            AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.ElapsedTicks);
+            AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.GetElapsedTime());
         }
 
         return instance;

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 using Autofac.Util;
 
 namespace Autofac.Core.Activators.Reflection;
@@ -218,11 +219,23 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
             {
                 CheckNotDisposed();
 
+                var recordMetrics = AutofacMetrics.MetricsEnabled;
+                ValueStopwatch instrumentationTimer = default;
+                if (recordMetrics)
+                {
+                    instrumentationTimer = ValueStopwatch.StartNew();
+                }
+
                 var instance = boundConstructor.Instantiate();
 
                 InjectProperties(instance, context, boundConstructor, GetAllParameters(context.Parameters));
 
                 context.Instance = instance;
+
+                if (recordMetrics)
+                {
+                    AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.ElapsedTicks);
+                }
 
                 next(context);
             });
@@ -232,6 +245,13 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
             pipelineBuilder.Use(ToString(), PipelinePhase.Activation, MiddlewareInsertionMode.EndOfPhase, (context, next) =>
             {
                 CheckNotDisposed();
+
+                var recordMetrics = AutofacMetrics.MetricsEnabled;
+                ValueStopwatch instrumentationTimer = default;
+                if (recordMetrics)
+                {
+                    instrumentationTimer = ValueStopwatch.StartNew();
+                }
 
                 var prioritizedParameters = GetAllParameters(context.Parameters);
 
@@ -247,6 +267,11 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
                 InjectProperties(instance, context, bound, prioritizedParameters);
 
                 context.Instance = instance;
+
+                if (recordMetrics)
+                {
+                    AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.ElapsedTicks);
+                }
 
                 next(context);
             });
@@ -277,6 +302,13 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
         CheckNotDisposed();
 
+        var recordMetrics = AutofacMetrics.MetricsEnabled;
+        ValueStopwatch instrumentationTimer = default;
+        if (recordMetrics)
+        {
+            instrumentationTimer = ValueStopwatch.StartNew();
+        }
+
         var prioritizedParameters = GetAllParameters(parameters);
 
         var allBindings = GetAllBindings(_constructorBinders!, context, prioritizedParameters);
@@ -294,6 +326,11 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
         var instance = selectedBinding.Instantiate();
 
         InjectProperties(instance, context, selectedBinding, prioritizedParameters);
+
+        if (recordMetrics)
+        {
+            AutofacMetrics.RecordReflectionActivation(_implementationType, instrumentationTimer.ElapsedTicks);
+        }
 
         return instance;
     }

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -5,12 +5,14 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using System.Threading;
 #if NET5_0_OR_GREATER
 using System.Runtime.Loader;
 #endif
 using Autofac.Builder;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving;
+using Autofac.Diagnostics;
 using Autofac.Util;
 
 namespace Autofac.Core.Lifetime;
@@ -269,8 +271,21 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             return tempResult;
         }
 
-        lock (_synchRoot)
+        var instrumentationDetail = AutofacMetrics.MetricsEnabled ? $"Tag:{Tag},Id:{id}" : null;
+        var lockTaken = false;
+        try
         {
+            if (AutofacMetrics.MetricsEnabled)
+            {
+                var wait = ValueStopwatch.StartNew();
+                Monitor.Enter(_synchRoot, ref lockTaken);
+                AutofacMetrics.RecordLockContention("LifetimeScopeSharedInstance", instrumentationDetail, wait.ElapsedTicks);
+            }
+            else
+            {
+                Monitor.Enter(_synchRoot, ref lockTaken);
+            }
+
             if (_sharedInstances.TryGetValue(id, out var result))
             {
                 return result;
@@ -283,6 +298,13 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             }
 
             return result;
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                Monitor.Exit(_synchRoot);
+            }
         }
     }
 
@@ -306,8 +328,21 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             return tempResult;
         }
 
-        lock (_synchRoot)
+        var instrumentationDetail = AutofacMetrics.MetricsEnabled ? $"Tag:{Tag},Key:{instanceKey}" : null;
+        var lockTaken = false;
+        try
         {
+            if (AutofacMetrics.MetricsEnabled)
+            {
+                var wait = ValueStopwatch.StartNew();
+                Monitor.Enter(_synchRoot, ref lockTaken);
+                AutofacMetrics.RecordLockContention("LifetimeScopeQualifiedSharedInstance", instrumentationDetail, wait.ElapsedTicks);
+            }
+            else
+            {
+                Monitor.Enter(_synchRoot, ref lockTaken);
+            }
+
             if (_sharedQualifiedInstances.TryGetValue(instanceKey, out var result))
             {
                 return result;
@@ -320,6 +355,13 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             }
 
             return result;
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                Monitor.Exit(_synchRoot);
+            }
         }
     }
 

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -279,7 +279,7 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             {
                 var wait = ValueStopwatch.StartNew();
                 Monitor.Enter(_synchRoot, ref lockTaken);
-                AutofacMetrics.RecordLockContention("LifetimeScopeSharedInstance", instrumentationDetail, wait.ElapsedTicks);
+                AutofacMetrics.RecordLockContention("LifetimeScopeSharedInstance", instrumentationDetail, wait.GetElapsedTime());
             }
             else
             {
@@ -336,7 +336,7 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             {
                 var wait = ValueStopwatch.StartNew();
                 Monitor.Enter(_synchRoot, ref lockTaken);
-                AutofacMetrics.RecordLockContention("LifetimeScopeQualifiedSharedInstance", instrumentationDetail, wait.ElapsedTicks);
+                AutofacMetrics.RecordLockContention("LifetimeScopeQualifiedSharedInstance", instrumentationDetail, wait.GetElapsedTime());
             }
             else
             {

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -294,7 +294,7 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         {
             var wait = ValueStopwatch.StartNew();
             Monitor.Enter(info, ref lockTaken);
-            AutofacMetrics.RecordLockContention("Service", instrumentationService, wait.ElapsedTicks);
+            AutofacMetrics.RecordLockContention("Service", instrumentationService, wait.GetElapsedTime());
         }
         else
         {

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -264,6 +264,12 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         // Do not call the base, otherwise the standard Dispose will fire.
     }
 
+    /// <summary>
+    /// Filters registration sources to skip a single source.
+    /// </summary>
+    /// <param name="sources">The source sequence to scan.</param>
+    /// <param name="exclude">The source to exclude.</param>
+    /// <returns>Sources that are not the excluded instance.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static IEnumerable<IRegistrationSource> ExcludeSource(IEnumerable<IRegistrationSource> sources, IRegistrationSource exclude)
     {
@@ -276,6 +282,33 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         }
     }
 
+    /// <summary>
+    /// Acquires the service info lock and records wait time when metrics are enabled.
+    /// </summary>
+    /// <param name="info">The service info lock target.</param>
+    /// <param name="instrumentationService">Optional detail about the service for metrics.</param>
+    /// <param name="lockTaken">Tracks whether the lock was acquired.</param>
+    private static void EnterServiceInfoLock(ServiceRegistrationInfo info, string? instrumentationService, ref bool lockTaken)
+    {
+        if (AutofacMetrics.MetricsEnabled)
+        {
+            var wait = ValueStopwatch.StartNew();
+            Monitor.Enter(info, ref lockTaken);
+            AutofacMetrics.RecordLockContention("Service", instrumentationService, wait.ElapsedTicks);
+        }
+        else
+        {
+            Monitor.Enter(info, ref lockTaken);
+        }
+    }
+
+    /// <summary>
+    /// Gets or creates an ephemeral service info entry used during pre-complete initialization.
+    /// </summary>
+    /// <param name="ephemeralSet">The ephemeral map for this initialization pass.</param>
+    /// <param name="service">The service key.</param>
+    /// <param name="info">The baseline service info to clone if needed.</param>
+    /// <returns>An ephemeral service info entry for the service.</returns>
     private static ServiceRegistrationInfo GetEphemeralServiceInfo(Dictionary<Service, ServiceRegistrationInfo> ephemeralSet, Service service, ServiceRegistrationInfo info)
     {
         if (ephemeralSet.TryGetValue(service, out var ephemeral))
@@ -290,18 +323,36 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         return newCopy;
     }
 
-    private ServiceRegistrationInfo GetInitializedServiceInfo(Service service)
+    /// <summary>
+    /// Unwraps scope-isolated services and notes when isolation applies.
+    /// </summary>
+    /// <param name="service">The service to inspect.</param>
+    /// <param name="isScopeIsolatedService">Set to <see langword="true"/> when the service is scope isolated.</param>
+    /// <returns>The inner service to process.</returns>
+    private static Service ResolveScopeIsolation(Service service, ref bool isScopeIsolatedService)
     {
-        var createdEphemeralSet = false;
-        var isScopeIsolatedService = false;
-
         if (service is ScopeIsolatedService scopeIsolatedService)
         {
             // This is an isolated service query; use the wrapped service instead and
             // remember that fact for later.
             isScopeIsolatedService = true;
-            service = scopeIsolatedService.Service;
+            return scopeIsolatedService.Service;
         }
+
+        return service;
+    }
+
+    /// <summary>
+    /// Ensures the service info is initialized and returns it.
+    /// </summary>
+    /// <param name="service">The service being queried.</param>
+    /// <returns>The initialized service info.</returns>
+    private ServiceRegistrationInfo GetInitializedServiceInfo(Service service)
+    {
+        var createdEphemeralSet = false;
+        var isScopeIsolatedService = false;
+
+        service = ResolveScopeIsolation(service, ref isScopeIsolatedService);
 
         var info = GetServiceInfo(service);
         var instrumentationService = AutofacMetrics.MetricsEnabled ? service.ToString() : null;
@@ -310,92 +361,21 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
             return info;
         }
 
-        if (!_trackerPopulationComplete)
-        {
-            // We need an ephemeral set for this pre-complete initialization.
-            if (_ephemeralServiceInfo is null)
-            {
-                _ephemeralServiceInfo = new Dictionary<Service, ServiceRegistrationInfo>();
-                createdEphemeralSet = true;
-            }
-
-            info = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
-        }
+        info = GetServiceInfoForInitialization(service, info, ref createdEphemeralSet);
 
         var succeeded = false;
         var lockTaken = false;
         try
         {
-            if (AutofacMetrics.MetricsEnabled)
-            {
-                var wait = ValueStopwatch.StartNew();
-                Monitor.Enter(info, ref lockTaken);
-                AutofacMetrics.RecordLockContention("Service", instrumentationService, wait.ElapsedTicks);
-            }
-            else
-            {
-                Monitor.Enter(info, ref lockTaken);
-            }
+            EnterServiceInfoLock(info, instrumentationService, ref lockTaken);
 
             if (info.IsInitialized)
             {
                 return info;
             }
 
-            if (!info.IsInitializing)
-            {
-                BeginServiceInfoInitialization(service, info, _dynamicRegistrationSources);
-            }
-
-            info.InitializationDepth++;
-
-            while (info.HasSourcesToQuery)
-            {
-                var next = info.DequeueNextSource();
-
-                // Do not query per-scope registration sources
-                // for isolated services.
-                if (isScopeIsolatedService && next is IPerScopeRegistrationSource)
-                {
-                    continue;
-                }
-
-                foreach (var provided in next.RegistrationsFor(service, _registrationAccessor))
-                {
-                    // This ensures that multiple services provided by the same
-                    // component share a single component (we don't re-query for them)
-                    foreach (var additionalService in provided.Services)
-                    {
-                        var additionalInfo = GetServiceInfo(additionalService);
-                        if (additionalInfo.IsInitialized || additionalInfo == info)
-                        {
-                            continue;
-                        }
-
-                        if (_ephemeralServiceInfo is not null)
-                        {
-                            // Use ephemeral info for additional services.
-                            additionalInfo = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
-                        }
-
-                        if (!additionalInfo.IsInitializing)
-                        {
-                            BeginServiceInfoInitialization(additionalService, additionalInfo, ExcludeSource(_dynamicRegistrationSources, next));
-                        }
-                        else
-                        {
-                            additionalInfo.SkipSource(next);
-                        }
-                    }
-
-                    AddRegistration(
-                        provided,
-                        preserveDefaults: true,
-                        originatedFromDynamicSource: true);
-                }
-            }
-
-            succeeded = true;
+            // PopulateServiceInfo increments InitializationDepth; the decrement is paired in finally.
+            succeeded = PopulateServiceInfo(service, info, isScopeIsolatedService);
         }
         finally
         {
@@ -421,8 +401,8 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
                 Monitor.Exit(info);
             }
 
-            // This method was the entry point to an ephemeral service info initialization.
-            // We need to discard it, so the next set of ephemeral service info is done from scratch.
+            // This method was the entry point to an ephemeral initialization pass.
+            // Discard the temporary map so later calls start with a clean slate.
             if (createdEphemeralSet)
             {
                 _ephemeralServiceInfo?.Clear();
@@ -433,6 +413,102 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         return info;
     }
 
+    /// <summary>
+    /// Returns the appropriate service info for initialization, swapping to an ephemeral copy when needed.
+    /// </summary>
+    /// <param name="service">The service being queried.</param>
+    /// <param name="info">The current service info.</param>
+    /// <param name="createdEphemeralSet">Set to <see langword="true"/> when a new ephemeral set is created.</param>
+    /// <returns>The service info to use for initialization.</returns>
+    private ServiceRegistrationInfo GetServiceInfoForInitialization(Service service, ServiceRegistrationInfo info, ref bool createdEphemeralSet)
+    {
+        if (!_trackerPopulationComplete)
+        {
+            // We need an ephemeral set for this pre-complete initialization.
+            if (_ephemeralServiceInfo is null)
+            {
+                _ephemeralServiceInfo = new Dictionary<Service, ServiceRegistrationInfo>();
+                createdEphemeralSet = true;
+            }
+
+            info = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
+        }
+
+        return info;
+    }
+
+    /// <summary>
+    /// Populates service info by querying registration sources and adding derived registrations.
+    /// </summary>
+    /// <param name="service">The service being initialized.</param>
+    /// <param name="info">The service info to populate.</param>
+    /// <param name="isScopeIsolatedService"><see langword="true"/> when per-scope sources should be skipped.</param>
+    /// <returns><see langword="true"/> when initialization completes.</returns>
+    private bool PopulateServiceInfo(Service service, ServiceRegistrationInfo info, bool isScopeIsolatedService)
+    {
+        if (!info.IsInitializing)
+        {
+            BeginServiceInfoInitialization(service, info, _dynamicRegistrationSources);
+        }
+
+        info.InitializationDepth++;
+
+        // Drain sources in-order; registrations can enqueue additional sources.
+        while (info.HasSourcesToQuery)
+        {
+            var next = info.DequeueNextSource();
+
+            // Do not query per-scope registration sources
+            // for isolated services.
+            if (isScopeIsolatedService && next is IPerScopeRegistrationSource)
+            {
+                continue;
+            }
+
+            foreach (var provided in next.RegistrationsFor(service, _registrationAccessor))
+            {
+                // This ensures that multiple services provided by the same
+                // component share a single component (we don't re-query for them)
+                foreach (var additionalService in provided.Services)
+                {
+                    var additionalInfo = GetServiceInfo(additionalService);
+                    if (additionalInfo.IsInitialized || additionalInfo == info)
+                    {
+                        continue;
+                    }
+
+                    if (_ephemeralServiceInfo is not null)
+                    {
+                        // Use ephemeral info for additional services.
+                        additionalInfo = GetEphemeralServiceInfo(_ephemeralServiceInfo, service, info);
+                    }
+
+                    if (!additionalInfo.IsInitializing)
+                    {
+                        BeginServiceInfoInitialization(additionalService, additionalInfo, ExcludeSource(_dynamicRegistrationSources, next));
+                    }
+                    else
+                    {
+                        additionalInfo.SkipSource(next);
+                    }
+                }
+
+                AddRegistration(
+                    provided,
+                    preserveDefaults: true,
+                    originatedFromDynamicSource: true);
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Seeds service info with middleware and registration sources.
+    /// </summary>
+    /// <param name="service">The service being initialized.</param>
+    /// <param name="info">The service info to update.</param>
+    /// <param name="registrationSources">Sources to query for registrations.</param>
     private void BeginServiceInfoInitialization(Service service, ServiceRegistrationInfo info, IEnumerable<IRegistrationSource> registrationSources)
     {
         // Add any additional service pipeline configuration from external sources.
@@ -444,6 +520,11 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         info.BeginInitialization(registrationSources);
     }
 
+    /// <summary>
+    /// Gets or creates the service info entry for a service key.
+    /// </summary>
+    /// <param name="service">The service key.</param>
+    /// <returns>The service info entry.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private ServiceRegistrationInfo GetServiceInfo(Service service)
     {

--- a/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
+++ b/src/Autofac/Core/Registration/DefaultRegisteredServicesTracker.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 using Autofac.Util;
 
 namespace Autofac.Core.Registration;
@@ -303,6 +304,7 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         }
 
         var info = GetServiceInfo(service);
+        var instrumentationService = AutofacMetrics.MetricsEnabled ? service.ToString() : null;
         if (info.IsInitialized)
         {
             return info;
@@ -324,7 +326,16 @@ internal class DefaultRegisteredServicesTracker : Disposable, IRegisteredService
         var lockTaken = false;
         try
         {
-            Monitor.Enter(info, ref lockTaken);
+            if (AutofacMetrics.MetricsEnabled)
+            {
+                var wait = ValueStopwatch.StartNew();
+                Monitor.Enter(info, ref lockTaken);
+                AutofacMetrics.RecordLockContention("Service", instrumentationService, wait.ElapsedTicks);
+            }
+            else
+            {
+                Monitor.Enter(info, ref lockTaken);
+            }
 
             if (info.IsInitialized)
             {

--- a/src/Autofac/Core/Resolving/Middleware/ActivatorErrorHandlingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ActivatorErrorHandlingMiddleware.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using System.Globalization;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -28,23 +30,20 @@ internal class ActivatorErrorHandlingMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
         try
         {
-            next(context);
-
-            if (context.Instance is null)
-            {
-                // Exited the Activation Stage without creating an instance.
-                throw new DependencyResolutionException(MiddlewareMessages.ActivatorDidNotPopulateInstance);
-            }
+            ExecuteCore(context, next);
         }
-        catch (ObjectDisposedException)
+        finally
         {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw PropagateActivationException(context.Registration.Activator, ex);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(ActivatorErrorHandlingMiddleware), Stopwatch.GetTimestamp() - start);
         }
     }
 
@@ -66,5 +65,27 @@ internal class ActivatorErrorHandlingMiddleware : IResolveMiddleware
         var result = new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, ComponentActivationResources.ErrorDuringActivation, activatorChain), innerException);
         result.Data[ActivatorChainExceptionData] = activatorChain;
         return result;
+    }
+
+    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
+        try
+        {
+            next(context);
+
+            if (context.Instance is null)
+            {
+                // Exited the Activation Stage without creating an instance.
+                throw new DependencyResolutionException(MiddlewareMessages.ActivatorDidNotPopulateInstance);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw PropagateActivationException(context.Registration.Activator, ex);
+        }
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/ActivatorErrorHandlingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ActivatorErrorHandlingMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using System.Globalization;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
@@ -36,14 +35,14 @@ internal class ActivatorErrorHandlingMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(ActivatorErrorHandlingMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(ActivatorErrorHandlingMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -38,6 +40,25 @@ internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
 
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            ExecuteCore(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(CircularDependencyDetectorMiddleware), Stopwatch.GetTimestamp() - start);
+        }
+    }
+
+    private void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         if (context.Operation is not IDependencyTrackingResolveOperation dependencyTrackingResolveOperation)
         {

--- a/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Autofac.Core.Resolving.Pipeline;
@@ -47,14 +46,14 @@ internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(CircularDependencyDetectorMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(CircularDependencyDetectorMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
@@ -58,6 +58,32 @@ internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
         }
     }
 
+    /// <inheritdoc/>
+    public override string ToString() => nameof(CircularDependencyDetectorMiddleware);
+
+    private static string CreateDependencyGraphTo(IComponentRegistration registration, IEnumerable<ResolveRequestContext> requestStack)
+    {
+        if (registration == null)
+        {
+            throw new ArgumentNullException(nameof(registration));
+        }
+
+        if (requestStack == null)
+        {
+            throw new ArgumentNullException(nameof(requestStack));
+        }
+
+        var dependencyGraph = Display(registration);
+
+        return requestStack.Select(a => a.Registration)
+            .Aggregate(dependencyGraph, (current, requestor) => Display(requestor) + " -> " + current);
+    }
+
+    private static string Display(IComponentRegistration registration)
+    {
+        return registration.Activator.DisplayName();
+    }
+
     private void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         if (context.Operation is not IDependencyTrackingResolveOperation dependencyTrackingResolveOperation)
@@ -115,31 +141,5 @@ internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
         {
             requestStack.Pop();
         }
-    }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(CircularDependencyDetectorMiddleware);
-
-    private static string CreateDependencyGraphTo(IComponentRegistration registration, IEnumerable<ResolveRequestContext> requestStack)
-    {
-        if (registration == null)
-        {
-            throw new ArgumentNullException(nameof(registration));
-        }
-
-        if (requestStack == null)
-        {
-            throw new ArgumentNullException(nameof(requestStack));
-        }
-
-        var dependencyGraph = Display(registration);
-
-        return requestStack.Select(a => a.Registration)
-            .Aggregate(dependencyGraph, (current, requestor) => Display(requestor) + " -> " + current);
-    }
-
-    private static string Display(IComponentRegistration registration)
-    {
-        return registration.Activator.DisplayName();
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
 
@@ -47,14 +46,14 @@ public class CoreEventMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             _callback(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(ToString(), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(ToString(), timer.GetElapsedTime());
         }
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -39,6 +41,20 @@ public class CoreEventMiddleware : IResolveMiddleware
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        _callback(context, next);
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            _callback(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            _callback(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(ToString(), Stopwatch.GetTimestamp() - start);
+        }
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/DelegateMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DelegateMiddleware.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -32,7 +34,21 @@ internal class DelegateMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        _callback(context, next);
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            _callback(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            _callback(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(ToString(), Stopwatch.GetTimestamp() - start);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Autofac/Core/Resolving/Middleware/DelegateMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DelegateMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
 
@@ -40,14 +39,14 @@ internal class DelegateMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             _callback(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(ToString(), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(ToString(), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -26,6 +28,28 @@ internal class DisposalTrackingMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            ExecuteCore(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(DisposalTrackingMiddleware), Stopwatch.GetTimestamp() - start);
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => nameof(DisposalTrackingMiddleware);
+
+    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
         next(context);
 
         if (context.Registration.Ownership == InstanceOwnership.OwnedByLifetimeScope)
@@ -44,7 +68,4 @@ internal class DisposalTrackingMiddleware : IResolveMiddleware
             }
         }
     }
-
-    /// <inheritdoc />
-    public override string ToString() => nameof(DisposalTrackingMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
 
@@ -34,14 +33,14 @@ internal class DisposalTrackingMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(DisposalTrackingMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(DisposalTrackingMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/RegistrationPipelineInvokeMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/RegistrationPipelineInvokeMiddleware.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -25,7 +27,21 @@ internal class RegistrationPipelineInvokeMiddleware : IResolveMiddleware
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        context.Registration.ResolvePipeline.Invoke(context);
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            context.Registration.ResolvePipeline.Invoke(context);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            context.Registration.ResolvePipeline.Invoke(context);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(RegistrationPipelineInvokeMiddleware), Stopwatch.GetTimestamp() - start);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Autofac/Core/Resolving/Middleware/RegistrationPipelineInvokeMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/RegistrationPipelineInvokeMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
 
@@ -33,14 +32,14 @@ internal class RegistrationPipelineInvokeMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             context.Registration.ResolvePipeline.Invoke(context);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(RegistrationPipelineInvokeMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(RegistrationPipelineInvokeMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -28,6 +30,28 @@ internal class ScopeSelectionMiddleware : IResolveMiddleware
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            ExecuteCore(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(ScopeSelectionMiddleware), Stopwatch.GetTimestamp() - start);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(ScopeSelectionMiddleware);
+
+    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
         try
         {
             context.ChangeScope(context.Registration.Lifetime.FindScope(context.ActivationScope));
@@ -47,7 +71,4 @@ internal class ScopeSelectionMiddleware : IResolveMiddleware
 
         next(context);
     }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(ScopeSelectionMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using Autofac.Core.Resolving.Pipeline;
@@ -36,14 +35,14 @@ internal class ScopeSelectionMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(ScopeSelectionMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(ScopeSelectionMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/SharingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/SharingMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
 
@@ -29,14 +28,14 @@ internal class SharingMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(SharingMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(SharingMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/SharingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/SharingMiddleware.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -20,6 +22,28 @@ internal class SharingMiddleware : IResolveMiddleware
 
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            ExecuteCore(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(SharingMiddleware), Stopwatch.GetTimestamp() - start);
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => nameof(SharingMiddleware);
+
+    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         var registration = context.Registration;
         var decoratorRegistration = context.DecoratorTarget;
@@ -55,7 +79,4 @@ internal class SharingMiddleware : IResolveMiddleware
             }
         }
     }
-
-    /// <inheritdoc />
-    public override string ToString() => nameof(SharingMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Builder;
 using Autofac.Core.Resolving.Pipeline;
 using Autofac.Diagnostics;
@@ -34,14 +33,14 @@ internal class StartableMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(StartableMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(StartableMiddleware), timer.GetElapsedTime());
         }
     }
 

--- a/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Builder;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -26,6 +28,28 @@ internal class StartableMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            ExecuteCore(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(StartableMiddleware), Stopwatch.GetTimestamp() - start);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(StartableMiddleware);
+
+    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
         next(context);
 
         if (context.Instance is IStartable startable
@@ -39,7 +63,4 @@ internal class StartableMiddleware : IResolveMiddleware
             startable.Start();
         }
     }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(StartableMiddleware);
 }

--- a/src/Autofac/Diagnostics/AutofacMetrics.cs
+++ b/src/Autofac/Diagnostics/AutofacMetrics.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Autofac.Diagnostics;
+
+/// <summary>
+/// Centralized metrics wiring for Autofac diagnostics.
+/// </summary>
+internal static class AutofacMetrics
+{
+    private const string DiagnosticsEnvironmentVariable = "AUTOFAC_METRICS";
+
+    static AutofacMetrics()
+    {
+        MetricsEnabled = IsEnabled(DiagnosticsEnvironmentVariable);
+        if (!MetricsEnabled)
+        {
+            return;
+        }
+
+        DiagnosticsMeter = new Meter("autofac", "1.0.0");
+
+        CollectionBuildDuration = DiagnosticsMeter.CreateHistogram<double>(
+            name: "autofac.collection.build.duration",
+            unit: "s",
+            description: "Time spent materializing implicit collection services.");
+        CollectionBuildCount = DiagnosticsMeter.CreateCounter<long>(
+            name: "autofac.collection.build.count",
+            description: "Number of implicit collection builds performed.");
+        CollectionItemCount = DiagnosticsMeter.CreateCounter<long>(
+            name: "autofac.collection.build.items",
+            description: "Total number of elements added to implicit collections.");
+
+        LockContentionDuration = DiagnosticsMeter.CreateHistogram<double>(
+            name: "autofac.lock.contention.duration",
+            unit: "s",
+            description: "Time threads waited to enter Autofac locks, broken down by category/detail.");
+        LockContentionCount = DiagnosticsMeter.CreateCounter<long>(
+            name: "autofac.lock.contention.count",
+            description: "Number of lock contention events observed in Autofac.");
+        LockContentionTotalTime = DiagnosticsMeter.CreateCounter<double>(
+            name: "autofac.lock.contention.total_time",
+            unit: "s",
+            description: "Total time spent waiting on Autofac locks.");
+
+        PropertyInjectionDuration = DiagnosticsMeter.CreateHistogram<double>(
+            name: "autofac.property.injection.duration",
+            unit: "s",
+            description: "Time spent performing property injection.");
+        PropertyInjectionCount = DiagnosticsMeter.CreateCounter<long>(
+            name: "autofac.property.injection.count",
+            description: "Number of instances that had property injection applied.");
+        PropertyInjectionAssignments = DiagnosticsMeter.CreateCounter<long>(
+            name: "autofac.property.injection.assignments",
+            description: "Number of individual property assignments performed.");
+
+        ReflectionActivationDuration = DiagnosticsMeter.CreateHistogram<double>(
+            name: "autofac.reflection.activation.duration",
+            unit: "s",
+            description: "Time spent activating components via ReflectionActivator.");
+
+        MiddlewareExecutionDuration = DiagnosticsMeter.CreateHistogram<double>(
+            name: "autofac.middleware.duration",
+            unit: "s",
+            description: "Time spent executing Autofac resolve pipeline middleware.");
+        MiddlewareExecutionCount = DiagnosticsMeter.CreateCounter<long>(
+            name: "autofac.middleware.count",
+            description: "Number of resolve pipeline middleware executions.");
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether diagnostics metrics are enabled.
+    /// </summary>
+    public static bool MetricsEnabled { get; }
+
+    /// <summary>
+    /// Gets the underlying diagnostics meter.
+    /// </summary>
+    public static Meter? DiagnosticsMeter { get; }
+
+    /// <summary>
+    /// Gets the histogram tracking lock contention duration.
+    /// </summary>
+    public static Histogram<double>? LockContentionDuration { get; }
+
+    /// <summary>
+    /// Gets the counter tracking the number of lock contention events.
+    /// </summary>
+    public static Counter<long>? LockContentionCount { get; }
+
+    /// <summary>
+    /// Gets the counter accumulating total lock wait time.
+    /// </summary>
+    public static Counter<double>? LockContentionTotalTime { get; }
+
+    /// <summary>
+    /// Gets the histogram tracking implicit collection build durations.
+    /// </summary>
+    public static Histogram<double>? CollectionBuildDuration { get; }
+
+    /// <summary>
+    /// Gets the counter measuring how many collections were materialized.
+    /// </summary>
+    public static Counter<long>? CollectionBuildCount { get; }
+
+    /// <summary>
+    /// Gets the counter measuring how many items were added across all collections.
+    /// </summary>
+    public static Counter<long>? CollectionItemCount { get; }
+
+    /// <summary>
+    /// Gets the histogram tracking property injection durations.
+    /// </summary>
+    public static Histogram<double>? PropertyInjectionDuration { get; }
+
+    /// <summary>
+    /// Gets the counter measuring how many instances had property injection.
+    /// </summary>
+    public static Counter<long>? PropertyInjectionCount { get; }
+
+    /// <summary>
+    /// Gets the counter tracking the number of property assignments performed.
+    /// </summary>
+    public static Counter<long>? PropertyInjectionAssignments { get; }
+
+    /// <summary>
+    /// Gets the histogram tracking reflection activator durations.
+    /// </summary>
+    public static Histogram<double>? ReflectionActivationDuration { get; }
+
+    /// <summary>
+    /// Gets the histogram tracking middleware execution duration.
+    /// </summary>
+    public static Histogram<double>? MiddlewareExecutionDuration { get; }
+
+    /// <summary>
+    /// Gets the counter tracking how many middleware executions occurred.
+    /// </summary>
+    public static Counter<long>? MiddlewareExecutionCount { get; }
+
+    /// <summary>
+    /// Records a collection build event.
+    /// </summary>
+    /// <param name="kind">The kind of collection (e.g., standard, any-keyed).</param>
+    /// <param name="detail">Additional detail such as the service description.</param>
+    /// <param name="itemCount">The number of elements added to the collection.</param>
+    /// <param name="elapsedTicks">The elapsed stopwatch ticks for the build.</param>
+    public static void RecordCollectionBuild(string kind, string? detail, int itemCount, long elapsedTicks)
+    {
+        if (!MetricsEnabled || CollectionBuildDuration is null || elapsedTicks <= 0)
+        {
+            return;
+        }
+
+        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
+        var tags = new TagList
+        {
+            { "autofac.collection.kind", kind },
+            { "autofac.collection.detail", detail ?? "<null>" },
+        };
+
+        CollectionBuildDuration.Record(seconds, tags);
+        CollectionBuildCount?.Add(1, tags);
+        CollectionItemCount?.Add(itemCount, tags);
+    }
+
+    /// <summary>
+    /// Records a property injection event.
+    /// </summary>
+    /// <param name="instanceType">The concrete instance type.</param>
+    /// <param name="inspectedProperties">The number of properties evaluated for injection.</param>
+    /// <param name="assignedProperties">The number of properties that were assigned.</param>
+    /// <param name="elapsedTicks">The elapsed stopwatch ticks for the injection.</param>
+    public static void RecordPropertyInjection(Type instanceType, int inspectedProperties, int assignedProperties, long elapsedTicks)
+    {
+        if (!MetricsEnabled || PropertyInjectionDuration is null || elapsedTicks <= 0)
+        {
+            return;
+        }
+
+        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
+        var tags = new TagList
+        {
+            { "autofac.property.type", instanceType.FullName ?? instanceType.Name },
+            { "autofac.property.inspected", inspectedProperties },
+        };
+
+        PropertyInjectionDuration.Record(seconds, tags);
+        PropertyInjectionCount?.Add(1, tags);
+        PropertyInjectionAssignments?.Add(assignedProperties, tags);
+    }
+
+    /// <summary>
+    /// Records a reflection-based activation event.
+    /// </summary>
+    /// <param name="implementationType">The activated implementation type.</param>
+    /// <param name="elapsedTicks">The elapsed stopwatch ticks for activation.</param>
+    public static void RecordReflectionActivation(Type implementationType, long elapsedTicks)
+    {
+        if (!MetricsEnabled || ReflectionActivationDuration is null || elapsedTicks <= 0)
+        {
+            return;
+        }
+
+        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
+        var tags = new TagList
+        {
+            { "autofac.reflection.type", implementationType.FullName ?? implementationType.Name },
+        };
+
+        ReflectionActivationDuration.Record(seconds, tags);
+    }
+
+    /// <summary>
+    /// Records the wait duration for a lock contention event.
+    /// </summary>
+    /// <param name="category">The lock category (e.g., service or lifetime scope).</param>
+    /// <param name="detail">Additional details about the lock, if any.</param>
+    /// <param name="elapsedTicks">The time spent waiting, in stopwatch ticks.</param>
+    public static void RecordLockContention(string category, string? detail, long elapsedTicks)
+    {
+        if (!MetricsEnabled || LockContentionDuration is null || elapsedTicks <= 0)
+        {
+            return;
+        }
+
+        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
+        var tags = new TagList
+        {
+            { "autofac.lock.category", category },
+            { "autofac.lock.detail", detail ?? "<null>" },
+        };
+
+        LockContentionDuration.Record(seconds, tags);
+        LockContentionCount?.Add(1, tags);
+        LockContentionTotalTime?.Add(seconds, tags);
+    }
+
+    /// <summary>
+    /// Records a resolve pipeline middleware execution event.
+    /// </summary>
+    /// <param name="middlewareName">The middleware name.</param>
+    /// <param name="elapsedTicks">The elapsed stopwatch ticks for the execution.</param>
+    public static void RecordMiddlewareExecution(string middlewareName, long elapsedTicks)
+    {
+        if (!MetricsEnabled || MiddlewareExecutionDuration is null || elapsedTicks <= 0)
+        {
+            return;
+        }
+
+        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
+        var tags = new TagList
+        {
+            { "autofac.middleware.name", middlewareName },
+        };
+
+        MiddlewareExecutionDuration.Record(seconds, tags);
+        MiddlewareExecutionCount?.Add(1, tags);
+    }
+
+    private static bool IsEnabled(string variableName)
+    {
+        var envValue = Environment.GetEnvironmentVariable(variableName);
+        return string.Equals(envValue, "1", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(envValue, "true", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Autofac/Diagnostics/AutofacMetrics.cs
+++ b/src/Autofac/Diagnostics/AutofacMetrics.cs
@@ -9,6 +9,7 @@ namespace Autofac.Diagnostics;
 /// <summary>
 /// Centralized metrics wiring for Autofac diagnostics.
 /// </summary>
+[ExcludeFromCodeCoverage]
 internal static class AutofacMetrics
 {
     private const string DiagnosticsEnvironmentVariable = "AUTOFAC_METRICS";

--- a/src/Autofac/Diagnostics/AutofacMetrics.cs
+++ b/src/Autofac/Diagnostics/AutofacMetrics.cs
@@ -213,10 +213,17 @@ internal static class AutofacMetrics
     }
 
     /// <summary>
-    /// Records the wait duration for a lock contention event.
+    /// Records the wait duration for a lock contention event. This may include
+    /// time spent waiting as well as acquiring the lock, but will be closely
+    /// correlated with contention time.
     /// </summary>
     /// <param name="category">The lock category (e.g., service or lifetime scope).</param>
-    /// <param name="detail">Additional details about the lock, if any.</param>
+    /// <param name="detail">
+    /// Additional details about the lock, if any. Note this will likely
+    /// generate high-cardinality metrics in a production environment since it
+    /// will track information about services and lifetime scopes acquiring
+    /// locks and include identities for each.
+    /// </param>
     /// <param name="elapsed">The time spent waiting.</param>
     public static void RecordLockContention(string category, string? detail, TimeSpan elapsed)
     {

--- a/src/Autofac/Diagnostics/AutofacMetrics.cs
+++ b/src/Autofac/Diagnostics/AutofacMetrics.cs
@@ -147,22 +147,21 @@ internal static class AutofacMetrics
     /// <param name="kind">The kind of collection (e.g., standard, any-keyed).</param>
     /// <param name="detail">Additional detail such as the service description.</param>
     /// <param name="itemCount">The number of elements added to the collection.</param>
-    /// <param name="elapsedTicks">The elapsed stopwatch ticks for the build.</param>
-    public static void RecordCollectionBuild(string kind, string? detail, int itemCount, long elapsedTicks)
+    /// <param name="elapsed">The elapsed time for the build.</param>
+    public static void RecordCollectionBuild(string kind, string? detail, int itemCount, TimeSpan elapsed)
     {
-        if (!MetricsEnabled || CollectionBuildDuration is null || elapsedTicks <= 0)
+        if (!MetricsEnabled || CollectionBuildDuration is null || elapsed <= TimeSpan.Zero)
         {
             return;
         }
 
-        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
         var tags = new TagList
         {
             { "autofac.collection.kind", kind },
             { "autofac.collection.detail", detail ?? "<null>" },
         };
 
-        CollectionBuildDuration.Record(seconds, tags);
+        CollectionBuildDuration.Record(elapsed.TotalSeconds, tags);
         CollectionBuildCount?.Add(1, tags);
         CollectionItemCount?.Add(itemCount, tags);
     }
@@ -173,22 +172,21 @@ internal static class AutofacMetrics
     /// <param name="instanceType">The concrete instance type.</param>
     /// <param name="inspectedProperties">The number of properties evaluated for injection.</param>
     /// <param name="assignedProperties">The number of properties that were assigned.</param>
-    /// <param name="elapsedTicks">The elapsed stopwatch ticks for the injection.</param>
-    public static void RecordPropertyInjection(Type instanceType, int inspectedProperties, int assignedProperties, long elapsedTicks)
+    /// <param name="elapsed">The elapsed time for the injection.</param>
+    public static void RecordPropertyInjection(Type instanceType, int inspectedProperties, int assignedProperties, TimeSpan elapsed)
     {
-        if (!MetricsEnabled || PropertyInjectionDuration is null || elapsedTicks <= 0)
+        if (!MetricsEnabled || PropertyInjectionDuration is null || elapsed <= TimeSpan.Zero)
         {
             return;
         }
 
-        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
         var tags = new TagList
         {
             { "autofac.property.type", instanceType.FullName ?? instanceType.Name },
             { "autofac.property.inspected", inspectedProperties },
         };
 
-        PropertyInjectionDuration.Record(seconds, tags);
+        PropertyInjectionDuration.Record(elapsed.TotalSeconds, tags);
         PropertyInjectionCount?.Add(1, tags);
         PropertyInjectionAssignments?.Add(assignedProperties, tags);
     }
@@ -197,21 +195,20 @@ internal static class AutofacMetrics
     /// Records a reflection-based activation event.
     /// </summary>
     /// <param name="implementationType">The activated implementation type.</param>
-    /// <param name="elapsedTicks">The elapsed stopwatch ticks for activation.</param>
-    public static void RecordReflectionActivation(Type implementationType, long elapsedTicks)
+    /// <param name="elapsed">The elapsed time for activation.</param>
+    public static void RecordReflectionActivation(Type implementationType, TimeSpan elapsed)
     {
-        if (!MetricsEnabled || ReflectionActivationDuration is null || elapsedTicks <= 0)
+        if (!MetricsEnabled || ReflectionActivationDuration is null || elapsed <= TimeSpan.Zero)
         {
             return;
         }
 
-        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
         var tags = new TagList
         {
             { "autofac.reflection.type", implementationType.FullName ?? implementationType.Name },
         };
 
-        ReflectionActivationDuration.Record(seconds, tags);
+        ReflectionActivationDuration.Record(elapsed.TotalSeconds, tags);
     }
 
     /// <summary>
@@ -219,45 +216,43 @@ internal static class AutofacMetrics
     /// </summary>
     /// <param name="category">The lock category (e.g., service or lifetime scope).</param>
     /// <param name="detail">Additional details about the lock, if any.</param>
-    /// <param name="elapsedTicks">The time spent waiting, in stopwatch ticks.</param>
-    public static void RecordLockContention(string category, string? detail, long elapsedTicks)
+    /// <param name="elapsed">The time spent waiting.</param>
+    public static void RecordLockContention(string category, string? detail, TimeSpan elapsed)
     {
-        if (!MetricsEnabled || LockContentionDuration is null || elapsedTicks <= 0)
+        if (!MetricsEnabled || LockContentionDuration is null || elapsed <= TimeSpan.Zero)
         {
             return;
         }
 
-        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
         var tags = new TagList
         {
             { "autofac.lock.category", category },
             { "autofac.lock.detail", detail ?? "<null>" },
         };
 
-        LockContentionDuration.Record(seconds, tags);
+        LockContentionDuration.Record(elapsed.TotalSeconds, tags);
         LockContentionCount?.Add(1, tags);
-        LockContentionTotalTime?.Add(seconds, tags);
+        LockContentionTotalTime?.Add(elapsed.TotalSeconds, tags);
     }
 
     /// <summary>
     /// Records a resolve pipeline middleware execution event.
     /// </summary>
     /// <param name="middlewareName">The middleware name.</param>
-    /// <param name="elapsedTicks">The elapsed stopwatch ticks for the execution.</param>
-    public static void RecordMiddlewareExecution(string middlewareName, long elapsedTicks)
+    /// <param name="elapsed">The elapsed time for the execution.</param>
+    public static void RecordMiddlewareExecution(string middlewareName, TimeSpan elapsed)
     {
-        if (!MetricsEnabled || MiddlewareExecutionDuration is null || elapsedTicks <= 0)
+        if (!MetricsEnabled || MiddlewareExecutionDuration is null || elapsed <= TimeSpan.Zero)
         {
             return;
         }
 
-        var seconds = elapsedTicks / (double)Stopwatch.Frequency;
         var tags = new TagList
         {
             { "autofac.middleware.name", middlewareName },
         };
 
-        MiddlewareExecutionDuration.Record(seconds, tags);
+        MiddlewareExecutionDuration.Record(elapsed.TotalSeconds, tags);
         MiddlewareExecutionCount?.Add(1, tags);
     }
 

--- a/src/Autofac/Diagnostics/ValueStopwatch.cs
+++ b/src/Autofac/Diagnostics/ValueStopwatch.cs
@@ -1,15 +1,22 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+// Original version from https://github.com/dotnet/aspnetcore/blob/main/src/Shared/ValueStopwatch/ValueStopwatch.cs
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 using System.Diagnostics;
 
 namespace Autofac.Diagnostics;
 
 /// <summary>
-/// Lightweight stopwatch with no heap allocations.
+/// Lightweight stopwatch for timing without heap allocations.
 /// </summary>
-internal readonly struct ValueStopwatch
+internal struct ValueStopwatch
 {
+#if !NET7_0_OR_GREATER
+    private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+#endif
+
     private readonly long _startTimestamp;
 
     private ValueStopwatch(long startTimestamp)
@@ -18,29 +25,48 @@ internal readonly struct ValueStopwatch
     }
 
     /// <summary>
-    /// Gets the number of elapsed ticks.
+    /// Gets a value indicating whether the stopwatch has been started.
     /// </summary>
-    public long ElapsedTicks
-    {
-        get
-        {
-            if (_startTimestamp == 0)
-            {
-                return 0;
-            }
-
-            return Stopwatch.GetTimestamp() - _startTimestamp;
-        }
-    }
-
-    /// <summary>
-    /// Gets the elapsed duration in milliseconds.
-    /// </summary>
-    public double ElapsedMilliseconds => ElapsedTicks * 1000.0 / Stopwatch.Frequency;
+    public bool IsActive => _startTimestamp != 0;
 
     /// <summary>
     /// Starts a new stopwatch instance.
     /// </summary>
     /// <returns>A running <see cref="ValueStopwatch"/>.</returns>
-    public static ValueStopwatch StartNew() => new(Stopwatch.GetTimestamp());
+    public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+    /// <summary>
+    /// Computes elapsed time between two timestamps captured from <see cref="Stopwatch.GetTimestamp"/>.
+    /// </summary>
+    /// <param name="startingTimestamp">The starting timestamp.</param>
+    /// <param name="endingTimestamp">The ending timestamp.</param>
+    /// <returns>The elapsed time between the timestamps.</returns>
+    public static TimeSpan GetElapsedTime(long startingTimestamp, long endingTimestamp)
+    {
+#if !NET7_0_OR_GREATER
+        var timestampDelta = endingTimestamp - startingTimestamp;
+        var ticks = (long)(TimestampToTicks * timestampDelta);
+        return new TimeSpan(ticks);
+#else
+        return Stopwatch.GetElapsedTime(startingTimestamp, endingTimestamp);
+#endif
+    }
+
+    /// <summary>
+    /// Gets the elapsed time since the stopwatch started.
+    /// </summary>
+    /// <returns>The elapsed time.</returns>
+    public TimeSpan GetElapsedTime()
+    {
+        // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be literally the first thing executed when the machine boots to be 0.
+        // So it being 0 is a clear indication of default(ValueStopwatch)
+        if (!IsActive)
+        {
+            throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+        }
+
+        var end = Stopwatch.GetTimestamp();
+
+        return GetElapsedTime(_startTimestamp, end);
+    }
 }

--- a/src/Autofac/Diagnostics/ValueStopwatch.cs
+++ b/src/Autofac/Diagnostics/ValueStopwatch.cs
@@ -11,6 +11,7 @@ namespace Autofac.Diagnostics;
 /// <summary>
 /// Lightweight stopwatch for timing without heap allocations.
 /// </summary>
+[ExcludeFromCodeCoverage]
 internal struct ValueStopwatch
 {
 #if !NET7_0_OR_GREATER

--- a/src/Autofac/Diagnostics/ValueStopwatch.cs
+++ b/src/Autofac/Diagnostics/ValueStopwatch.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Autofac.Diagnostics;
+
+/// <summary>
+/// Lightweight stopwatch with no heap allocations.
+/// </summary>
+internal readonly struct ValueStopwatch
+{
+    private readonly long _startTimestamp;
+
+    private ValueStopwatch(long startTimestamp)
+    {
+        _startTimestamp = startTimestamp;
+    }
+
+    /// <summary>
+    /// Gets the number of elapsed ticks.
+    /// </summary>
+    public long ElapsedTicks
+    {
+        get
+        {
+            if (_startTimestamp == 0)
+            {
+                return 0;
+            }
+
+            return Stopwatch.GetTimestamp() - _startTimestamp;
+        }
+    }
+
+    /// <summary>
+    /// Gets the elapsed duration in milliseconds.
+    /// </summary>
+    public double ElapsedMilliseconds => ElapsedTicks * 1000.0 / Stopwatch.Frequency;
+
+    /// <summary>
+    /// Starts a new stopwatch instance.
+    /// </summary>
+    /// <returns>A running <see cref="ValueStopwatch"/>.</returns>
+    public static ValueStopwatch StartNew() => new(Stopwatch.GetTimestamp());
+}

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -8,6 +8,7 @@ using Autofac.Core;
 using Autofac.Core.Activators.Delegate;
 using Autofac.Core.Lifetime;
 using Autofac.Core.Registration;
+using Autofac.Diagnostics;
 using Autofac.Features.Decorators;
 using Autofac.Util;
 using Autofac.Util.Cache;
@@ -124,7 +125,11 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
                         .ConvertAll(static tuple => ((Service)tuple.KeyedService, tuple.Registration))
                     : BuildStandardRegistrationList(c.ComponentRegistry, elementTypeService);
 
-                return BuildCollection(c, factory, registrationTuples, p);
+                var collectionKind = isAnyKeyQuery ? "any-keyed" : "standard";
+                var collectionDetail = isAnyKeyQuery
+                    ? elementType.FullName ?? elementType.Name
+                    : elementTypeService.ToString() ?? elementTypeService.GetType().Name;
+                return BuildCollection(c, factory, registrationTuples, p, collectionKind, collectionDetail);
             });
 
         var registration = new ComponentRegistration(
@@ -237,8 +242,17 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
         IComponentContext context,
         Func<int, IList> factory,
         List<(Service Service, ServiceRegistration Registration)> registrations,
-        IEnumerable<Parameter> parameters)
+        IEnumerable<Parameter> parameters,
+        string collectionKind,
+        string collectionDetail)
     {
+        var recordMetrics = AutofacMetrics.MetricsEnabled;
+        ValueStopwatch instrumentationTimer = default;
+        if (recordMetrics)
+        {
+            instrumentationTimer = ValueStopwatch.StartNew();
+        }
+
         var output = factory(registrations.Count);
         var isFixedSize = output.IsFixedSize;
 
@@ -256,6 +270,15 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
             {
                 output.Add(component);
             }
+        }
+
+        if (recordMetrics)
+        {
+            AutofacMetrics.RecordCollectionBuild(
+                kind: collectionKind,
+                detail: collectionDetail,
+                itemCount: registrations.Count,
+                elapsedTicks: instrumentationTimer.ElapsedTicks);
         }
 
         return output;

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -125,10 +125,17 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
                         .ConvertAll(static tuple => ((Service)tuple.KeyedService, tuple.Registration))
                     : BuildStandardRegistrationList(c.ComponentRegistry, elementTypeService);
 
-                var collectionKind = isAnyKeyQuery ? "any-keyed" : "standard";
-                var collectionDetail = isAnyKeyQuery
-                    ? elementType.FullName ?? elementType.Name
-                    : elementTypeService.ToString() ?? elementTypeService.GetType().Name;
+                string? collectionKind = null;
+                string? collectionDetail = null;
+                if (AutofacMetrics.MetricsEnabled)
+                {
+                    // The collection kind and detail are only used in recording metrics.
+                    collectionKind = isAnyKeyQuery ? "any-keyed" : "standard";
+                    collectionDetail = isAnyKeyQuery
+                        ? elementType.FullName ?? elementType.Name
+                        : elementTypeService.ToString() ?? elementTypeService.GetType().Name;
+                }
+
                 return BuildCollection(c, factory, registrationTuples, p, collectionKind, collectionDetail);
             });
 
@@ -243,9 +250,10 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
         Func<int, IList> factory,
         List<(Service Service, ServiceRegistration Registration)> registrations,
         IEnumerable<Parameter> parameters,
-        string collectionKind,
-        string collectionDetail)
+        string? collectionKind,
+        string? collectionDetail)
     {
+        // Collection kind and detail will be null unless metrics are enabled.
         var recordMetrics = AutofacMetrics.MetricsEnabled;
         ValueStopwatch instrumentationTimer = default;
         if (recordMetrics)
@@ -275,7 +283,7 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
         if (recordMetrics)
         {
             AutofacMetrics.RecordCollectionBuild(
-                kind: collectionKind,
+                kind: collectionKind!,
                 detail: collectionDetail,
                 itemCount: registrations.Count,
                 elapsed: instrumentationTimer.GetElapsedTime());

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -278,7 +278,7 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
                 kind: collectionKind,
                 detail: collectionDetail,
                 itemCount: registrations.Count,
-                elapsedTicks: instrumentationTimer.ElapsedTicks);
+                elapsed: instrumentationTimer.GetElapsedTime());
         }
 
         return output;

--- a/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
+++ b/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Diagnostics;
 using Autofac.Core;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving;
 using Autofac.Core.Resolving.Pipeline;
+using Autofac.Diagnostics;
 
 namespace Autofac.Features.Decorators;
 
@@ -32,6 +34,28 @@ internal class DecoratorMiddleware : IResolveMiddleware
 
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    {
+        if (!AutofacMetrics.MetricsEnabled)
+        {
+            ExecuteCore(context, next);
+            return;
+        }
+
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            ExecuteCore(context, next);
+        }
+        finally
+        {
+            AutofacMetrics.RecordMiddlewareExecution(nameof(DecoratorMiddleware), Stopwatch.GetTimestamp() - start);
+        }
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(DecoratorMiddleware) + " [" + _decoratorRegistration.Activator.LimitType.Name + "]";
+
+    private void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         // Go down the pipeline first, need that instance.
         next(context);
@@ -128,7 +152,4 @@ internal class DecoratorMiddleware : IResolveMiddleware
             context.Instance = decoratedInstance;
         }
     }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(DecoratorMiddleware) + " [" + _decoratorRegistration.Activator.LimitType.Name + "]";
 }

--- a/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
+++ b/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Diagnostics;
 using Autofac.Core;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving;
@@ -41,14 +40,14 @@ internal class DecoratorMiddleware : IResolveMiddleware
             return;
         }
 
-        var start = Stopwatch.GetTimestamp();
+        var timer = ValueStopwatch.StartNew();
         try
         {
             ExecuteCore(context, next);
         }
         finally
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(DecoratorMiddleware), Stopwatch.GetTimestamp() - start);
+            AutofacMetrics.RecordMiddlewareExecution(nameof(DecoratorMiddleware), timer.GetElapsedTime());
         }
     }
 


### PR DESCRIPTION
This adds some metrics to Autofac that can be enabled by setting the environment variable `AUTOFAC_METRICS` to `1` or `true`. Doing this will enable counters that indicate how long various things like middleware and operations take as well as information on lock contentions.

The benchmarking project has also been updated to more easily be run so it can compare the current source branch against a baseline version by specifying a released NuGet version of Autofac as a comparison.