### PR TITLE
Only subscribe Module registry events when hooks are overridden (#1446)

### DIFF
--- a/bench/Autofac.Benchmarks/BenchmarkSet.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkSet.cs
@@ -33,5 +33,6 @@ public static class BenchmarkSet
         typeof(MultiConstructorBenchmark),
         typeof(LambdaResolveBenchmark),
         typeof(RequiredPropertyBenchmark),
+        typeof(ModuleRegistrationBenchmark),
     };
 }

--- a/bench/Autofac.Benchmarks/ModuleRegistrationBenchmark.cs
+++ b/bench/Autofac.Benchmarks/ModuleRegistrationBenchmark.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Benchmarks;
+
+/// <summary>
+/// Measures the cost of building a container that registers many modules which do
+/// not override <see cref="Module.AttachToComponentRegistration"/> or
+/// <see cref="Module.AttachToRegistrationSource"/>.
+/// </summary>
+/// <remarks>
+/// See https://github.com/autofac/Autofac/issues/1446. Prior to the fix, every module
+/// unconditionally subscribed to the registry's <c>Registered</c> and
+/// <c>RegistrationSourceAdded</c> events. Each subscription replays all existing
+/// registrations, so build time and allocations grew quadratically with the number of
+/// modules. Modules that do not override the hooks no longer subscribe, removing the
+/// quadratic behavior. Compare against a baseline package version (for example
+/// <c>--baseline-version 9.1.0</c>) to see the difference.
+/// </remarks>
+public class ModuleRegistrationBenchmark
+{
+    [Params(100, 1000)]
+    public int ModuleCount
+    {
+        get; set;
+    }
+
+    [Benchmark]
+    public void BuildContainerWithModules()
+    {
+        var builder = new ContainerBuilder();
+
+        for (var i = 0; i < ModuleCount; i++)
+        {
+            builder.RegisterModule<NoHookModule>();
+        }
+
+        using var container = builder.Build();
+        GC.KeepAlive(container);
+    }
+
+    // A module that overrides neither hook - the common case from issue #1446.
+    private sealed class NoHookModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<Service>().As<IService>();
+        }
+
+        private interface IService
+        {
+        }
+
+        private sealed class Service : IService
+        {
+        }
+    }
+}

--- a/src/Autofac/Core/InternalReflectionCaches.cs
+++ b/src/Autofac/Core/InternalReflectionCaches.cs
@@ -25,6 +25,16 @@ internal class InternalReflectionCaches
             Usage = ReflectionCacheUsage.Registration,
         });
 
+        ModuleOverridesAttachToComponentRegistration = set.GetOrCreateCache(nameof(ModuleOverridesAttachToComponentRegistration), _ => new ReflectionCacheDictionary<Type, bool>
+        {
+            Usage = ReflectionCacheUsage.Registration,
+        });
+
+        ModuleOverridesAttachToRegistrationSource = set.GetOrCreateCache(nameof(ModuleOverridesAttachToRegistrationSource), _ => new ReflectionCacheDictionary<Type, bool>
+        {
+            Usage = ReflectionCacheUsage.Registration,
+        });
+
         IsGenericEnumerableInterface = set.GetOrCreateCache<ReflectionCacheDictionary<Type, bool>>(nameof(IsGenericEnumerableInterface));
         IsGenericListOrCollectionInterfaceType = set.GetOrCreateCache<ReflectionCacheDictionary<Type, bool>>(nameof(IsGenericListOrCollectionInterfaceType));
         IsGenericTypeDefinedBy = set.GetOrCreateCache<ReflectionCacheTupleDictionary<Type, bool>>(nameof(IsGenericTypeDefinedBy));
@@ -148,6 +158,24 @@ internal class InternalReflectionCaches
     /// Gets a cache used to determine if a type uses <see cref="ServiceKeyAttribute"/>.
     /// </summary>
     public ReflectionCacheDictionary<Type, bool> ServiceKeyUsageByType
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a cache used by <see cref="Module"/> to determine whether a concrete module type
+    /// overrides <see cref="Module.AttachToComponentRegistration"/>.
+    /// </summary>
+    public ReflectionCacheDictionary<Type, bool> ModuleOverridesAttachToComponentRegistration
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets a cache used by <see cref="Module"/> to determine whether a concrete module type
+    /// overrides <see cref="Module.AttachToRegistrationSource"/>.
+    /// </summary>
+    public ReflectionCacheDictionary<Type, bool> ModuleOverridesAttachToRegistrationSource
     {
         get;
     }

