### PR TITLE
Add GetRegistrationId extension to expose a registration's unique ID (#1327)

### DIFF
--- a/default.proj
+++ b/default.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="All" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="Current">
   <PropertyGroup>
     <!-- Increment the overall semantic version here. -->
-    <Version>9.1.1</Version>
+    <Version>9.2.0</Version>
     <SolutionName>Autofac</SolutionName>
     <Configuration Condition="'$(Configuration)'==''">Release</Configuration>
     <ArtifactDirectory>$([System.IO.Path]::Combine($(MSBuildProjectDirectory),"artifacts"))</ArtifactDirectory>

--- a/src/Autofac/RegistrationExtensions.cs
+++ b/src/Autofac/RegistrationExtensions.cs
@@ -780,4 +780,51 @@ public static partial class RegistrationExtensions
         var tags = new[] { MatchingScopeLifetimeTags.RequestLifetimeScopeTag }.Concat(lifetimeScopeTags).ToArray();
         return registration.InstancePerMatchingLifetimeScope(tags);
     }
+
+    /// <summary>
+    /// Gets the unique <see cref="Guid"/> identity assigned to a single-component registration.
+    /// </summary>
+    /// <typeparam name="TLimit">Registration limit type.</typeparam>
+    /// <typeparam name="TActivatorData">Activator data type.</typeparam>
+    /// <param name="registration">The registration whose identity to retrieve.</param>
+    /// <returns>
+    /// The <see cref="Guid"/> that uniquely identifies this registration. This is the same value
+    /// that will appear on the resulting <see cref="Core.IComponentRegistration.Id"/> after the
+    /// container is built.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="registration" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Each single-component registration (created via <see cref="RegisterType{TImplementer}(ContainerBuilder)"/>,
+    /// <see cref="Register{T}(ContainerBuilder, Func{IComponentContext, T})"/>, or
+    /// <see cref="RegisterInstance{T}(ContainerBuilder, T)"/>) is assigned a stable <see cref="Guid"/>
+    /// at the time the registration builder is created. This ID flows through unchanged to
+    /// <see cref="Core.IComponentRegistration.Id"/> when the container is built.
+    /// </para>
+    /// <para>
+    /// A common use case is to capture the registration ID before building the container and use
+    /// it as a key in <see cref="ContainerBuilder.Properties"/> to associate per-registration
+    /// state or metadata, then look that state up at resolve time via
+    /// <see cref="Core.IComponentRegistration.Id"/>.
+    /// </para>
+    /// <para>
+    /// This method is only available for single-component registrations
+    /// (<see cref="Builder.SingleRegistrationStyle"/>). Multi-component registrations such as
+    /// open-generic registrations (via <c>RegisterGeneric</c>), assembly-scanning registrations,
+    /// adapters, and decorators do not have a single stable identity and this method is not
+    /// callable on them — attempting to do so results in a compile-time error.
+    /// </para>
+    /// </remarks>
+    public static Guid GetRegistrationId<TLimit, TActivatorData>(
+        this IRegistrationBuilder<TLimit, TActivatorData, SingleRegistrationStyle> registration)
+    {
+        if (registration == null)
+        {
+            throw new ArgumentNullException(nameof(registration));
+        }
+
+        return registration.RegistrationStyle.Id;
+    }
 }

