### PR TITLE
Fail fast when a scope-local registration binds its lifetime to an ancestor scope (#1460)

### DIFF
--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -597,17 +597,14 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
 
     private void CheckLocalRegistrationsDoNotBindToAncestorScope(object newScopeTag, IEnumerable<IComponentRegistration> localRegistrations)
     {
-        // Build the set of strict ancestor tags: the current scope and all its parents (but NOT the new
-        // child scope's own tag). A locally-registered component whose MatchingScopeLifetime references
-        // an ancestor tag will be hoisted into that ancestor on every child scope creation, accumulating
-        // instances and causing a memory leak. Fail fast here rather than silently leaking.
-        var ancestorTags = new HashSet<object>();
-        ISharingLifetimeScope? current = this;
-        while (current is not null)
-        {
-            ancestorTags.Add(current.Tag);
-            current = current.ParentLifetimeScope;
-        }
+        // Issue #1460: A locally-registered component whose MatchingScopeLifetime references an
+        // ancestor tag (e.g. InstancePerMatchingLifetimeScope("outer") registered in a child scope's
+        // configuration action) gets hoisted into that ancestor on every child scope creation,
+        // accumulating instances and causing a memory leak. Fail fast here rather than silently
+        // leaking. Only matching-lifetime registrations can trigger this, and creating configured
+        // child scopes is a hot path, so we avoid all work (no allocation, no parent-chain walk)
+        // unless and until we actually encounter a MatchingScopeLifetime registration.
+        HashSet<object>? ancestorTags = null;
 
         foreach (var registration in localRegistrations)
         {
@@ -615,6 +612,10 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
             {
                 continue;
             }
+
+            // Lazily build the set of strict ancestor tags on first need: the current scope and all
+            // its parents (but NOT the new child scope's own tag, which is a legal, leak-free target).
+            ancestorTags ??= BuildAncestorTagSet();
 
             foreach (var matchedTag in matchingLifetime.TagsToMatch)
             {
@@ -629,6 +630,19 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
                 }
             }
         }
+    }
+
+    private HashSet<object> BuildAncestorTagSet()
+    {
+        var ancestorTags = new HashSet<object>();
+        ISharingLifetimeScope? current = this;
+        while (current is not null)
+        {
+            ancestorTags.Add(current.Tag);
+            current = current.ParentLifetimeScope;
+        }
+
+        return ancestorTags;
     }
 
     /// <summary>

--- a/src/Autofac/Core/Lifetime/LifetimeScope.cs
+++ b/src/Autofac/Core/Lifetime/LifetimeScope.cs
@@ -589,7 +589,46 @@ public class LifetimeScope : Disposable, ISharingLifetimeScope, IServiceProvider
         configurationAction(builder);
 
         builder.UpdateRegistry(registryBuilder);
+
+        CheckLocalRegistrationsDoNotBindToAncestorScope(tag, tracker.Registrations);
+
         return registryBuilder;