--- a/src/Autofac/Module.cs
+++ b/src/Autofac/Module.cs
@@ -132,8 +132,28 @@ public abstract class Module : IModule
             throw new ArgumentNullException(nameof(componentRegistry));
         }
 
-        componentRegistry.Registered +=
-            (sender, e) => AttachToComponentRegistration(e.ComponentRegistryBuilder, e.ComponentRegistration);
+        var moduleType = GetType();
+        var cache = ReflectionCacheSet.Shared.Internal.ModuleOverridesAttachToComponentRegistration;
+
+        var overrides = cache.GetOrAdd(
+            moduleType,
+            static t =>
+            {
+                var method = t.GetMethod(
+                    nameof(AttachToComponentRegistration),
+                    BindingFlags.Instance | BindingFlags.NonPublic,
+                    binder: null,
+                    types: new[] { typeof(IComponentRegistryBuilder), typeof(IComponentRegistration) },
+                    modifiers: null);
+
+                return method is not null && method.DeclaringType != typeof(Module);
+            });
+
+        if (overrides)
+        {
+            componentRegistry.Registered +=
+                (sender, e) => AttachToComponentRegistration(e.ComponentRegistryBuilder, e.ComponentRegistration);
+        }
     }
 
     private void AttachToSources(IComponentRegistryBuilder componentRegistry)
@@ -143,7 +163,27 @@ public abstract class Module : IModule
             throw new ArgumentNullException(nameof(componentRegistry));
         }
 
-        componentRegistry.RegistrationSourceAdded +=
-            (sender, e) => AttachToRegistrationSource(e.ComponentRegistry, e.RegistrationSource);
+        var moduleType = GetType();
+        var cache = ReflectionCacheSet.Shared.Internal.ModuleOverridesAttachToRegistrationSource;
+
+        var overrides = cache.GetOrAdd(
+            moduleType,
+            static t =>
+            {
+                var method = t.GetMethod(
+                    nameof(AttachToRegistrationSource),
+                    BindingFlags.Instance | BindingFlags.NonPublic,
+                    binder: null,
+                    types: new[] { typeof(IComponentRegistryBuilder), typeof(IRegistrationSource) },
+                    modifiers: null);
+
+                return method is not null && method.DeclaringType != typeof(Module);
+            });
+
+        if (overrides)
+        {
+            componentRegistry.RegistrationSourceAdded +=
+                (sender, e) => AttachToRegistrationSource(e.ComponentRegistry, e.RegistrationSource);
+        }
     }
 }

--- a/test/Autofac.Test/ModuleTests.cs
+++ b/test/Autofac.Test/ModuleTests.cs
@@ -206,7 +206,8 @@ public class ModuleTests
         Assert.Equal("value", builder.Properties["prop"]);
     }
 
-    // A module that overrides neither hook (the common case that caused the performance issue).
+    // #1446: A module that overrides neither hook (the common case that caused the
+    // O(N^2) performance issue) must not subscribe to the registry events at all.
     internal class NoHookModule : Module
     {
         protected override void Load(ContainerBuilder builder)
@@ -216,38 +217,35 @@ public class ModuleTests
     }
 
     [Fact]
-    public void NoHookModule_DoesNotSubscribeToRegisteredEvent()
+    public void ModuleWithoutHookDoesNotSubscribeToRegisteredEvent()
     {
-        // Arrange
+        // #1446: Subscribing replays every existing registration, so a module that
+        // does not override AttachToComponentRegistration must not subscribe.
         using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
 
-        // Act
         new NoHookModule().Configure(registryBuilder);
 
-        // Assert: the Registered event delegate stored in Properties should be null
-        // (no module subscription was added), meaning the key is either absent or null.
         var hasRegisteredHandler =
             registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
             && registeredValue is not null;
 
-        Assert.False(hasRegisteredHandler, "A module that does not override AttachToComponentRegistration should not subscribe to the Registered event.");
+        Assert.False(hasRegisteredHandler);
     }
 
     [Fact]
