### PR TITLE
Performance improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,4 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup>
-    <NuGetAudit>false</NuGetAudit>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,4 +3,7 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup>
+    <NuGetAudit>false</NuGetAudit>
+  </PropertyGroup>
 </Project>

--- a/bench/Autofac.Benchmarks/BenchmarkSet.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkSet.cs
@@ -13,6 +13,7 @@ public static class BenchmarkSet
         typeof(ConcurrencyBenchmark),
         typeof(ConcurrencyNestedScopeBenchmark),
         typeof(KeyedGenericBenchmark),
+        typeof(KeyedAnyKeyBenchmark),
         typeof(KeyedNestedBenchmark),
         typeof(KeyedSimpleBenchmark),
         typeof(KeylessGenericBenchmark),

--- a/bench/Autofac.Benchmarks/BenchmarkSet.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkSet.cs
@@ -13,7 +13,7 @@ public static class BenchmarkSet
         typeof(ConcurrencyBenchmark),
         typeof(ConcurrencyNestedScopeBenchmark),
         typeof(KeyedGenericBenchmark),
-        typeof(KeyedAnyKeyBenchmark),
+        typeof(KeyedAnyKeySimpleBenchmark),
         typeof(KeyedNestedBenchmark),
         typeof(KeyedSimpleBenchmark),
         typeof(KeylessGenericBenchmark),

--- a/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
+++ b/bench/Autofac.Benchmarks/Decorators/DecoratorBenchmarkBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Autofac.Benchmarks.Decorators;
 
 public abstract class DecoratorBenchmarkBase<TCommandHandler>

--- a/bench/Autofac.Benchmarks/Decorators/KeyedAnyKeyBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeyedAnyKeyBenchmark.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Benchmarks.Decorators.Scenario;
+using Autofac.Core;
+
+namespace Autofac.Benchmarks.Decorators;
+
+/// <summary>
+/// Benchmarks keyed decorators when components are registered with AnyKey.
+/// </summary>
+public class KeyedAnyKeyBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+{
+    [GlobalSetup]
+    public void Setup()
+    {
+        var builder = new ContainerBuilder();
+
+        builder.RegisterType<CommandHandlerOne>()
+            .Keyed<ICommandHandler>(KeyedService.AnyKey);
+        builder.RegisterType<CommandHandlerTwo>()
+            .Keyed<ICommandHandler>(KeyedService.AnyKey);
+        builder.RegisterDecorator<ICommandHandler>(
+            (c, inner) => new CommandHandlerDecoratorOne(inner),
+            fromKey: "handler");
+
+        Container = builder.Build();
+    }
+}

--- a/bench/Autofac.Benchmarks/Decorators/KeyedAnyKeySimpleBenchmark.cs
+++ b/bench/Autofac.Benchmarks/Decorators/KeyedAnyKeySimpleBenchmark.cs
@@ -9,7 +9,7 @@ namespace Autofac.Benchmarks.Decorators;
 /// <summary>
 /// Benchmarks keyed decorators when components are registered with AnyKey.
 /// </summary>
-public class KeyedAnyKeyBenchmark : DecoratorBenchmarkBase<ICommandHandler>
+public class KeyedAnyKeySimpleBenchmark : DecoratorBenchmarkBase<ICommandHandler>
 {
     [GlobalSetup]
     public void Setup()

--- a/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
+++ b/src/Autofac/Core/Activators/Reflection/ReflectionActivator.cs
@@ -228,7 +228,11 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
                 var instance = boundConstructor.Instantiate();
 
-                InjectProperties(instance, context, boundConstructor, GetAllParameters(context.Parameters));
+                if (ShouldInjectProperties(boundConstructor))
+                {
+                    var prioritizedParameters = GetAllParameters(context.Parameters);
+                    InjectProperties(instance, context, boundConstructor, prioritizedParameters);
+                }
 
                 context.Instance = instance;
 
@@ -422,20 +426,12 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
 
     private void InjectProperties(object instance, IComponentContext context, BoundConstructor constructor, IEnumerable<Parameter> allParameters)
     {
-        // We only need to do any injection if we have a set of property information.
-        if (_defaultFoundPropertySet is null)
+        if (!ShouldInjectProperties(constructor))
         {
             return;
         }
 
-        // If this constructor sets all required members,
-        // and we have no configured properties, we can just jump out.
-        if (_configuredProperties.Length == 0 && constructor.SetsRequiredMembers)
-        {
-            return;
-        }
-
-        var workingSetOfProperties = (InjectablePropertyState[])_defaultFoundPropertySet.Clone();
+        var workingSetOfProperties = (InjectablePropertyState[])_defaultFoundPropertySet!.Clone();
 
         foreach (var configuredProperty in _configuredProperties)
         {
@@ -507,6 +503,16 @@ public class ReflectionActivator : InstanceActivator, IInstanceActivator
                 throw new DependencyResolutionException(BuildRequiredPropertyResolutionMessage(failingRequiredProperties));
             }
         }
+    }
+
+    private bool ShouldInjectProperties(BoundConstructor constructor)
+    {
+        if (_defaultFoundPropertySet is null)
+        {
+            return false;
+        }
+
+        return _configuredProperties.Length != 0 || !constructor.SetsRequiredMembers;
     }
 
     private string BuildRequiredPropertyResolutionMessage(IReadOnlyList<InjectableProperty> failingRequiredProperties)

