### PR TITLE
Dispose container when an IStartable throws during Build (#1392)

### DIFF
--- a/src/Autofac/ContainerBuilder.cs
+++ b/src/Autofac/ContainerBuilder.cs
@@ -175,13 +175,21 @@ public sealed class ContainerBuilder
         var componentRegistry = ComponentRegistryBuilder.Build();
 
         var result = new Container(componentRegistry);
-        if ((options & ContainerBuildOptions.IgnoreStartableComponents) == ContainerBuildOptions.None)
+        try
         {
-            StartableManager.StartStartableComponents(Properties, result);
-        }
+            if ((options & ContainerBuildOptions.IgnoreStartableComponents) == ContainerBuildOptions.None)
+            {
+                StartableManager.StartStartableComponents(Properties, result);
+            }
 
-        // Run any build callbacks.
-        BuildCallbackManager.RunBuildCallbacks(result);
+            // Run any build callbacks.
+            BuildCallbackManager.RunBuildCallbacks(result);
+        }
+        catch
+        {
+            result.Dispose();
+            throw;
+        }
 
         // Allow the reflection cache to empty any registration-time caches to save memory.
         ReflectionCacheSet.Shared.OnContainerBuildClearCaches(_clearRegistrationCaches);

--- a/test/Autofac.Specification.Test/Features/StartableTests.cs
+++ b/test/Autofac.Specification.Test/Features/StartableTests.cs
@@ -121,6 +121,22 @@ public class StartableTests
     }
 
     [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposal is part of the test.")]
+    public void Startable_WhenStartableThrows_DependenciesAreDisposed()
+    {
+        // Issue #1392 - disposable instances resolved to satisfy a startable should be
+        // disposed when the startable's Start() method throws.
+        var dependency = new DisposableDependency();
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(dependency);
+        builder.RegisterType<ThrowingStartable>().As<IStartable>().SingleInstance();
+
+        Assert.Throws<DependencyResolutionException>(() => builder.Build());
+
+        Assert.True(dependency.IsDisposed);
+    }
+
+    [Fact]
     public void Startable_WhenStartIsSpecified_StartableComponentsAreStarted()
     {
         var startable = new Startable();
@@ -187,23 +203,6 @@ public class StartableTests
         builder.RegisterType<object>();
         builder.Build();
         Assert.Equal(1, instanceCount);
-    }
-
-    [Fact]
-    public void Startable_WhenStartableThrows_DependenciesAreDisposed()
-    {
-        // Issue #1392 - disposable instances resolved to satisfy a startable should be
-        // disposed when the startable's Start() method throws.
-#pragma warning disable CA2000 // Dispose objects before losing scope - ownership transferred to container
-        var dependency = new DisposableDependency();
-#pragma warning restore CA2000 // Dispose objects before losing scope
-        var builder = new ContainerBuilder();
-        builder.RegisterInstance(dependency);
-        builder.RegisterType<ThrowingStartable>().As<IStartable>().SingleInstance();
-
-        Assert.Throws<DependencyResolutionException>(() => builder.Build());
-
-        Assert.True(dependency.IsDisposed);
     }
 
     private class ComponentTakesStartableDependency : IStartable

--- a/test/Autofac.Specification.Test/Features/StartableTests.cs
+++ b/test/Autofac.Specification.Test/Features/StartableTests.cs
@@ -189,6 +189,23 @@ public class StartableTests
         Assert.Equal(1, instanceCount);
     }
 
+    [Fact]
+    public void Startable_WhenStartableThrows_DependenciesAreDisposed()
+    {
+        // Issue #1392 - disposable instances resolved to satisfy a startable should be
+        // disposed when the startable's Start() method throws.
+#pragma warning disable CA2000 // Dispose objects before losing scope - ownership transferred to container
+        var dependency = new DisposableDependency();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+        var builder = new ContainerBuilder();
+        builder.RegisterInstance(dependency);
+        builder.RegisterType<ThrowingStartable>().As<IStartable>().SingleInstance();
+
+        Assert.Throws<DependencyResolutionException>(() => builder.Build());
+
+        Assert.True(dependency.IsDisposed);
+    }
+
     private class ComponentTakesStartableDependency : IStartable
     {
         public ComponentTakesStartableDependency(StartableTakesDependency dependency, bool expectStarted)
@@ -283,6 +300,31 @@ public class StartableTests
         public void Start()
         {
             WasStarted = true;
+        }
+    }
+
+    private class DisposableDependency : IDisposable
+    {
+        public bool IsDisposed
+        {
+            get; private set;
+        }
+
+        public void Dispose()
+        {
+            IsDisposed = true;
+        }
+    }
+
+    private class ThrowingStartable : IStartable
+    {
+        public ThrowingStartable(DisposableDependency dependency)
+        {
+        }
+
+        public void Start()
+        {
+            throw new InvalidOperationException("Startable failed.");
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1392. When an `IStartable.Start()` threw during `ContainerBuilder.Build()`, the partially-initialized container was abandoned without being disposed. Any `IDisposable` services instantiated to satisfy the startable (and its dependencies) leaked, because the root lifetime scope's `Disposer` was tracking them but `Dispose()` was never called.

## Fix

In `ContainerBuilder.Build()`, the block that starts startable components and runs build callbacks is now wrapped in a `try/catch`. On exception, the container is disposed before the exception propagates, then rethrown. On the success path the caller still owns the container as before. The fix covers both `IStartable.Start()` and build-callback failures, since both run in the window where the container is owned but not yet returned.

## Tests

Adds `Startable_WhenStartableThrows_DependenciesAreDisposed`: registers a disposable dependency plus an `IStartable` whose `Start()` throws, asserts `Build()` throws, and asserts the dependency was disposed.

No public API changes. Zero warnings/errors; full `Autofac.Test` and `Autofac.Specification.Test` suites pass on net8.0 and net10.0.