-    public void NoHookModule_DoesNotSubscribeToRegistrationSourceAddedEvent()
+    public void ModuleWithoutHookDoesNotSubscribeToRegistrationSourceAddedEvent()
     {
-        // Arrange
+        // #1446: A module that does not override AttachToRegistrationSource must not
+        // subscribe to the RegistrationSourceAdded event.
         using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
 
-        // Act
         new NoHookModule().Configure(registryBuilder);
 
-        // Assert: the RegistrationSourceAdded event delegate stored in Properties should be null.
         var hasSourceHandler =
             registryBuilder.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var sourceValue)
             && sourceValue is not null;
 
-        Assert.False(hasSourceHandler, "A module that does not override AttachToRegistrationSource should not subscribe to the RegistrationSourceAdded event.");
+        Assert.False(hasSourceHandler);
     }
 
     // A module that overrides only AttachToComponentRegistration.
@@ -264,26 +262,24 @@ public class ModuleTests
     }
 
     [Fact]
-    public void ComponentRegistrationHookModule_SubscribesToRegisteredEvent()
+    public void ModuleOverridingComponentRegistrationHookSubscribesToRegisteredEvent()
     {
-        // Arrange
+        // #1446: A module that overrides AttachToComponentRegistration must still subscribe.
         using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
 
-        // Act
         new ComponentRegistrationHookModule().Configure(registryBuilder);
 
-        // Assert: the Registered event delegate stored in Properties should be non-null.
         var hasRegisteredHandler =
             registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
             && registeredValue is not null;
 
-        Assert.True(hasRegisteredHandler, "A module that overrides AttachToComponentRegistration must subscribe to the Registered event.");
+        Assert.True(hasRegisteredHandler);
     }
 
     [Fact]
-    public void ComponentRegistrationHookModule_HookIsCalledForSubsequentRegistrations()
+    public void ModuleOverridingComponentRegistrationHookStillReceivesRegistrations()
     {
-        // Verify the hook is still called when the override is present (regression guard).
+        // #1446: regression guard - the overridden hook must still fire for registrations.
         var module = new ComponentRegistrationHookModule();
         var builder = new ContainerBuilder();
         builder.RegisterModule(module);
@@ -292,6 +288,22 @@ public class ModuleTests
         using var container = builder.Build();
 
         Assert.NotEmpty(module.Seen);
+    }
+
+    [Fact]
+    public void ModuleOverridingOnlyComponentRegistrationHookDoesNotSubscribeToRegistrationSourceAddedEvent()
+    {
+        // #1446: the two detection paths are independent - overriding only the
+        // component-registration hook must not subscribe to the source-added event.
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        new ComponentRegistrationHookModule().Configure(registryBuilder);
+
+        var hasSourceHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var sourceValue)
+            && sourceValue is not null;
+
+        Assert.False(hasSourceHandler);
     }
 
     // A module that overrides only AttachToRegistrationSource.
@@ -308,20 +320,34 @@ public class ModuleTests
     }
 
     [Fact]
-    public void RegistrationSourceHookModule_SubscribesToRegistrationSourceAddedEvent()
+    public void ModuleOverridingRegistrationSourceHookSubscribesToRegistrationSourceAddedEvent()
     {
-        // Arrange
+        // #1446: A module that overrides AttachToRegistrationSource must still subscribe.
         using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
 
-        // Act
         new RegistrationSourceHookModule().Configure(registryBuilder);
 
-        // Assert: the RegistrationSourceAdded event delegate stored in Properties should be non-null.
         var hasSourceHandler =
             registryBuilder.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var sourceValue)
             && sourceValue is not null;
 