+    }
+
+    private void CheckLocalRegistrationsDoNotBindToAncestorScope(object newScopeTag, IEnumerable<IComponentRegistration> localRegistrations)
+    {
+        // Build the set of strict ancestor tags: the current scope and all its parents (but NOT the new
+        // child scope's own tag). A locally-registered component whose MatchingScopeLifetime references
+        // an ancestor tag will be hoisted into that ancestor on every child scope creation, accumulating
+        // instances and causing a memory leak. Fail fast here rather than silently leaking.
+        var ancestorTags = new HashSet<object>();
+        ISharingLifetimeScope? current = this;
+        while (current is not null)
+        {
+            ancestorTags.Add(current.Tag);
+            current = current.ParentLifetimeScope;
+        }
+
+        foreach (var registration in localRegistrations)
+        {
+            if (registration.Lifetime is not MatchingScopeLifetime matchingLifetime)
+            {
+                continue;
+            }
+
+            foreach (var matchedTag in matchingLifetime.TagsToMatch)
+            {
+                if (ancestorTags.Contains(matchedTag))
+                {
+                    throw new InvalidOperationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            LifetimeScopeResources.MatchingScopeLifetimeAncestorTag,
+                            matchedTag,
+                            newScopeTag));
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Autofac/Core/Lifetime/LifetimeScopeResources.resx
+++ b/src/Autofac/Core/Lifetime/LifetimeScopeResources.resx
@@ -123,6 +123,9 @@
   <data name="DuplicateTagDetected" xml:space="preserve">
     <value>The tag '{0}' has already been assigned to a parent lifetime scope. If you are using Owned&lt;T&gt; this indicates you may have a circular dependency chain.</value>
   </data>
+  <data name="MatchingScopeLifetimeAncestorTag" xml:space="preserve">
+    <value>A component registered in a BeginLifetimeScope configuration action has a lifetime bound to tag '{0}', which belongs to a strict ancestor scope. Such a registration can only be resolved within the current child scope, but each child scope creation will hoist a new instance into the ancestor, causing a memory leak. Either register the component in the ancestor scope directly, or use a tag that matches the current scope ('{1}') or a future descendant scope.</value>
+  </data>
   <data name="ScopeIsDisposed" xml:space="preserve">
     <value>Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope as it (or one of its parent scopes) has already been disposed.</value>
   </data>

--- a/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
@@ -67,7 +67,7 @@ public class InstancePerMatchingLifetimeScopeTests
     }
 
     [Fact]
-    public void LocalRegistration_BindingToGrandchildTag_DoesNotThrow()
+    public void LocalRegistration_BindToGrandchildTag()
     {
         // #1460: a descendant tag more than one level down is still a future descendant,
         // not an ancestor, so it must not throw at scope-creation time.

--- a/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
@@ -67,6 +67,21 @@ public class InstancePerMatchingLifetimeScopeTests
     }
 
     [Fact]
+    public void LocalRegistration_BindingToGrandchildTag_DoesNotThrow()
+    {
+        // #1460: a descendant tag more than one level down is still a future descendant,
+        // not an ancestor, so it must not throw at scope-creation time.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+
+        using var child = container.BeginLifetimeScope("child", b =>
+            b.RegisterType<object>().InstancePerMatchingLifetimeScope("grandchild"));
+
+        using var grandchild = child.BeginLifetimeScope("grandchild");
+        Assert.NotNull(grandchild.Resolve<object>());
+    }
+
+    [Fact]
     public void LocalRegistration_BindingToRootContainerTag_ThrowsAtScopeCreation()
     {
         // The container's root tag is also a strict ancestor; binding to it from a

--- a/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
@@ -9,6 +9,92 @@ namespace Autofac.Specification.Test.Lifetime;
 public class InstancePerMatchingLifetimeScopeTests
 {
     [Fact]
+    public void LocalRegistration_BindingToAncestorTag_ThrowsAtScopeCreation()
+    {
+        // Reproduces the exact memory-leak scenario from issue #1460:
+        // A child scope is created with a local registration whose matching-scope
+        // tag refers to an ancestor (the outer scope). Each BeginLifetimeScope call
+        // would hoist a fresh instance into the ancestor indefinitely, so we now
+        // throw InvalidOperationException at scope-creation time instead.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+
+        using var outer = container.BeginLifetimeScope("outer");
+
+        Assert.Throws<InvalidOperationException>(() =>
+            outer.BeginLifetimeScope("inner", b =>
+                b.RegisterType<object>().InstancePerMatchingLifetimeScope("outer")));
+    }
+
+    [Fact]
+    public void LocalRegistration_BindingToScopeOwnTag_DoesNotThrow()
+    {
+        // A scope-local registration whose MatchingScopeLifetime tag matches the
+        // NEW scope's own tag is perfectly legal: the component's lifetime exactly
+        // matches its reachability, so there is no leak.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+
+        // Must not throw.
+        using var scope = container.BeginLifetimeScope("x", b =>
+            b.RegisterType<object>().InstancePerMatchingLifetimeScope("x"));
+
+        // The component should be resolvable within the scope.
+        var instance = scope.Resolve<object>();
+        Assert.NotNull(instance);
+
+        // And it should be shared within the same scope (singleton-within-scope semantics).
+        Assert.Same(instance, scope.Resolve<object>());
+    }
+
+    [Fact]
+    public void LocalRegistration_BindingToDescendantTag_DoesNotThrow()
+    {
+        // A scope-local registration whose MatchingScopeLifetime tag will only be
+        // matched by a future descendant scope must NOT throw at registration time —
+        // this is the documented, intended usage pattern.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+
+        // "child" does not yet exist in the scope chain → must not throw.
+        using var parent = container.BeginLifetimeScope("parent", b =>
+            b.RegisterType<object>().InstancePerMatchingLifetimeScope("child"));
+
+        // Creating a named child scope with the matching tag should work and resolve correctly.
+        using var child = parent.BeginLifetimeScope("child");
+        var instance = child.Resolve<object>();
+        Assert.NotNull(instance);
+    }
+
+    [Fact]
+    public void LocalRegistration_BindingToRootContainerTag_ThrowsAtScopeCreation()
+    {
+        // The container's root tag is also a strict ancestor; binding to it from a
+        // scope-local registration should likewise be rejected.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            container.BeginLifetimeScope("child", b =>
+                b.RegisterType<object>().InstancePerMatchingLifetimeScope(LifetimeScope.RootTag)));
+    }
+
+    [Fact]
+    public void LocalRegistration_BindingToAncestorTag_MultipleTagsOneAncestor_ThrowsAtScopeCreation()
+    {
+        // When multiple tags are supplied to InstancePerMatchingLifetimeScope and at
+        // least one of them refers to an ancestor, it must still throw.
+        var builder = new ContainerBuilder();
+        var container = builder.Build();
+
+        using var outer = container.BeginLifetimeScope("outer");
+
+        Assert.Throws<InvalidOperationException>(() =>
+            outer.BeginLifetimeScope("inner", b =>
+                b.RegisterType<object>().InstancePerMatchingLifetimeScope("inner", "outer")));
+    }
+
+    [Fact]
     public void ChildOfNamedScopeGetsSharedInstance()
     {
         var contextName = "ctx";

--- a/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
+++ b/test/Autofac.Specification.Test/Lifetime/InstancePerMatchingLifetimeScopeTests.cs
@@ -9,9 +9,9 @@ namespace Autofac.Specification.Test.Lifetime;
 public class InstancePerMatchingLifetimeScopeTests
 {
     [Fact]
-    public void LocalRegistration_BindingToAncestorTag_ThrowsAtScopeCreation()
+    public void LocalRegistration_BindToAncestorTag()
     {
-        // Reproduces the exact memory-leak scenario from issue #1460:
+        // #1460: Reproduces the exact memory-leak scenario from the issue.
         // A child scope is created with a local registration whose matching-scope
         // tag refers to an ancestor (the outer scope). Each BeginLifetimeScope call
         // would hoist a fresh instance into the ancestor indefinitely, so we now
@@ -27,9 +27,9 @@ public class InstancePerMatchingLifetimeScopeTests
     }
 
     [Fact]
-    public void LocalRegistration_BindingToScopeOwnTag_DoesNotThrow()
+    public void LocalRegistration_BindToScopeOwnTag()
     {
-        // A scope-local registration whose MatchingScopeLifetime tag matches the
+        // #1460: A scope-local registration whose MatchingScopeLifetime tag matches the
         // NEW scope's own tag is perfectly legal: the component's lifetime exactly
         // matches its reachability, so there is no leak.
         var builder = new ContainerBuilder();
@@ -48,9 +48,9 @@ public class InstancePerMatchingLifetimeScopeTests
     }
 
     [Fact]
-    public void LocalRegistration_BindingToDescendantTag_DoesNotThrow()
+    public void LocalRegistration_BindToDescendantTag()
     {
-        // A scope-local registration whose MatchingScopeLifetime tag will only be
+        // #1460: A scope-local registration whose MatchingScopeLifetime tag will only be
         // matched by a future descendant scope must NOT throw at registration time —
         // this is the documented, intended usage pattern.
         var builder = new ContainerBuilder();
@@ -82,9 +82,9 @@ public class InstancePerMatchingLifetimeScopeTests
     }
 
     [Fact]
-    public void LocalRegistration_BindingToRootContainerTag_ThrowsAtScopeCreation()
+    public void LocalRegistration_BindToRootContainerTag()
     {
-        // The container's root tag is also a strict ancestor; binding to it from a
+        // #1460: The container's root tag is also a strict ancestor; binding to it from a
         // scope-local registration should likewise be rejected.
         var builder = new ContainerBuilder();
         var container = builder.Build();
@@ -95,9 +95,9 @@ public class InstancePerMatchingLifetimeScopeTests
     }
 
     [Fact]
-    public void LocalRegistration_BindingToAncestorTag_MultipleTagsOneAncestor_ThrowsAtScopeCreation()
+    public void LocalRegistration_BindToMultipleTagsIncludingAncestor()
     {
-        // When multiple tags are supplied to InstancePerMatchingLifetimeScope and at
+        // #1460: When multiple tags are supplied to InstancePerMatchingLifetimeScope and at
         // least one of them refers to an ancestor, it must still throw.
         var builder = new ContainerBuilder();
         var container = builder.Build();


### PR DESCRIPTION
## Summary

Fixes #1460. Registering `InstancePerMatchingLifetimeScope("tag")` *inside* a child scope's configuration lambda, where `"tag"` refers to a **strict ancestor** scope, caused a memory leak: the registration is local to the child (a fresh registration with a new GUID on every child creation, so instance sharing never hits), but its lifetime attaches to the ancestor — so every child hoists a new instance into the ancestor, and they accumulate until the ancestor is disposed.

Per the decision recorded in the [issue thread](https://github.com/autofac/Autofac/issues/1460), this configuration is logically contradictory (the lifetime is strictly longer than the registration's reachability) and is never useful, so we now fail fast rather than leak.

## Fix

`CreateScopeRestrictedRegistry` now inspects the registrations added by the configuration action after they are materialized. For any registration whose lifetime is a `MatchingScopeLifetime`, if a matched tag belongs to a **strict ancestor** scope, it throws `InvalidOperationException`. This mirrors the existing `CheckTagIsUnique` / `DuplicateTagDetected` guard.

Boundaries that remain legal (and are covered by tests):
- Matching the scope's **own** tag (lifetime == reachability).
- Matching a **future descendant** tag (the intended use of matching lifetimes).
- The normal "register in the builder, create the named scope later" path — it doesn't route through `CreateScopeRestrictedRegistry` and is unaffected.

The root container tag is always an ancestor, so binding to it from a child config action also throws.

## Tests

Adds 5 tests: the exact repro (binding to an ancestor tag throws), own-tag is allowed, future-descendant tag is allowed, root tag throws, and a multi-tag case where one tag is an ancestor throws. Existing matching-scope/lifetime tests pass unchanged.

Adds resource string `MatchingScopeLifetimeAncestorTag` (internal). No public API changes. Zero warnings/errors; full suites pass on net8.0 and net10.0.

Note: this converts previously-silent (leaking) behavior into a thrown exception. It adds no API and only affects code that was already leaking.