--- a/src/Autofac/Core/KeyedServiceParameterInjector.cs
+++ b/src/Autofac/Core/KeyedServiceParameterInjector.cs
@@ -132,6 +132,21 @@ internal static class KeyedServiceParameterInjector
             return new Parameter[] { keyParameter };
         }
 
+        // Build a concrete array to avoid LINQ AppendIterator allocation.
+        if (parameters is IReadOnlyCollection<Parameter> collection)
+        {
+            var result = new Parameter[collection.Count + 1];
+            var i = 0;
+            foreach (var p in collection)
+            {
+                result[i++] = p;
+            }
+
+            result[i] = keyParameter;
+            return result;
+        }
+
+        // Fallback for unknown enumerable types.
         return parameters.Append(keyParameter);
     }
 }

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Threading;
 #if NET5_0_OR_GREATER
 using System.Runtime.Loader;
 #endif

--- a/src/Autofac/Core/ReflectionCacheSet.cs
+++ b/src/Autofac/Core/ReflectionCacheSet.cs
@@ -18,6 +18,8 @@ public sealed class ReflectionCacheSet
 
     private readonly ConcurrentDictionary<string, IReflectionCache> _caches = new();
 
+    private readonly List<WeakReference<IReflectionCache>> _externalCaches = new();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ReflectionCacheSet"/> class.
     /// </summary>
@@ -102,6 +104,26 @@ public sealed class ReflectionCacheSet
     }
 
     /// <summary>
+    /// Register an externally-owned <see cref="IReflectionCache"/> so it participates
+    /// in <see cref="Clear()"/> and <see cref="Clear(ReflectionCacheClearPredicate)"/> calls.
+    /// The cache is held via a weak reference so it does not prevent garbage collection
+    /// of the owning object (e.g., a container or registration source).
+    /// </summary>
+    /// <param name="cache">The cache to register.</param>
+    public void RegisterExternalCache(IReflectionCache cache)
+    {
+        if (cache is null)
+        {
+            throw new ArgumentNullException(nameof(cache));
+        }
+
+        lock (_externalCaches)
+        {
+            _externalCaches.Add(new WeakReference<IReflectionCache>(cache));
+        }
+    }
+
+    /// <summary>
     /// Clear the internal reflection cache. Only call this method if you are
     /// dynamically unloading types from the process; calling this method
     /// otherwise will only slow down Autofac during normal operation.
@@ -117,6 +139,8 @@ public sealed class ReflectionCacheSet
         {
             cache.Clear();
         }
+
+        ClearExternalCaches(static cache => cache.Clear());
     }
 
     /// <summary>
@@ -139,6 +163,8 @@ public sealed class ReflectionCacheSet
         {
             cache.Clear(predicate);
         }
+
+        ClearExternalCaches(cache => cache.Clear(predicate));
     }
 
     /// <summary>
@@ -171,6 +197,25 @@ public sealed class ReflectionCacheSet
         }
 
         return _sharedSet.TryGetTarget(out sharedCache);
+    }
+
+    private void ClearExternalCaches(Action<IReflectionCache> clearAction)
+    {
+        lock (_externalCaches)
+        {
+            for (var i = _externalCaches.Count - 1; i >= 0; i--)
+            {
+                if (_externalCaches[i].TryGetTarget(out var cache))
+                {
+                    clearAction(cache);
+                }
+                else
+                {
+                    // Prune dead references.
+                    _externalCaches.RemoveAt(i);
+                }
+            }
+        }
     }
 
     private IEnumerable<IReflectionCache> GetAllCaches()