-        Assert.True(hasSourceHandler, "A module that overrides AttachToRegistrationSource must subscribe to the RegistrationSourceAdded event.");
+        Assert.True(hasSourceHandler);
+    }
+
+    [Fact]
+    public void ModuleOverridingOnlyRegistrationSourceHookDoesNotSubscribeToRegisteredEvent()
+    {
+        // #1446: the two detection paths are independent - overriding only the
+        // source-added hook must not subscribe to the component-registered event.
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        new RegistrationSourceHookModule().Configure(registryBuilder);
+
+        var hasRegisteredHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
+            && registeredValue is not null;
+
+        Assert.False(hasRegisteredHandler);
     }
 
     internal class NullRegistrationSource : IRegistrationSource
@@ -335,9 +361,9 @@ public class ModuleTests
     }
 
     [Fact]
-    public void RegistrationSourceHookModule_HookIsCalledWhenSourceIsAdded()
+    public void ModuleOverridingRegistrationSourceHookStillReceivesSources()
     {
-        // Verify the hook is still called when the override is present (regression guard).
+        // #1446: regression guard - the overridden hook must still fire for sources.
         var module = new RegistrationSourceHookModule();
         var builder = new ContainerBuilder();
         builder.RegisterModule(module);
@@ -371,10 +397,10 @@ public class ModuleTests
     }
 
     [Fact]
-    public void IntermediateBaseOverride_HookIsCalledForConcreteSubclass()
+    public void ModuleInheritingHookFromIntermediateBaseStillReceivesRegistrations()
     {
-        // A module that inherits the override from an intermediate class must still
-        // have its hook invoked (DeclaringType != typeof(Module) covers this case).
+        // #1446: the override-detection uses DeclaringType != typeof(Module), so an
+        // override inherited from an intermediate base class must still fire.
         var module = new ConcreteIntermediateModule();
         var builder = new ContainerBuilder();
         builder.RegisterModule(module);
@@ -386,8 +412,9 @@ public class ModuleTests
     }
 
     [Fact]
-    public void IntermediateBaseOverride_SubscribesToRegisteredEvent()
+    public void ModuleInheritingHookFromIntermediateBaseSubscribesToRegisteredEvent()
     {
+        // #1446: a module whose override is declared on an intermediate base class must subscribe.
         using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
 
         new ConcreteIntermediateModule().Configure(registryBuilder);
@@ -396,7 +423,7 @@ public class ModuleTests
             registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
             && registeredValue is not null;
 
-        Assert.True(hasRegisteredHandler, "A module with an override declared on an intermediate base class must still subscribe to the Registered event.");
+        Assert.True(hasRegisteredHandler);
     }
 
     private class Service1

--- a/test/Autofac.Test/ModuleTests.cs
+++ b/test/Autofac.Test/ModuleTests.cs
@@ -125,9 +125,9 @@ public class ModuleTests
                 });
                 c.RegisterCallback(outerBuilder =>
                 {
-                    Assert.Equal(
-                        container.ComponentRegistry.Properties[MetadataKeys.RegistrationSourceAddedPropertyKey],
-                        outerBuilder.Properties[MetadataKeys.RegistrationSourceAddedPropertyKey]);
+                    container.ComponentRegistry.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var containerSourceAdded);
+                    outerBuilder.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var scopeSourceAdded);
+                    Assert.Equal(containerSourceAdded, scopeSourceAdded);
 
                     outerBuilder.RegistrationSourceAdded += (s, e) => { };
 
@@ -204,6 +204,199 @@ public class ModuleTests
         var container = builder.Build();
         Assert.Equal(2, container.ComponentRegistry.Properties["count"]);
         Assert.Equal("value", builder.Properties["prop"]);
