### PR TITLE
Honor ExternallyOwned ownership for decorators (#1402)

### DIFF
--- a/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
+++ b/src/Autofac/Core/Resolving/Middleware/DisposalTrackingMiddleware.cs
@@ -28,7 +28,13 @@ internal class DisposalTrackingMiddleware : IResolveMiddleware
     {
         next(context);
 
-        if (context.Registration.Ownership == InstanceOwnership.OwnedByLifetimeScope)
+        // When a decorator is being resolved, context.DecoratorTarget is the underlying component
+        // registration. If the underlying component is ExternallyOwned, the decorator should also
+        // not be tracked for disposal - the caller opted out of lifetime management for the entire
+        // decorated chain. See https://github.com/autofac/Autofac/issues/1402.
+        var effectiveOwnership = context.DecoratorTarget?.Ownership ?? context.Registration.Ownership;
+
+        if (effectiveOwnership == InstanceOwnership.OwnedByLifetimeScope)
         {
             // The fact this adds instances for disposal agnostic of the activator is
             // important. The ProvidedInstanceActivator will NOT dispose of the provided

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -676,6 +676,32 @@ public class DecoratorTests
     }
 
     [Fact]
+    public void DecoratorNotDisposedWhenDecoratedServiceIsExternallyOwned()
+    {
+        // #1402: A decorator wrapping an ExternallyOwned service should itself
+        // not be disposed by the lifetime scope.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<DisposableImplementor>()
+            .As<IDecoratedService>()
+            .ExternallyOwned();
+        builder.RegisterDecorator<DisposableDecorator, IDecoratedService>();
+        var container = builder.Build();
+
+        DisposableDecorator decorator;
+        DisposableImplementor decorated;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            var instance = scope.Resolve<IDecoratedService>();
+            decorator = (DisposableDecorator)instance;
+            decorated = (DisposableImplementor)instance.Decorated;
+        }
+
+        Assert.Equal(0, decorator.DisposeCallCount);
+        Assert.Equal(0, decorated.DisposeCallCount);
+    }
+
+    [Fact]
     public void DecoratorAppliedOnlyOnceToComponentWithExternalRegistrySource()
     {
         // #965: A nested lifetime scope that has a registration lambda

--- a/test/Autofac.Specification.Test/Features/DecoratorTests.cs
+++ b/test/Autofac.Specification.Test/Features/DecoratorTests.cs
@@ -702,6 +702,118 @@ public class DecoratorTests
     }
 
     [Fact]
+    public void StackedDecoratorsNotDisposedWhenDecoratedServiceIsExternallyOwned()
+    {
+        // #1402: When several decorators are stacked over an ExternallyOwned
+        // service, the ownership of the underlying component governs the entire
+        // chain - none of the decorators should be disposed by the scope.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<DisposableImplementor>()
+            .As<IDecoratedService>()
+            .ExternallyOwned();
+        builder.RegisterDecorator<DisposableDecorator, IDecoratedService>();
+        builder.RegisterDecorator<DisposableDecoratorB, IDecoratedService>();
+        var container = builder.Build();
+
+        DisposableDecoratorB outer;
+        DisposableDecorator inner;
+        DisposableImplementor decorated;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            var instance = scope.Resolve<IDecoratedService>();
+            outer = (DisposableDecoratorB)instance;
+            inner = (DisposableDecorator)outer.Decorated;
+            decorated = (DisposableImplementor)inner.Decorated;
+        }
+
+        Assert.Equal(0, outer.DisposeCallCount);
+        Assert.Equal(0, inner.DisposeCallCount);
+        Assert.Equal(0, decorated.DisposeCallCount);
+    }
+
+    [Fact]
+    public void StackedDecoratorsAllDisposedWhenDecoratedServiceOwnedByLifetimeScope()
+    {
+        // #1402 regression guard: stacked decorators over a normally-owned
+        // service must continue to be disposed along with the decorated instance.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<DisposableImplementor>()
+            .As<IDecoratedService>();
+        builder.RegisterDecorator<DisposableDecorator, IDecoratedService>();
+        builder.RegisterDecorator<DisposableDecoratorB, IDecoratedService>();
+        var container = builder.Build();
+
+        DisposableDecoratorB outer;
+        DisposableDecorator inner;
+        DisposableImplementor decorated;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            var instance = scope.Resolve<IDecoratedService>();
+            outer = (DisposableDecoratorB)instance;
+            inner = (DisposableDecorator)outer.Decorated;
+            decorated = (DisposableImplementor)inner.Decorated;
+        }
+
+        Assert.Equal(1, outer.DisposeCallCount);
+        Assert.Equal(1, inner.DisposeCallCount);
+        Assert.Equal(1, decorated.DisposeCallCount);
+    }
+
+    [Fact]
+    public void GenericDecoratorNotDisposedWhenDecoratedServiceIsExternallyOwned()
+    {
+        // #1402: The open-generic decorator path also runs through the decorator
+        // middleware, so an ExternallyOwned decorated component must prevent the
+        // generic decorator from being disposed by the scope.
+        var builder = new ContainerBuilder();
+        builder.RegisterGeneric(typeof(DisposableGenericComponent<>))
+            .As(typeof(IDisposableGenericService<>))
+            .ExternallyOwned();
+        builder.RegisterGenericDecorator(typeof(DisposableGenericDecorator<>), typeof(IDisposableGenericService<>));
+        var container = builder.Build();
+
+        DisposableGenericDecorator<int> decorator;
+        DisposableGenericComponent<int> decorated;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            var instance = scope.Resolve<IDisposableGenericService<int>>();
+            decorator = (DisposableGenericDecorator<int>)instance;
+            decorated = (DisposableGenericComponent<int>)decorator.Decorated;
+        }
+
+        Assert.Equal(0, decorator.DisposeCallCount);
+        Assert.Equal(0, decorated.DisposeCallCount);
+    }
+
+    [Fact]
+    public void GenericDecoratorAndDecoratedBothDisposedWhenOwnedByLifetimeScope()
+    {
+        // #1402 regression guard: open-generic decorator over a normally-owned
+        // service must continue to be disposed along with the decorated instance.
+        var builder = new ContainerBuilder();
+        builder.RegisterGeneric(typeof(DisposableGenericComponent<>))
+            .As(typeof(IDisposableGenericService<>));
+        builder.RegisterGenericDecorator(typeof(DisposableGenericDecorator<>), typeof(IDisposableGenericService<>));
+        var container = builder.Build();
+
+        DisposableGenericDecorator<int> decorator;
+        DisposableGenericComponent<int> decorated;
+
+        using (var scope = container.BeginLifetimeScope())
+        {
+            var instance = scope.Resolve<IDisposableGenericService<int>>();
+            decorator = (DisposableGenericDecorator<int>)instance;
+            decorated = (DisposableGenericComponent<int>)decorator.Decorated;
+        }
+
+        Assert.Equal(1, decorator.DisposeCallCount);
+        Assert.Equal(1, decorated.DisposeCallCount);
+    }
+
+    [Fact]
     public void DecoratorAppliedOnlyOnceToComponentWithExternalRegistrySource()
     {
         // #965: A nested lifetime scope that has a registration lambda
@@ -1440,6 +1552,25 @@ public class DecoratorTests
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local
+    private sealed class DisposableDecoratorB : Decorator, IDisposable
+    {
+        public DisposableDecoratorB(IDecoratedService decorated)
+            : base(decorated)
+        {
+        }
+
+        public int DisposeCallCount
+        {
+            get; private set;
+        }
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
+        }
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
     private sealed class DisposableImplementor : IDecoratedService, IDisposable
     {
         public IDecoratedService Decorated => this;
@@ -1556,6 +1687,48 @@ public class DecoratorTests
         public IGenericService<T> Decorated
         {
             get;
+        }
+    }
+
+    private interface IDisposableGenericService<T>
+    {
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private sealed class DisposableGenericComponent<T> : IDisposableGenericService<T>, IDisposable
+    {
+        public int DisposeCallCount
+        {
+            get; private set;
+        }
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
+        }
+    }
+
+    // ReSharper disable once ClassNeverInstantiated.Local
+    private sealed class DisposableGenericDecorator<T> : IDisposableGenericService<T>, IDisposable
+    {
+        public DisposableGenericDecorator(IDisposableGenericService<T> decorated)
+        {
+            Decorated = decorated;
+        }
+
+        public IDisposableGenericService<T> Decorated
+        {
+            get;
+        }
+
+        public int DisposeCallCount
+        {
+            get; private set;
+        }
+
+        public void Dispose()
+        {
+            DisposeCallCount++;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #1402. When a decorated service was registered as `ExternallyOwned`, the decorator wrapping it was still created with the default `OwnedByLifetimeScope` ownership. The lifetime scope therefore tracked the decorator for disposal and disposed it (and, through it, the decorated instance) — violating the user's `ExternallyOwned` opt-out and causing double-disposal.

## Fix

`DisposalTrackingMiddleware.Execute` now uses the *effective* ownership when deciding whether to track an instance for disposal: `context.DecoratorTarget?.Ownership ?? context.Registration.Ownership`. For non-decorator resolutions `DecoratorTarget` is null and behavior is unchanged; for decorator resolutions the underlying decorated component's ownership governs, so an `ExternallyOwned` decorated service no longer has its decorator disposed by the scope.

This was chosen over propagating ownership onto the decorator registration at build time, because the decorator registration is created before the decorated registration is known. The middleware approach is non-invasive and covers all decorator styles (generic, non-generic, lambda, open-generic) as well as async disposal, since they all route through `DisposalTrackingMiddleware`.

## Tests

Adds `DecoratorNotDisposedWhenDecoratedServiceIsExternallyOwned`: an `ExternallyOwned` disposable service decorated by a disposable decorator, asserting neither is disposed when the scope is disposed. The existing decorator disposal tests (`InstancePerDependency`, `InstancePerLifetimeScope`, `InstancePerMatchingLifetimeScope`, `SingleInstance`) serve as the regression guard for normal-ownership behavior.

No public API changes. Zero warnings/errors; full suites pass on net8.0 and net10.0.