--- a/src/Autofac/Core/Resolving/Middleware/ActivatorErrorHandlingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ActivatorErrorHandlingMiddleware.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -29,20 +28,23 @@ internal class ActivatorErrorHandlingMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
         try
         {
-            ExecuteCore(context, next);
+            next(context);
+
+            if (context.Instance is null)
+            {
+                // Exited the Activation Stage without creating an instance.
+                throw new DependencyResolutionException(MiddlewareMessages.ActivatorDidNotPopulateInstance);
+            }
         }
-        finally
+        catch (ObjectDisposedException)
         {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(ActivatorErrorHandlingMiddleware), timer.GetElapsedTime());
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw PropagateActivationException(context.Registration.Activator, ex);
         }
     }
 
@@ -64,27 +66,5 @@ internal class ActivatorErrorHandlingMiddleware : IResolveMiddleware
         var result = new DependencyResolutionException(string.Format(CultureInfo.CurrentCulture, ComponentActivationResources.ErrorDuringActivation, activatorChain), innerException);
         result.Data[ActivatorChainExceptionData] = activatorChain;
         return result;
-    }
-
-    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
-        try
-        {
-            next(context);
-
-            if (context.Instance is null)
-            {
-                // Exited the Activation Stage without creating an instance.
-                throw new DependencyResolutionException(MiddlewareMessages.ActivatorDidNotPopulateInstance);
-            }
-        }
-        catch (ObjectDisposedException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw PropagateActivationException(context.Registration.Activator, ex);
-        }
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CircularDependencyDetectorMiddleware.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -39,51 +38,6 @@ internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
 
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            ExecuteCore(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(CircularDependencyDetectorMiddleware), timer.GetElapsedTime());
-        }
-    }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(CircularDependencyDetectorMiddleware);
-
-    private static string CreateDependencyGraphTo(IComponentRegistration registration, IEnumerable<ResolveRequestContext> requestStack)
-    {
-        if (registration == null)
-        {
-            throw new ArgumentNullException(nameof(registration));
-        }
-
-        if (requestStack == null)
-        {
-            throw new ArgumentNullException(nameof(requestStack));
-        }
-
-        var dependencyGraph = Display(registration);
-
-        return requestStack.Select(a => a.Registration)
-            .Aggregate(dependencyGraph, (current, requestor) => Display(requestor) + " -> " + current);
-    }
-
-    private static string Display(IComponentRegistration registration)
-    {
-        return registration.Activator.DisplayName();
-    }
-
-    private void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         if (context.Operation is not IDependencyTrackingResolveOperation dependencyTrackingResolveOperation)
         {
@@ -140,5 +94,31 @@ internal class CircularDependencyDetectorMiddleware : IResolveMiddleware
         {
             requestStack.Pop();
         }
+    }
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(CircularDependencyDetectorMiddleware);
+
+    private static string CreateDependencyGraphTo(IComponentRegistration registration, IEnumerable<ResolveRequestContext> requestStack)
+    {
+        if (registration == null)
+        {
+            throw new ArgumentNullException(nameof(registration));
+        }
+
+        if (requestStack == null)
+        {
+            throw new ArgumentNullException(nameof(requestStack));
+        }
+
+        var dependencyGraph = Display(registration);
+
+        return requestStack.Select(a => a.Registration)
+            .Aggregate(dependencyGraph, (current, requestor) => Display(requestor) + " -> " + current);
+    }
+
+    private static string Display(IComponentRegistration registration)
+    {
+        return registration.Activator.DisplayName();
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/CoreEventMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -40,20 +39,6 @@ public class CoreEventMiddleware : IResolveMiddleware
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            _callback(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            _callback(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(ToString(), timer.GetElapsedTime());
-        }
+        _callback(context, next);
     }
 }

--- a/src/Autofac/Core/Resolving/Middleware/DelegateMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DelegateMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -33,21 +32,7 @@ internal class DelegateMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            _callback(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            _callback(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(ToString(), timer.GetElapsedTime());
-        }
+        _callback(context, next);
     }
 
     /// <inheritdoc />