+    }
+
+    // A module that overrides neither hook (the common case that caused the performance issue).
+    internal class NoHookModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<Service1>();
+        }
+    }
+
+    [Fact]
+    public void NoHookModule_DoesNotSubscribeToRegisteredEvent()
+    {
+        // Arrange
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        // Act
+        new NoHookModule().Configure(registryBuilder);
+
+        // Assert: the Registered event delegate stored in Properties should be null
+        // (no module subscription was added), meaning the key is either absent or null.
+        var hasRegisteredHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
+            && registeredValue is not null;
+
+        Assert.False(hasRegisteredHandler, "A module that does not override AttachToComponentRegistration should not subscribe to the Registered event.");
+    }
+
+    [Fact]
+    public void NoHookModule_DoesNotSubscribeToRegistrationSourceAddedEvent()
+    {
+        // Arrange
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        // Act
+        new NoHookModule().Configure(registryBuilder);
+
+        // Assert: the RegistrationSourceAdded event delegate stored in Properties should be null.
+        var hasSourceHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var sourceValue)
+            && sourceValue is not null;
+
+        Assert.False(hasSourceHandler, "A module that does not override AttachToRegistrationSource should not subscribe to the RegistrationSourceAdded event.");
+    }
+
+    // A module that overrides only AttachToComponentRegistration.
+    internal class ComponentRegistrationHookModule : Module
+    {
+        public IList<IComponentRegistration> Seen { get; } = new List<IComponentRegistration>();
+
+        protected override void AttachToComponentRegistration(
+            IComponentRegistryBuilder componentRegistry,
+            IComponentRegistration registration)
+        {
+            Seen.Add(registration);
+        }
+    }
+
+    [Fact]
+    public void ComponentRegistrationHookModule_SubscribesToRegisteredEvent()
+    {
+        // Arrange
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        // Act
+        new ComponentRegistrationHookModule().Configure(registryBuilder);
+
+        // Assert: the Registered event delegate stored in Properties should be non-null.
+        var hasRegisteredHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
+            && registeredValue is not null;
+
+        Assert.True(hasRegisteredHandler, "A module that overrides AttachToComponentRegistration must subscribe to the Registered event.");
+    }
+
+    [Fact]
+    public void ComponentRegistrationHookModule_HookIsCalledForSubsequentRegistrations()
+    {
+        // Verify the hook is still called when the override is present (regression guard).
+        var module = new ComponentRegistrationHookModule();
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(module);
+        builder.RegisterType<Service1>();
+
+        using var container = builder.Build();
+
+        Assert.NotEmpty(module.Seen);
+    }
+
+    // A module that overrides only AttachToRegistrationSource.
+    internal class RegistrationSourceHookModule : Module
+    {
+        public IList<IRegistrationSource> Seen { get; } = new List<IRegistrationSource>();
+
+        protected override void AttachToRegistrationSource(
+            IComponentRegistryBuilder componentRegistry,
+            IRegistrationSource registrationSource)
+        {
+            Seen.Add(registrationSource);
+        }
+    }
+
+    [Fact]
+    public void RegistrationSourceHookModule_SubscribesToRegistrationSourceAddedEvent()
+    {
+        // Arrange
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        // Act
+        new RegistrationSourceHookModule().Configure(registryBuilder);
+
+        // Assert: the RegistrationSourceAdded event delegate stored in Properties should be non-null.
+        var hasSourceHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegistrationSourceAddedPropertyKey, out var sourceValue)
+            && sourceValue is not null;
+
+        Assert.True(hasSourceHandler, "A module that overrides AttachToRegistrationSource must subscribe to the RegistrationSourceAdded event.");
+    }
+
+    internal class NullRegistrationSource : IRegistrationSource
+    {
+        public bool IsAdapterForIndividualComponents => false;
+
+        public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<ServiceRegistration>> registrationAccessor)
+        {
+            return Enumerable.Empty<IComponentRegistration>();
+        }
+    }
+
+    [Fact]
+    public void RegistrationSourceHookModule_HookIsCalledWhenSourceIsAdded()
+    {
+        // Verify the hook is still called when the override is present (regression guard).
+        var module = new RegistrationSourceHookModule();
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(module);
+        builder.RegisterSource(new NullRegistrationSource());
+
+        using var container = builder.Build();
+
+        Assert.NotEmpty(module.Seen);
+    }
+
+    // Intermediate base class scenario: the override is declared on an abstract intermediate
+    // class between Module and the concrete type, not directly on the concrete type.
+    internal abstract class IntermediateModuleBase : Module
+    {
+        public IList<IComponentRegistration> Seen { get; } = new List<IComponentRegistration>();
+
+        protected override void AttachToComponentRegistration(
+            IComponentRegistryBuilder componentRegistry,
+            IComponentRegistration registration)
+        {
+            Seen.Add(registration);
+        }
+    }
+
+    internal class ConcreteIntermediateModule : IntermediateModuleBase
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            builder.RegisterType<Service1>();
+        }
+    }
+
+    [Fact]
+    public void IntermediateBaseOverride_HookIsCalledForConcreteSubclass()
+    {
+        // A module that inherits the override from an intermediate class must still
+        // have its hook invoked (DeclaringType != typeof(Module) covers this case).
+        var module = new ConcreteIntermediateModule();
+        var builder = new ContainerBuilder();
+        builder.RegisterModule(module);
+        builder.RegisterType<Service2>();
+
+        using var container = builder.Build();
+
+        Assert.NotEmpty(module.Seen);
+    }
+
+    [Fact]
+    public void IntermediateBaseOverride_SubscribesToRegisteredEvent()
+    {
+        using var registryBuilder = Factory.CreateEmptyComponentRegistryBuilder();
+
+        new ConcreteIntermediateModule().Configure(registryBuilder);
+
+        var hasRegisteredHandler =
+            registryBuilder.Properties.TryGetValue(MetadataKeys.RegisteredPropertyKey, out var registeredValue)
+            && registeredValue is not null;
+
+        Assert.True(hasRegisteredHandler, "A module with an override declared on an intermediate base class must still subscribe to the Registered event.");
     }
 
     private class Service1