--- a/test/Autofac.Test/Builder/GetRegistrationIdTests.cs
+++ b/test/Autofac.Test/Builder/GetRegistrationIdTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using Autofac.Builder;
+using Autofac.Core;
+
+namespace Autofac.Test.Builder;
+
+public class GetRegistrationIdTests
+{
+    [Fact]
+    public void GetRegistrationId_NullRegistration_ThrowsArgumentNullException()
+    {
+        // Issue #1327
+        IRegistrationBuilder<object, SimpleActivatorData, SingleRegistrationStyle> registration = null;
+        Assert.Throws<ArgumentNullException>(() => registration.GetRegistrationId());
+    }
+
+    [Fact]
+    public void GetRegistrationId_RegisterType_MatchesBuiltComponentRegistrationId()
+    {
+        // Issue #1327 - The ID returned before build matches IComponentRegistration.Id after build.
+        var cb = new ContainerBuilder();
+        var rb = cb.RegisterType<MyComponent>();
+        var capturedId = rb.GetRegistrationId();
+        var container = cb.Build();
+
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(MyComponent)), out var cr));
+        Assert.Equal(capturedId, cr.Id);
+    }
+
+    [Fact]
+    public void GetRegistrationId_RegisterDelegate_MatchesBuiltComponentRegistrationId()
+    {
+        // Issue #1327 - The ID returned before build matches IComponentRegistration.Id after build.
+        var cb = new ContainerBuilder();
+        var rb = cb.Register(_ => new MyComponent());
+        var capturedId = rb.GetRegistrationId();
+        var container = cb.Build();
+
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(MyComponent)), out var cr));
+        Assert.Equal(capturedId, cr.Id);
+    }
+
+    [Fact]
+    public void GetRegistrationId_RegisterInstance_MatchesBuiltComponentRegistrationId()
+    {
+        // Issue #1327 - The ID returned before build matches IComponentRegistration.Id after build.
+        var instance = new MyComponent();
+        var cb = new ContainerBuilder();
+        var rb = cb.RegisterInstance(instance);
+        var capturedId = rb.GetRegistrationId();
+        var container = cb.Build();
+
+        Assert.True(container.ComponentRegistry.TryGetRegistration(new TypedService(typeof(MyComponent)), out var cr));
+        Assert.Equal(capturedId, cr.Id);
+    }
+
+    [Fact]
+    public void GetRegistrationId_CalledTwice_ReturnsSameGuid()
+    {
+        // Issue #1327 - The ID is stable across multiple calls on the same builder.
+        var cb = new ContainerBuilder();
+        var rb = cb.RegisterType<MyComponent>();
+
+        var id1 = rb.GetRegistrationId();
+        var id2 = rb.GetRegistrationId();
+
+        Assert.Equal(id1, id2);
+    }
+
+    [Fact]
+    public void GetRegistrationId_TwoDistinctRegistrations_ReturnDifferentGuids()
+    {
+        // Issue #1327 - Each registration gets its own unique ID.
+        var cb = new ContainerBuilder();
+        var rb1 = cb.RegisterType<MyComponent>();
+        var rb2 = cb.Register(_ => new MyComponent());
+
+        Assert.NotEqual(rb1.GetRegistrationId(), rb2.GetRegistrationId());
+    }
+
+    private class MyComponent
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1327. There was no way to obtain a stable, unique identity for a registration from the `IRegistrationBuilder` returned by `RegisterType` / `Register` / `RegisterInstance`. The identity already exists internally (`SingleRegistrationStyle.Id`, which flows to `IComponentRegistration.Id`), but it was not reachable from the builder, so callers could not (for example) use it as a key in `ContainerBuilder.Properties` to track per-registration state before the container is built.

## Fix

Adds a single extension method:

```csharp
public static Guid GetRegistrationId<TLimit, TActivatorData>(
    this IRegistrationBuilder<TLimit, TActivatorData, SingleRegistrationStyle> registration)
```

It returns `registration.RegistrationStyle.Id` — the same `Guid` that appears on `IComponentRegistration.Id` after the container is built.

The method is generically constrained to `SingleRegistrationStyle`, so it is **only callable on single-component registrations**. Multi-component registrations (open generics via `RegisterGeneric`, assembly scanning, adapters, decorators) use `DynamicRegistrationStyle` and have no single stable identity — calling `GetRegistrationId` on them is a **compile-time error** rather than a runtime throw.

No interface changes (avoids breaking external implementers of `IRegistrationBuilder`); purely additive API. Placed alongside the similarly-constrained `PreserveExistingDefaults`.

## Tests

6 tests (all tagged `#1327`): the returned id matches `IComponentRegistration.Id` after build for `RegisterType`, `Register(lambda)`, and `RegisterInstance`; the id is stable across repeated calls; distinct registrations get distinct ids; and the null-argument guard. No compile test for the dynamic-style case is possible (it's a compile error by design).

Verified: the `Guid` is assigned once at `SingleRegistrationStyle` construction and never reassigned, flowing unchanged into `IComponentRegistration.Id` via `RegistrationBuilder.CreateRegistration`. Full XML docs; zero warnings; `Autofac.Test` passes; format clean.

## Versioning

Because this adds new public API (a backwards-compatible additive surface change), this PR bumps the version in `default.proj` from `9.1.1` to `9.2.0` per semver. The bug fixes already merged to `develop` since 9.1.1 (#1485, #1486, #1487, #1488, #1489) will ship together in the 9.2.0 release.