--- a/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -27,28 +26,6 @@ internal class DisposalTrackingMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            ExecuteCore(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(DisposalTrackingMiddleware), timer.GetElapsedTime());
-        }
-    }
-
-    /// <inheritdoc />
-    public override string ToString() => nameof(DisposalTrackingMiddleware);
-
-    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
         next(context);
 
         if (context.Registration.Ownership == InstanceOwnership.OwnedByLifetimeScope)
@@ -67,4 +44,7 @@ internal class DisposalTrackingMiddleware : IResolveMiddleware
             }
         }
     }
+
+    /// <inheritdoc />
+    public override string ToString() => nameof(DisposalTrackingMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Middleware/RegistrationPipelineInvokeMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/RegistrationPipelineInvokeMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -26,21 +25,7 @@ internal class RegistrationPipelineInvokeMiddleware : IResolveMiddleware
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            context.Registration.ResolvePipeline.Invoke(context);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            context.Registration.ResolvePipeline.Invoke(context);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(RegistrationPipelineInvokeMiddleware), timer.GetElapsedTime());
-        }
+        context.Registration.ResolvePipeline.Invoke(context);
     }
 
     /// <inheritdoc/>

--- a/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/ScopeSelectionMiddleware.cs
@@ -4,7 +4,6 @@
 using System.Globalization;
 using System.Text;
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -21,35 +20,13 @@ internal class ScopeSelectionMiddleware : IResolveMiddleware
     /// <summary>
     /// Gets the singleton instance of the <see cref="ScopeSelectionMiddleware"/>.
     /// </summary>
-    public static ScopeSelectionMiddleware Instance => new();
+    public static ScopeSelectionMiddleware Instance { get; } = new ScopeSelectionMiddleware();
 
     /// <inheritdoc/>
     public PipelinePhase Phase => PipelinePhase.ScopeSelection;
 
     /// <inheritdoc/>
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            ExecuteCore(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(ScopeSelectionMiddleware), timer.GetElapsedTime());
-        }
-    }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(ScopeSelectionMiddleware);
-
-    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         try
         {
@@ -70,4 +47,7 @@ internal class ScopeSelectionMiddleware : IResolveMiddleware
 
         next(context);
     }
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(ScopeSelectionMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Middleware/SharingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/SharingMiddleware.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -21,28 +20,6 @@ internal class SharingMiddleware : IResolveMiddleware
 
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            ExecuteCore(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(SharingMiddleware), timer.GetElapsedTime());
-        }
-    }
-
-    /// <inheritdoc />
-    public override string ToString() => nameof(SharingMiddleware);
-
-    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         var registration = context.Registration;
         var decoratorRegistration = context.DecoratorTarget;
@@ -78,4 +55,7 @@ internal class SharingMiddleware : IResolveMiddleware
             }
         }
     }
+
+    /// <inheritdoc />
+    public override string ToString() => nameof(SharingMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/StartableMiddleware.cs
@@ -3,7 +3,6 @@
 
 using Autofac.Builder;
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Core.Resolving.Middleware;
 
@@ -27,28 +26,6 @@ internal class StartableMiddleware : IResolveMiddleware
     /// <inheritdoc />
     public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            ExecuteCore(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(StartableMiddleware), timer.GetElapsedTime());
-        }
-    }
-
-    /// <inheritdoc/>
-    public override string ToString() => nameof(StartableMiddleware);
-
-    private static void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
         next(context);
 
         if (context.Instance is IStartable startable
@@ -62,4 +39,7 @@ internal class StartableMiddleware : IResolveMiddleware
             startable.Start();
         }
     }
+
+    /// <inheritdoc/>
+    public override string ToString() => nameof(StartableMiddleware);
 }