### PR DESCRIPTION
## Summary

Fixes #1446. `Module.Configure` unconditionally subscribed lambda event handlers to `componentRegistry.Registered` and `componentRegistry.RegistrationSourceAdded`, even when the concrete module overrode *neither* `AttachToComponentRegistration` nor `AttachToRegistrationSource`. Each subscription replays every existing registration, so with many registered modules this produced O(N²) delegate invocations and allocations at build time (the reporter measured ~1.56 GB allocated and ~22× slower build vs. ~55 MB without the subscriptions).

## Fix

The two private subscription helpers now subscribe only when the derived module type actually overrides the corresponding virtual method, detected via reflection (`GetMethod(...).DeclaringType != typeof(Module)`, using exact parameter-type arrays to select the right overload). This correctly handles overrides declared in an intermediate base class. Results are cached per-type in `InternalReflectionCaches` (registration-scoped, cleared after build) to avoid repeated reflection.

Modules that override the hooks behave identically to before; only modules that override neither stop subscribing — which is the entire point.

## Tests

Tests reference #1446 and follow the repo conventions (no AAA comments; names aligned with the existing file style). Coverage:

- A no-hook module subscribes to neither event.
- A module overriding `AttachToComponentRegistration` (or `AttachToRegistrationSource`) still subscribes and still has its hook invoked (regression guards).
- An override inherited from an intermediate abstract base class still subscribes and fires.
- **Independence guards:** overriding only one hook must not subscribe to the *other* event (the two detection paths are independent).

Each "does not subscribe" test was confirmed to fail when the fix is disabled (forced always-subscribe), so they are genuine guards rather than tautologies. One pre-existing test (`ModifiedScopesHaveTheirOwnDelegate`) was updated to use `TryGetValue` for a registry property key that is now legitimately absent when no hook is overridden.

## Benchmark

Adds `ModuleRegistrationBenchmark` (`bench/Autofac.Benchmarks/`, registered in `BenchmarkSet.All`) measuring container build cost vs. module count, with the `MemoryDiagnoser` from the existing config. Run it against a pre-fix package to see the difference:

```
dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.1.0 --filter *ModuleRegistrationBenchmark*
```

Measured results (1000 no-hook modules):

| Version | Mean time | Allocated |
|---------|-----------|-----------|
| Package 9.1.0 (before) | 11,776 µs | 22,338 KB |
| Source (with fix) | 1,825 µs | 5,096 KB |
| **Ratio** | **0.16 (≈6.4× faster)** | **0.23 (≈4.4× less)** |

Build time also scales roughly linearly with module count after the fix instead of quadratically.

No public API changes. Zero warnings/errors; full suites pass on net8.0 and net10.0.