--- a/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
+++ b/src/Autofac/Core/Resolving/Pipeline/ResolvePipelineBuilder.cs
@@ -210,6 +210,61 @@ internal class ResolvePipelineBuilder : IResolvePipelineBuilder, IEnumerable<IRe
         {
             var stagePhase = stage.Phase;
 
+            // MetricsEnabled is static readonly (set once at startup), so checking here
+            // at pipeline build time avoids a per-invocation branch in every middleware.
+            if (AutofacMetrics.MetricsEnabled)
+            {
+                var stageName = stage.ToString()!;
+
+                return (context) =>
+                {
+                    if (context.DiagnosticSource.IsEnabled())
+                    {
+                        context.DiagnosticSource.MiddlewareStart(context, stage);
+                        var succeeded = false;
+                        try
+                        {
+                            context.PhaseReached = stagePhase;
+                            var timer = ValueStopwatch.StartNew();
+                            try
+                            {
+                                stage.Execute(context, next);
+                            }
+                            finally
+                            {
+                                AutofacMetrics.RecordMiddlewareExecution(stageName, timer.GetElapsedTime());
+                            }
+
+                            succeeded = true;
+                        }
+                        finally
+                        {
+                            if (succeeded)
+                            {
+                                context.DiagnosticSource.MiddlewareSuccess(context, stage);
+                            }
+                            else
+                            {
+                                context.DiagnosticSource.MiddlewareFailure(context, stage);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        context.PhaseReached = stagePhase;
+                        var timer = ValueStopwatch.StartNew();
+                        try
+                        {
+                            stage.Execute(context, next);
+                        }
+                        finally
+                        {
+                            AutofacMetrics.RecordMiddlewareExecution(stageName, timer.GetElapsedTime());
+                        }
+                    }
+                };
+            }
+
             return (context) =>
             {
                 // Same basic flow in if/else, but doing a one-time check for diagnostics

--- a/src/Autofac/Core/Resolving/ResolveOperation.cs
+++ b/src/Autofac/Core/Resolving/ResolveOperation.cs
@@ -99,6 +99,19 @@ internal sealed class ResolveOperation : IDependencyTrackingResolveOperation
             throw new ObjectDisposedException(ResolveOperationResources.TemporaryContextDisposed, innerException: null);
         }
 
+        // Fast-path: if the registration is shared and already cached, skip the entire
+        // pipeline (context allocation, middleware chain, etc.). Only safe when:
+        //  - no event handlers or diagnostics are observing,
+        //  - the service pipeline is the default (no decorators or custom service middleware).
+        if (request.Registration.Sharing == InstanceSharing.Shared &&
+            request.ResolvePipeline == ServicePipelines.DefaultServicePipeline &&
+            ResolveRequestBeginning is null &&
+            !DiagnosticSource.IsEnabled() &&
+            currentOperationScope.TryGetSharedInstance(request.Registration.Id, request.DecoratorTarget?.Id, out var cached))
+        {
+            return cached;
+        }
+
         // Create a new request context.
         var requestContext = new DefaultResolveRequestContext(this, request, currentOperationScope, DiagnosticSource);
 

--- a/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
+++ b/src/Autofac/Features/Collections/CollectionRegistrationSource.cs
@@ -203,8 +203,13 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
                 continue;
             }
 
-            foreach (var keyed in registration.Services.OfType<KeyedService>())
+            foreach (var svc in registration.Services)
             {
+                if (svc is not KeyedService keyed)
+                {
+                    continue;
+                }
+
                 if (keyed.ServiceType != elementType || KeyedService.IsAnyKey(keyed.ServiceKey))
                 {
                     continue;
@@ -215,34 +220,38 @@ internal class CollectionRegistrationSource : IRegistrationSource, IPerScopeRegi
                     continue;
                 }
 
-                var serviceRegistrations = registry
-                    .ServiceRegistrationsFor(keyed)
-                    .Where(cr =>
-                        !cr.Registration.Options.HasOption(RegistrationOptions.ExcludeFromCollections) &&
-                        !cr.Registration.Metadata.ContainsKey(MetadataKeys.AnyKeyAdapter));
-
-                foreach (var serviceRegistration in serviceRegistrations)
+                foreach (var serviceRegistration in registry.ServiceRegistrationsFor(keyed))
                 {
-                    // Return both the keyed service and the registration so callers can issue
-                    // resolve requests that still know the original key.
+                    if (serviceRegistration.Registration.Options.HasOption(RegistrationOptions.ExcludeFromCollections) ||
+                        serviceRegistration.Registration.Metadata.ContainsKey(MetadataKeys.AnyKeyAdapter))
+                    {
+                        continue;
+                    }
+
                     result.Add((keyed, serviceRegistration));
                 }
             }
         }
 
-        return result
-            .OrderBy(tuple => tuple.Item2.Registration.GetRegistrationOrder())
-            .ToList();
+        result.Sort(static (a, b) => a.Item2.GetRegistrationOrder().CompareTo(b.Item2.GetRegistrationOrder()));
+        return result;
     }
 
     private static List<(Service Service, ServiceRegistration Registration)> BuildStandardRegistrationList(IComponentRegistry registry, Service elementTypeService)
     {
-        return registry
-            .ServiceRegistrationsFor(elementTypeService)
-            .Where(cr => !cr.Registration.Options.HasOption(RegistrationOptions.ExcludeFromCollections))
-            .OrderBy(cr => cr.Registration.GetRegistrationOrder())
-            .Select(cr => ((Service)elementTypeService, cr))
-            .ToList();
+        var registrations = registry.ServiceRegistrationsFor(elementTypeService);
+        var result = new List<(Service, ServiceRegistration)>();
+
+        foreach (var cr in registrations)
+        {
+            if (!cr.Registration.Options.HasOption(RegistrationOptions.ExcludeFromCollections))
+            {
+                result.Add((elementTypeService, cr));
+            }
+        }
+
+        result.Sort(static (a, b) => a.Item2.GetRegistrationOrder().CompareTo(b.Item2.GetRegistrationOrder()));
+        return result;
     }
 
     private static IList BuildCollection(

--- a/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
+++ b/src/Autofac/Features/Decorators/DecoratorMiddleware.cs
@@ -5,7 +5,6 @@ using Autofac.Core;
 using Autofac.Core.Registration;
 using Autofac.Core.Resolving;
 using Autofac.Core.Resolving.Pipeline;
-using Autofac.Diagnostics;
 
 namespace Autofac.Features.Decorators;
 
@@ -32,29 +31,10 @@ internal class DecoratorMiddleware : IResolveMiddleware
     public PipelinePhase Phase => PipelinePhase.Decoration;
 
     /// <inheritdoc/>
-    public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
-    {
-        if (!AutofacMetrics.MetricsEnabled)
-        {
-            ExecuteCore(context, next);
-            return;
-        }
-
-        var timer = ValueStopwatch.StartNew();
-        try
-        {
-            ExecuteCore(context, next);
-        }
-        finally
-        {
-            AutofacMetrics.RecordMiddlewareExecution(nameof(DecoratorMiddleware), timer.GetElapsedTime());
-        }
-    }
-
-    /// <inheritdoc/>
     public override string ToString() => nameof(DecoratorMiddleware) + " [" + _decoratorRegistration.Activator.LimitType.Name + "]";
 
-    private void ExecuteCore(ResolveRequestContext context, Action<ResolveRequestContext> next)
+    /// <inheritdoc/>
+    public void Execute(ResolveRequestContext context, Action<ResolveRequestContext> next)
     {
         // Go down the pipeline first, need that instance.
         next(context);

--- a/src/Autofac/Features/KeyedServices/AnyKeyRegistrationSource.cs
+++ b/src/Autofac/Features/KeyedServices/AnyKeyRegistrationSource.cs
@@ -6,6 +6,7 @@ using Autofac.Core;
 using Autofac.Core.Activators.Delegate;
 using Autofac.Core.Registration;
 using Autofac.Util;
+using Autofac.Util.Cache;
 
 namespace Autofac.Features.KeyedServices;
 
@@ -14,6 +15,17 @@ namespace Autofac.Features.KeyedServices;
 /// </summary>
 internal sealed class AnyKeyRegistrationSource : IRegistrationSource
 {
+    private readonly ReflectionCacheKeyedServiceDictionary<IComponentRegistration[]> _adapterCache;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AnyKeyRegistrationSource"/> class.
+    /// </summary>
+    public AnyKeyRegistrationSource()
+    {
+        _adapterCache = ReflectionCacheSet.Shared.GetOrCreateCache<ReflectionCacheKeyedServiceDictionary<IComponentRegistration[]>>(nameof(AnyKeyRegistrationSource));
+        _adapterCache.Usage = ReflectionCacheUsage.Resolution;
+    }
+
     /// <inheritdoc/>
     public bool IsAdapterForIndividualComponents => true;
 
@@ -37,6 +49,11 @@ internal sealed class AnyKeyRegistrationSource : IRegistrationSource
             return Enumerable.Empty<IComponentRegistration>();
         }
 
+        if (_adapterCache.TryGetValue(keyedService, out var cached))
+        {
+            return cached;
+        }
+
         // If there are already specific registrations for this key, do nothing.
         if (registrationAccessor(service).Any())
         {
@@ -51,7 +68,14 @@ internal sealed class AnyKeyRegistrationSource : IRegistrationSource
             return Enumerable.Empty<IComponentRegistration>();
         }
 
-        return anyKeyRegistrations.Select(r => CreateAdapterRegistration(r, keyedService));
+        var adapters = new IComponentRegistration[anyKeyRegistrations.Length];
+        for (var i = 0; i < anyKeyRegistrations.Length; i++)
+        {
+            adapters[i] = CreateAdapterRegistration(anyKeyRegistrations[i], keyedService);
+        }
+
+        _adapterCache.TryAdd(keyedService, adapters);
+        return adapters;
     }
 
     private static ComponentRegistration CreateAdapterRegistration(ServiceRegistration anyKeyRegistration, KeyedService requestedService)

--- a/src/Autofac/Features/KeyedServices/AnyKeyRegistrationSource.cs
+++ b/src/Autofac/Features/KeyedServices/AnyKeyRegistrationSource.cs
@@ -22,8 +22,12 @@ internal sealed class AnyKeyRegistrationSource : IRegistrationSource
     /// </summary>
     public AnyKeyRegistrationSource()
     {
-        _adapterCache = ReflectionCacheSet.Shared.GetOrCreateCache<ReflectionCacheKeyedServiceDictionary<IComponentRegistration[]>>(nameof(AnyKeyRegistrationSource));
-        _adapterCache.Usage = ReflectionCacheUsage.Resolution;
+        _adapterCache = new ReflectionCacheKeyedServiceDictionary<IComponentRegistration[]>
+        {
+            Usage = ReflectionCacheUsage.Resolution,
+        };
+
+        ReflectionCacheSet.Shared.RegisterExternalCache(_adapterCache);
     }
 
     /// <inheritdoc/>

--- a/src/Autofac/Util/Cache/ReflectionCacheKeyedServiceDictionary.cs
+++ b/src/Autofac/Util/Cache/ReflectionCacheKeyedServiceDictionary.cs
@@ -8,11 +8,11 @@ using Autofac.Core;
 namespace Autofac.Util.Cache;
 
 /// <summary>
-/// A reflection cache dictionary, keyed on a <see cref="ParameterInfo"/>.
+/// A reflection cache dictionary keyed on <see cref="KeyedService"/>, using the service type for cache eviction.
 /// </summary>
 /// <typeparam name="TValue">The value type.</typeparam>
-internal sealed class ReflectionCacheParameterDictionary<TValue>
-    : ConcurrentDictionary<ParameterInfo, TValue>, IReflectionCache
+internal sealed class ReflectionCacheKeyedServiceDictionary<TValue>
+    : ConcurrentDictionary<KeyedService, TValue>, IReflectionCache
 {
     /// <inheritdoc />
     public ReflectionCacheUsage Usage { get; set; } = ReflectionCacheUsage.All;
@@ -34,8 +34,8 @@ internal sealed class ReflectionCacheParameterDictionary<TValue>
 
         foreach (var kvp in this)
         {
-            var member = kvp.Key.Member;
-            if (predicate(member, TypeAssemblyReferenceProvider.GetAllReferencedAssemblies(member, reusableAssemblySet)))
+            var serviceType = kvp.Key.ServiceType;
+            if (predicate(serviceType, TypeAssemblyReferenceProvider.GetAllReferencedAssemblies(serviceType, reusableAssemblySet)))
             {
                 TryRemove(kvp.Key, out _);
             }

--- a/test/Autofac.Test/ResolutionExtensionsTests.cs
+++ b/test/Autofac.Test/ResolutionExtensionsTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
 using Autofac.Core;
 using Autofac.Core.Activators.ProvidedInstance;
 using Autofac.Core.Registration;


### PR DESCRIPTION
After adding AnyKey support it seemed like the benchmarks were starting to slip from the last major release. I did some passes through the code to find some performance/maintainability wins to try to claw back some of that perf.

- Performance-focused refactor across resolve pipeline and middleware to reduce per-resolve overhead and trim hot-path allocations.
- Removed several LINQ-based paths in critical resolution/injection flows and replaced them with lower-overhead logic.
- Added and improved caching for AnyKey and adapted AnyKey registrations, including per-scope cache behavior.
- Added support for externally managed reflection caches and expanded reflection cache dictionary handling for keyed services/parameters.
- Optimized reflection activation and keyed service parameter injection to skip unnecessary work when possible.
- Updated benchmark coverage with additional AnyKey scenarios and benchmark-set updates to verify performance impact.
- Included cleanup and stability updates (for example, removing unused usings and reverting temporary audit configuration changes).
- Validation completed with test and benchmark runs during development.