### PR TITLE
Cache compiled factory-delegate generators to avoid recompilation across scopes (#1461)

### DIFF
--- a/bench/Autofac.Benchmarks/BenchmarkSet.cs
+++ b/bench/Autofac.Benchmarks/BenchmarkSet.cs
@@ -34,5 +34,6 @@ public static class BenchmarkSet
         typeof(LambdaResolveBenchmark),
         typeof(RequiredPropertyBenchmark),
         typeof(ModuleRegistrationBenchmark),
+        typeof(GeneratedFactoryChildScopeBenchmark),
     };
 }

--- a/bench/Autofac.Benchmarks/GeneratedFactoryChildScopeBenchmark.cs
+++ b/bench/Autofac.Benchmarks/GeneratedFactoryChildScopeBenchmark.cs
@@ -4,17 +4,17 @@
 namespace Autofac.Benchmarks;
 
 /// <summary>
-/// Measures the cost of resolving a generated factory delegate (<c>Func&lt;T&gt;</c>) from
-/// repeated child lifetime scopes where the product type <c>T</c> is registered in the root
-/// container.
+/// Measures the cost of resolving a component registered in a child lifetime scope that
+/// depends on <c>Func&lt;T&gt;</c>, where <c>T</c> is registered in the root container.
 /// </summary>
 /// <remarks>
 /// See https://github.com/autofac/Autofac/issues/1461. Prior to the fix, each child scope
-/// resolution caused the factory's expression tree to be recompiled via
-/// <c>Expression.Lambda(...).Compile()</c>. The fix caches the compiled generator keyed on
-/// <c>(delegateType, parameterMapping)</c> so the expensive compile happens once and is reused
-/// across all scopes. Compare against a baseline package version using a command such as
-/// <c>dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.1.1
+/// that registered a consumer of <c>Func&lt;T&gt;</c> caused the factory's expression tree to
+/// be recompiled via <c>Expression.Lambda(...).Compile()</c> on every resolution. The fix
+/// caches the compiled generator keyed on <c>(delegateType, parameterMapping)</c> so the
+/// expensive compile happens once and is reused across all scopes. Compare against a baseline
+/// package version using a command such as
+/// <c>dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.1.0
 /// --filter *GeneratedFactoryChildScopeBenchmark*</c>.
 /// </remarks>
 public class GeneratedFactoryChildScopeBenchmark
@@ -36,22 +36,36 @@ public class GeneratedFactoryChildScopeBenchmark
     }
 
     /// <summary>
-    /// Resolves <c>Func&lt;Product&gt;</c> from a fresh child scope on each iteration.
-    /// Before the fix, each child-scope resolution recompiled the factory expression tree;
-    /// after the fix, the compiled generator is retrieved from a shared cache.
+    /// Creates a child scope with a consumer of <c>Func&lt;Product&gt;</c> registered locally,
+    /// then resolves that consumer on each iteration. Before the fix, each child-scope
+    /// resolution recompiled the factory expression tree; after the fix, the compiled generator
+    /// is retrieved from a shared cache.
     /// </summary>
     [Benchmark]
     public void ResolveGeneratedFactoryFromChildScope()
     {
         for (var i = 0; i < ScopeCount; i++)
         {
-            using var scope = _container.BeginLifetimeScope();
-            var factory = scope.Resolve<Func<Product>>();
-            GC.KeepAlive(factory());
+            using var scope = _container.BeginLifetimeScope(c => c.RegisterType<Consumer>());
+            var consumer = scope.Resolve<Consumer>();
+            GC.KeepAlive(consumer.Factory());
         }
     }
 
     private sealed class Product
     {
+    }
+
+    private sealed class Consumer
+    {
+        public Func<Product> Factory
+        {
+            get;
+        }
+
+        public Consumer(Func<Product> factory)
+        {
+            Factory = factory;
+        }
     }
 }

--- a/bench/Autofac.Benchmarks/GeneratedFactoryChildScopeBenchmark.cs
+++ b/bench/Autofac.Benchmarks/GeneratedFactoryChildScopeBenchmark.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace Autofac.Benchmarks;
+
+/// <summary>
+/// Measures the cost of resolving a generated factory delegate (<c>Func&lt;T&gt;</c>) from
+/// repeated child lifetime scopes where the product type <c>T</c> is registered in the root
+/// container.
+/// </summary>
+/// <remarks>
+/// See https://github.com/autofac/Autofac/issues/1461. Prior to the fix, each child scope
+/// resolution caused the factory's expression tree to be recompiled via
+/// <c>Expression.Lambda(...).Compile()</c>. The fix caches the compiled generator keyed on
+/// <c>(delegateType, parameterMapping)</c> so the expensive compile happens once and is reused
+/// across all scopes. Compare against a baseline package version using a command such as
+/// <c>dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.1.1
+/// --filter *GeneratedFactoryChildScopeBenchmark*</c>.
+/// </remarks>
+public class GeneratedFactoryChildScopeBenchmark
+{
+    private IContainer _container = default!;
+
+    [Params(100, 1000)]
+    public int ScopeCount
+    {
+        get; set;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Product>();
+        _container = builder.Build();
+    }
+
+    /// <summary>
+    /// Resolves <c>Func&lt;Product&gt;</c> from a fresh child scope on each iteration.
+    /// Before the fix, each child-scope resolution recompiled the factory expression tree;
+    /// after the fix, the compiled generator is retrieved from a shared cache.
+    /// </summary>
+    [Benchmark]
+    public void ResolveGeneratedFactoryFromChildScope()
+    {
+        for (var i = 0; i < ScopeCount; i++)
+        {
+            using var scope = _container.BeginLifetimeScope();
+            var factory = scope.Resolve<Func<Product>>();
+            GC.KeepAlive(factory());
+        }
+    }
+
+    private sealed class Product
+    {
+    }
+}

--- a/src/Autofac/Core/InternalReflectionCaches.cs
+++ b/src/Autofac/Core/InternalReflectionCaches.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Autofac.Core.Activators.Reflection;
+using Autofac.Features.GeneratedFactories;
 using Autofac.Util;
 using Autofac.Util.Cache;
 
@@ -48,6 +49,20 @@ internal class InternalReflectionCaches
         ServiceKeyParameterAttributes = set.GetOrCreateCache<ReflectionCacheParameterDictionary<bool>>(nameof(ServiceKeyParameterAttributes));
         ServiceKeyPropertyAttributes = set.GetOrCreateCache<ReflectionCacheDictionary<PropertyInfo, bool>>(nameof(ServiceKeyPropertyAttributes));
         ServiceKeyUsageByType = set.GetOrCreateCache<ReflectionCacheDictionary<Type, bool>>(nameof(ServiceKeyUsageByType));
+
+        GeneratedFactoryServiceOnlyGenerators = set.GetOrCreateCache(
+            nameof(GeneratedFactoryServiceOnlyGenerators),
+            _ => new ReflectionCacheTypeKeyedDictionary<ParameterMapping, Func<Service, IComponentContext, IEnumerable<Parameter>, Delegate>>
+            {
+                Usage = ReflectionCacheUsage.All,
+            });
+
+        GeneratedFactoryServiceRegistrationGenerators = set.GetOrCreateCache(
+            nameof(GeneratedFactoryServiceRegistrationGenerators),
+            _ => new ReflectionCacheTypeKeyedDictionary<ParameterMapping, Func<Service, ServiceRegistration, IComponentContext, IEnumerable<Parameter>, Delegate>>
+            {
+                Usage = ReflectionCacheUsage.All,
+            });
     }
 
     /// <summary>
@@ -176,6 +191,26 @@ internal class InternalReflectionCaches
     /// overrides <see cref="Module.AttachToRegistrationSource"/>.
     /// </summary>
     public ReflectionCacheDictionary<Type, bool> ModuleOverridesAttachToRegistrationSource
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the cache of compiled factory-delegate generators for
+    /// <see cref="Features.GeneratedFactories.FactoryGenerator"/> instances that resolve via
+    /// <c>ResolveService</c>. Keyed on <c>(delegateType, effectiveParameterMapping)</c>.
+    /// </summary>
+    public ReflectionCacheTypeKeyedDictionary<ParameterMapping, Func<Service, IComponentContext, IEnumerable<Parameter>, Delegate>> GeneratedFactoryServiceOnlyGenerators
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the cache of compiled factory-delegate generators for
+    /// <see cref="Features.GeneratedFactories.FactoryGenerator"/> instances that resolve via
+    /// <see cref="IComponentContext.ResolveComponent"/>. Keyed on <c>(delegateType, effectiveParameterMapping)</c>.
+    /// </summary>
+    public ReflectionCacheTypeKeyedDictionary<ParameterMapping, Func<Service, ServiceRegistration, IComponentContext, IEnumerable<Parameter>, Delegate>> GeneratedFactoryServiceRegistrationGenerators
     {
         get;
     }

--- a/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
+++ b/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -15,6 +16,22 @@ namespace Autofac.Features.GeneratedFactories;
 /// </summary>
 public class FactoryGenerator
 {
+    /// <summary>
+    /// Cached compiled generators for the <see cref="FactoryGenerator(Type, Service, ParameterMapping)"/> overload
+    /// (resolves via <c>ResolveService</c>). Keyed on <c>(delegateType, effectiveParameterMapping)</c>.
+    /// Exposed internally for test observability only.
+    /// </summary>
+    internal static readonly ConcurrentDictionary<(Type, ParameterMapping), Func<Service, IComponentContext, IEnumerable<Parameter>, Delegate>>
+        ServiceOnlyGeneratorCache = new();
+
+    /// <summary>
+    /// Cached compiled generators for the <see cref="FactoryGenerator(Type, Service, ServiceRegistration, ParameterMapping)"/> overload
+    /// (resolves via <see cref="IComponentContext.ResolveComponent"/>). Keyed on <c>(delegateType, effectiveParameterMapping)</c>.
+    /// Exposed internally for test observability only.
+    /// </summary>
+    internal static readonly ConcurrentDictionary<(Type, ParameterMapping), Func<Service, ServiceRegistration, IComponentContext, IEnumerable<Parameter>, Delegate>>
+        ServiceRegistrationGeneratorCache = new();
+
     // The explicit '!' default is ok because the code is never executed, it's just used by
     // the expression tree.
     private static readonly ConstructorInfo _requestConstructor
@@ -38,25 +55,18 @@ public class FactoryGenerator
 
         Enforce.ArgumentTypeIsFunction(delegateType);
 
-        _generator = CreateGenerator(
-            (activatorContextParam, resolveParameterArray) =>
-            {
-                // c, service, [new Parameter(name, (object)dps)]*
-                var resolveParams = new[]
-                {
-                    activatorContextParam,
-                    Expression.Constant(service, typeof(Service)),
-                    Expression.NewArrayInit(typeof(Parameter), resolveParameterArray),
-                };
+        var pm = GetParameterMapping(delegateType, parameterMapping);
 
-                // c.Resolve(...)
-                // default! here is for reflection only
-                return Expression.Call(
-                ReflectionExtensions.GetMethod<IComponentContext>(cc => cc.ResolveService(default!, default!)),
-                resolveParams);
-            },
-            delegateType,
-            GetParameterMapping(delegateType, parameterMapping));
+        // Retrieve the cached compiled generator for this delegate type and parameter mapping,
+        // or compile it once on first use. The cached delegate is parameterised on 'service'
+        // (passed at invocation time) so it contains no instance-specific captures and is safe
+        // to share across all FactoryGenerator instances with the same structural signature.
+        var compiledGenerator = ServiceOnlyGeneratorCache.GetOrAdd(
+            (delegateType, pm),
+            static key => CreateServiceOnlyGenerator(key.Item1, key.Item2));
+
+        // Close over the specific service so _generator matches the expected signature.
+        _generator = (context, parameters) => compiledGenerator(service, context, parameters);
     }
 
     /// <summary>
@@ -72,27 +82,20 @@ public class FactoryGenerator
     {
         Enforce.ArgumentTypeIsFunction(delegateType);
 
-        _generator = CreateGenerator(
-            (activatorContextParam, resolveParameterArray) =>
-            {
-                // new ResolveRequest(service, productRegistration, [new Parameter(name, (object)dps)])*)
-                var newExpression = Expression.New(
-                _requestConstructor,
-                Expression.Constant(service, typeof(Service)),
-                Expression.Constant(productRegistration, typeof(ServiceRegistration)),
-                Expression.NewArrayInit(typeof(Parameter), resolveParameterArray),
-                Expression.Constant(null, typeof(IComponentRegistration)));
+        var pm = GetParameterMapping(delegateType, parameterMapping);
 
-                // c.Resolve(...)
-                // default! for reflection only
-                return Expression.Call(
-                activatorContextParam,
-                ReflectionExtensions.GetMethod<IComponentContext>(cc => cc.ResolveComponent(
-                    new ResolveRequest(default!, default, default(Parameter[])!, default))),
-                newExpression);
-            },
-            delegateType,
-            GetParameterMapping(delegateType, parameterMapping));
+        // Retrieve the cached compiled generator for this delegate type and parameter mapping,
+        // or compile it once on first use. The cached delegate is parameterised on both 'service'
+        // and 'productRegistration' (passed at invocation time), so it contains no instance-specific
+        // captures and is safe to share across all FactoryGenerator instances for the same delegate type.
+        var compiledGenerator = ServiceRegistrationGeneratorCache.GetOrAdd(
+            (delegateType, pm),
+            static key => CreateServiceRegistrationGenerator(key.Item1, key.Item2));
+
+        // Close over the specific service and product registration so _generator matches the
+        // expected signature. These values are instance-specific but are not baked into the
+        // compiled expression tree — they are passed as arguments at each invocation.
+        _generator = (context, parameters) => compiledGenerator(service, productRegistration, context, parameters);
     }
 
     /// <summary>
@@ -144,13 +147,18 @@ public class FactoryGenerator
         return delegateType.Name.StartsWith("Func`", StringComparison.Ordinal);
     }
 
-    private static Func<IComponentContext, IEnumerable<Parameter>, Delegate> CreateGenerator(Func<Expression, Expression[], Expression> makeResolveCall, Type delegateType, ParameterMapping pm)
+    /// <summary>
+    /// Creates a compiled generator for the overload that resolves via <c>ResolveService</c>.
+    /// The returned delegate accepts <paramref name="delegateType"/>-specific parameters at runtime and contains
+    /// no instance-specific compile-time captures, making it safe to cache and share across all
+    /// <see cref="FactoryGenerator"/> instances with the same (<paramref name="delegateType"/>, <paramref name="pm"/>) pair.
+    /// </summary>
+    private static Func<Service, IComponentContext, IEnumerable<Parameter>, Delegate> CreateServiceOnlyGenerator(Type delegateType, ParameterMapping pm)
     {
-        // (c, p) => ([dps]*) => (drt)Resolve(c, productRegistration, [new NamedParameter(name, (object)dps)]*)
-        // (c, p)
+        // Outer parameters: (Service svc, IComponentContext c, IEnumerable<Parameter> p)
+        var serviceParam = Expression.Parameter(typeof(Service), "svc");
         var activatorContextParam = Expression.Parameter(typeof(IComponentContext), "c");
         var activatorParamsParam = Expression.Parameter(typeof(IEnumerable<Parameter>), "p");
-        var activatorParams = new[] { activatorContextParam, activatorParamsParam };
 
         var invoke = delegateType.GetDeclaredMethod("Invoke");
 
@@ -163,18 +171,12 @@ public class FactoryGenerator
         Expression? resolveCast = null;
         if (DelegateTypeIsFunc(delegateType) && pm == ParameterMapping.ByType)
         {
-            // Issue #269:
-            // If we're resolving a Func<X1...XN>() and there are duplicate input parameter types
-            // and the parameter mapping is by type, we shouldn't be able to resolve it.
+            // Issue #269: duplicate input parameter types are not allowed for ByType mapping.
             var arguments = delegateType.GenericTypeArguments;
             var returnType = arguments[arguments.Length - 1];
-
-            // Remove the return type to check the list of input types only.
             Array.Resize(ref arguments, arguments.Length - 1);
             if (arguments.Distinct().Count() != arguments.Length)
             {
-                // There are duplicate input types - that's a problem. Throw
-                // when the function is invoked.
                 object[] argumentsArray = arguments.ToArray();
                 var message = string.Format(CultureInfo.CurrentCulture, GeneratedFactoryRegistrationSourceResources.DuplicateTypesInTypeMappedFuncParameterList, returnType.AssemblyQualifiedName, string.Join(", ", argumentsArray));
                 resolveCast = Expression.Throw(Expression.Constant(new DependencyResolutionException(message)), invoke.ReturnType);
@@ -183,23 +185,105 @@ public class FactoryGenerator
 
         if (resolveCast == null)
         {
-            // Issue #269: There aren't duplicate parameter types in the generated
-            // factory, so in the case of Func<X1...XN>() typed parameter mapping,
-            // if there are duplicate types in the target constructor, both constructor
-            // parameters will get the same value passed in. (We don't know
-            // the activator, so we can't do much more about it than that.)
-            //
-            // (drt)
             var resolveParameterArray = MapParameters(creatorParams, pm);
-            var resolveCall = makeResolveCall(activatorContextParam, resolveParameterArray);
+
+            // c.ResolveService(svc, [new Parameter(...)]*) — 'svc' is supplied as a runtime parameter.
+            var resolveParams = new Expression[]
+            {
+                activatorContextParam,
+                serviceParam,
+                Expression.NewArrayInit(typeof(Parameter), resolveParameterArray),
+            };
+
+            var resolveCall = Expression.Call(
+                ReflectionExtensions.GetMethod<IComponentContext>(cc => cc.ResolveService(default!, default!)),
+                resolveParams);
+
             resolveCast = Expression.Convert(resolveCall, invoke.ReturnType);
         }
 
-        // ([dps]*) => c.Resolve(service, [new Parameter(name, dps)]*)
+        // ([dps]*) => (drt)c.ResolveService(svc, [...])
         var creator = Expression.Lambda(delegateType, resolveCast, creatorParams);
 
-        // (c, p) => (
-        var activator = Expression.Lambda<Func<IComponentContext, IEnumerable<Parameter>, Delegate>>(creator, activatorParams);
+        // (svc, c, p) => ([dps]*) => ...
+        var activator = Expression.Lambda<Func<Service, IComponentContext, IEnumerable<Parameter>, Delegate>>(
+            creator,
+            serviceParam,
+            activatorContextParam,
+            activatorParamsParam);
+
+        return activator.Compile();
+    }
+
+    /// <summary>
+    /// Creates a compiled generator for the overload that resolves via <see cref="IComponentContext.ResolveComponent"/>.
+    /// The returned delegate accepts <paramref name="delegateType"/>-specific parameters at runtime and contains
+    /// no instance-specific compile-time captures, making it safe to cache and share across all
+    /// <see cref="FactoryGenerator"/> instances with the same (<paramref name="delegateType"/>, <paramref name="pm"/>) pair.
+    /// </summary>
+    private static Func<Service, ServiceRegistration, IComponentContext, IEnumerable<Parameter>, Delegate> CreateServiceRegistrationGenerator(Type delegateType, ParameterMapping pm)
+    {
+        // Outer parameters: (Service svc, ServiceRegistration sr, IComponentContext c, IEnumerable<Parameter> p)
+        var serviceParam = Expression.Parameter(typeof(Service), "svc");
+        var serviceRegistrationParam = Expression.Parameter(typeof(ServiceRegistration), "sr");
+        var activatorContextParam = Expression.Parameter(typeof(IComponentContext), "c");
+        var activatorParamsParam = Expression.Parameter(typeof(IEnumerable<Parameter>), "p");
+
+        var invoke = delegateType.GetDeclaredMethod("Invoke");
+
+        // [dps]*
+        var creatorParams = invoke
+            .GetParameters()
+            .Select(pi => Expression.Parameter(pi.ParameterType, pi.Name))
+            .ToList();
+
+        Expression? resolveCast = null;
+        if (DelegateTypeIsFunc(delegateType) && pm == ParameterMapping.ByType)
+        {
+            // Issue #269: duplicate input parameter types are not allowed for ByType mapping.
+            var arguments = delegateType.GenericTypeArguments;
+            var returnType = arguments[arguments.Length - 1];
+            Array.Resize(ref arguments, arguments.Length - 1);
+            if (arguments.Distinct().Count() != arguments.Length)
+            {
+                object[] argumentsArray = arguments.ToArray();
+                var message = string.Format(CultureInfo.CurrentCulture, GeneratedFactoryRegistrationSourceResources.DuplicateTypesInTypeMappedFuncParameterList, returnType.AssemblyQualifiedName, string.Join(", ", argumentsArray));
+                resolveCast = Expression.Throw(Expression.Constant(new DependencyResolutionException(message)), invoke.ReturnType);
+            }
+        }
+
+        if (resolveCast == null)
+        {
+            var resolveParameterArray = MapParameters(creatorParams, pm);
+
+            // new ResolveRequest(svc, sr, [...], null) — 'svc' and 'sr' are runtime parameters.
+            var newExpression = Expression.New(
+                _requestConstructor,
+                serviceParam,
+                serviceRegistrationParam,
+                Expression.NewArrayInit(typeof(Parameter), resolveParameterArray),
+                Expression.Constant(null, typeof(IComponentRegistration)));
+
+            // c.ResolveComponent(new ResolveRequest(...))
+            var resolveCall = Expression.Call(
+                activatorContextParam,
+                ReflectionExtensions.GetMethod<IComponentContext>(cc => cc.ResolveComponent(
+                    new ResolveRequest(default!, default, default(Parameter[])!, default))),
+                newExpression);
+
+            resolveCast = Expression.Convert(resolveCall, invoke.ReturnType);
+        }
+
+        // ([dps]*) => (drt)c.ResolveComponent(new ResolveRequest(svc, sr, [...]))
+        var creator = Expression.Lambda(delegateType, resolveCast, creatorParams);
+
+        // (svc, sr, c, p) => ([dps]*) => ...
+        var activator = Expression.Lambda<Func<Service, ServiceRegistration, IComponentContext, IEnumerable<Parameter>, Delegate>>(
+            creator,
+            serviceParam,
+            serviceRegistrationParam,
+            activatorContextParam,
+            activatorParamsParam);
 
         return activator.Compile();
     }

--- a/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
+++ b/src/Autofac/Features/GeneratedFactories/FactoryGenerator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Autofac Project. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-using System.Collections.Concurrent;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -16,22 +15,6 @@ namespace Autofac.Features.GeneratedFactories;
 /// </summary>
 public class FactoryGenerator
 {
-    /// <summary>
-    /// Cached compiled generators for the <see cref="FactoryGenerator(Type, Service, ParameterMapping)"/> overload
-    /// (resolves via <c>ResolveService</c>). Keyed on <c>(delegateType, effectiveParameterMapping)</c>.
-    /// Exposed internally for test observability only.
-    /// </summary>
-    internal static readonly ConcurrentDictionary<(Type, ParameterMapping), Func<Service, IComponentContext, IEnumerable<Parameter>, Delegate>>
-        ServiceOnlyGeneratorCache = new();
-
-    /// <summary>
-    /// Cached compiled generators for the <see cref="FactoryGenerator(Type, Service, ServiceRegistration, ParameterMapping)"/> overload
-    /// (resolves via <see cref="IComponentContext.ResolveComponent"/>). Keyed on <c>(delegateType, effectiveParameterMapping)</c>.
-    /// Exposed internally for test observability only.
-    /// </summary>
-    internal static readonly ConcurrentDictionary<(Type, ParameterMapping), Func<Service, ServiceRegistration, IComponentContext, IEnumerable<Parameter>, Delegate>>
-        ServiceRegistrationGeneratorCache = new();
-
     // The explicit '!' default is ok because the code is never executed, it's just used by
     // the expression tree.
     private static readonly ConstructorInfo _requestConstructor
@@ -61,7 +44,9 @@ public class FactoryGenerator
         // or compile it once on first use. The cached delegate is parameterised on 'service'
         // (passed at invocation time) so it contains no instance-specific captures and is safe
         // to share across all FactoryGenerator instances with the same structural signature.
-        var compiledGenerator = ServiceOnlyGeneratorCache.GetOrAdd(
+        // Accessing ReflectionCacheSet.Shared at point-of-use (not stored in a field) ensures
+        // correct weak-reference collection of the cache set.
+        var compiledGenerator = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceOnlyGenerators.GetOrAdd(
             (delegateType, pm),
             static key => CreateServiceOnlyGenerator(key.Item1, key.Item2));
 
@@ -88,7 +73,9 @@ public class FactoryGenerator
         // or compile it once on first use. The cached delegate is parameterised on both 'service'
         // and 'productRegistration' (passed at invocation time), so it contains no instance-specific
         // captures and is safe to share across all FactoryGenerator instances for the same delegate type.
-        var compiledGenerator = ServiceRegistrationGeneratorCache.GetOrAdd(
+        // Accessing ReflectionCacheSet.Shared at point-of-use (not stored in a field) ensures
+        // correct weak-reference collection of the cache set.
+        var compiledGenerator = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.GetOrAdd(
             (delegateType, pm),
             static key => CreateServiceRegistrationGenerator(key.Item1, key.Item2));
 

--- a/src/Autofac/Util/Cache/ReflectionCacheTypeKeyedDictionary.cs
+++ b/src/Autofac/Util/Cache/ReflectionCacheTypeKeyedDictionary.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Autofac Project. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using Autofac.Core;
+
+namespace Autofac.Util.Cache;
+
+/// <summary>
+/// A reflection cache dictionary, keyed on a <c>(<see cref="Type"/>, <typeparamref name="TDiscriminator"/>)</c>
+/// tuple where <typeparamref name="TDiscriminator"/> is a non-assembly-bearing discriminator (e.g. an enum).
+/// Only the <see cref="Type"/> component of the key participates in assembly-predicate–based clearing.
+/// </summary>
+/// <typeparam name="TDiscriminator">
+/// The second component of the tuple key; must be non-null but need not be a <see cref="MemberInfo"/>.
+/// </typeparam>
+/// <typeparam name="TValue">The value type.</typeparam>
+internal sealed class ReflectionCacheTypeKeyedDictionary<TDiscriminator, TValue>
+    : ConcurrentDictionary<(Type, TDiscriminator), TValue>, IReflectionCache
+    where TDiscriminator : notnull
+{
+    /// <inheritdoc />
+    public ReflectionCacheUsage Usage { get; set; } = ReflectionCacheUsage.All;
+
+    /// <inheritdoc />
+    public void Clear(ReflectionCacheClearPredicate predicate)
+    {
+        if (predicate is null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        if (Count == 0)
+        {
+            return;
+        }
+
+        var reusableAssemblySet = new HashSet<Assembly>();
+
+        foreach (var kvp in this)
+        {
+            if (predicate(kvp.Key.Item1, TypeAssemblyReferenceProvider.GetAllReferencedAssemblies(kvp.Key.Item1, reusableAssemblySet)))
+            {
+                TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+}

--- a/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
+++ b/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
@@ -414,4 +414,228 @@ public class GeneratedFactoriesTests
             C = c;
         }
     }
+
+    // #1461 — types used by the regression tests below.
+    private class Dependency1461
+    {
+    }
+
+    private class DependencyWithParam1461
+    {
+        public string Value
+        {
+            get;
+        }
+
+        public DependencyWithParam1461(string value)
+        {
+            Value = value;
+        }
+    }
+
+    private record FuncConsumer1461(Func<Dependency1461> Factory);
+
+    [Fact]
+    public void LifetimeWithConsumer_SiblingScopes()
+    {
+        // #1461: Resolving Func<T> from sibling child scopes where T is registered in the
+        // parent must not recompile the expression tree for each scope. The factory
+        // delegates produced in each scope must resolve the correct product type.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>();
+        using var container = builder.Build();
+
+        using var lifetimeScope1 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+        using var lifetimeScope2 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+        using var lifetimeScope3 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+
+        var c1 = lifetimeScope1.Resolve<FuncConsumer1461>();
+        var c2 = lifetimeScope2.Resolve<FuncConsumer1461>();
+        var c3 = lifetimeScope3.Resolve<FuncConsumer1461>();
+
+        Assert.NotNull(c1.Factory());
+        Assert.NotNull(c2.Factory());
+        Assert.NotNull(c3.Factory());
+        Assert.IsType<Dependency1461>(c1.Factory());
+        Assert.IsType<Dependency1461>(c2.Factory());
+        Assert.IsType<Dependency1461>(c3.Factory());
+    }
+
+    [Fact]
+    public void FactoryDelegate_CompiledGeneratorCached_SiblingScopes()
+    {
+        // #1461: The compiled expression-tree generator for a given (delegateType, parameterMapping)
+        // pair must be compiled exactly once and reused across sibling child scopes.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>();
+        using var container = builder.Build();
+
+        var cacheKey = (typeof(Func<Dependency1461>), Autofac.Features.GeneratedFactories.ParameterMapping.ByType);
+
+        using var scope1 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+        scope1.Resolve<FuncConsumer1461>();
+
+        // After the first resolve, the compiled generator must be present in the cache.
+        Assert.True(Autofac.Features.GeneratedFactories.FactoryGenerator.ServiceRegistrationGeneratorCache.ContainsKey(cacheKey));
+
+        var countAfterFirstScope = Autofac.Features.GeneratedFactories.FactoryGenerator.ServiceRegistrationGeneratorCache.Count;
+
+        using var scope2 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+        scope2.Resolve<FuncConsumer1461>();
+
+        using var scope3 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+        scope3.Resolve<FuncConsumer1461>();
+
+        // Resolving the same Func<T> from additional sibling scopes must not add new cache entries;
+        // the count must remain stable after the first scope warms the entry.
+        var countAfterAllScopes = Autofac.Features.GeneratedFactories.FactoryGenerator.ServiceRegistrationGeneratorCache.Count;
+        Assert.Equal(countAfterFirstScope, countAfterAllScopes);
+    }
+
+    [Fact]
+    public void FactoryDelegate_WithTypedParameter_SiblingScopes()
+    {
+        // #1461: Caching must not break Func<TParam, TProduct> factories where parameters
+        // are mapped by type (ByType). Each sibling scope must produce correct instances.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<DependencyWithParam1461>();
+        using var container = builder.Build();
+
+        using var scope1 = container.BeginLifetimeScope();
+        using var scope2 = container.BeginLifetimeScope();
+
+        var f1 = scope1.Resolve<Func<string, DependencyWithParam1461>>();
+        var f2 = scope2.Resolve<Func<string, DependencyWithParam1461>>();
+
+        Assert.Equal("hello", f1("hello").Value);
+        Assert.Equal("world", f2("world").Value);
+    }
+
+    [Fact]
+    public void FactoryDelegate_WithNamedParameter_SiblingScopes()
+    {
+        // #1461: Caching must not break custom delegate factories where parameters are mapped
+        // by name (ByName). Each sibling scope must produce correct instances.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<DependencyWithParam1461>();
+        using var container = builder.Build();
+
+        using var scope1 = container.BeginLifetimeScope();
+        using var scope2 = container.BeginLifetimeScope();
+
+        var f1 = scope1.Resolve<Func<string, DependencyWithParam1461>>();
+        var f2 = scope2.Resolve<Func<string, DependencyWithParam1461>>();
+
+        Assert.Equal("a", f1("a").Value);
+        Assert.Equal("b", f2("b").Value);
+    }
+
+    [Fact]
+    public void FactoryDelegate_DifferentProductTypes_NoCacheCollision()
+    {
+        // #1461: The cache must not collide across different product types.
+        // Func<Dependency1461> and Func<DependencyWithParam1461> must each compile their
+        // own generator entry and produce the correct product type.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>();
+        builder.RegisterType<DependencyWithParam1461>();
+        using var container = builder.Build();
+
+        using var scope = container.BeginLifetimeScope();
+
+        var f1 = scope.Resolve<Func<Dependency1461>>();
+        var f2 = scope.Resolve<Func<string, DependencyWithParam1461>>();
+
+        Assert.IsType<Dependency1461>(f1());
+        Assert.IsType<DependencyWithParam1461>(f2("test"));
+        Assert.Equal("test", f2("test").Value);
+    }
+
+    [Fact]
+    public void FactoryDelegate_InstancePerDependency_SiblingScopes()
+    {
+        // #1461: When the product is InstancePerDependency, each factory invocation must
+        // produce a distinct instance even when the compiled generator is shared.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>().InstancePerDependency();
+        using var container = builder.Build();
+
+        using var scope1 = container.BeginLifetimeScope();
+        using var scope2 = container.BeginLifetimeScope();
+
+        var f1 = scope1.Resolve<Func<Dependency1461>>();
+        var f2 = scope2.Resolve<Func<Dependency1461>>();
+
+        Assert.NotSame(f1(), f1());
+        Assert.NotSame(f2(), f2());
+        Assert.NotSame(f1(), f2());
+    }
+
+    [Fact]
+    public void FactoryDelegate_InstancePerLifetimeScope_SiblingScopes()
+    {
+        // #1461: When the product is InstancePerLifetimeScope, the factory must return the
+        // same instance within a scope but a different instance across sibling scopes.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>().InstancePerLifetimeScope();
+        using var container = builder.Build();
+
+        using var scope1 = container.BeginLifetimeScope();
+        using var scope2 = container.BeginLifetimeScope();
+
+        var f1 = scope1.Resolve<Func<Dependency1461>>();
+        var f2 = scope2.Resolve<Func<Dependency1461>>();
+
+        Assert.Same(f1(), f1());
+        Assert.Same(f2(), f2());
+        Assert.NotSame(f1(), f2());
+    }
+
+    [Fact]
+    public void FactoryDelegate_SingleInstance_SiblingScopes()
+    {
+        // #1461: When the product is SingleInstance, every factory invocation across all
+        // scopes must return the same singleton — the cached compiled generator must not
+        // change singleton semantics.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>().SingleInstance();
+        using var container = builder.Build();
+
+        using var scope1 = container.BeginLifetimeScope();
+        using var scope2 = container.BeginLifetimeScope();
+
+        var f1 = scope1.Resolve<Func<Dependency1461>>();
+        var f2 = scope2.Resolve<Func<Dependency1461>>();
+
+        Assert.Same(f1(), f2());
+    }
+
+    [Fact]
+    public void FactoryDelegate_RespectsChildScopeContext_SiblingScopes()
+    {
+        // #1461: Each factory delegate must resolve from its own child scope, not a shared
+        // ancestor scope. InstancePerLifetimeScope behaviour validates this.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>().InstancePerLifetimeScope();
+        using var container = builder.Build();
+
+        using var scope1 = container.BeginLifetimeScope();
+        using var scope2 = container.BeginLifetimeScope();
+
+        var f1 = scope1.Resolve<Func<Dependency1461>>();
+        var f2 = scope2.Resolve<Func<Dependency1461>>();
+
+        var result1 = f1();
+        var result2 = f2();
+
+        Assert.NotNull(result1);
+        Assert.NotNull(result2);
+
+        // Each factory is bound to its own scope — instances must differ.
+        Assert.NotSame(result1, result2);
+
+        // Within the same scope, calling the factory twice returns the same instance.
+        Assert.Same(result1, f1());
+        Assert.Same(result2, f2());
+    }
 }

--- a/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
+++ b/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
@@ -475,10 +475,12 @@ public class GeneratedFactoriesTests
         using var scope1 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
         scope1.Resolve<FuncConsumer1461>();
 
-        // After the first resolve, the compiled generator must be present in the cache.
-        Assert.True(ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.ContainsKey(cacheKey));
+        // After the first resolve, the compiled generator must be present in the shared cache.
+        var cache = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators;
+        Assert.True(cache.ContainsKey(cacheKey));
 
-        var countAfterFirstScope = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.Count;
+        // Capture the cached delegate instance — sibling scopes must reuse the same compiled entry.
+        Assert.True(cache.TryGetValue(cacheKey, out var cachedGeneratorAfterScope1));
 
         using var scope2 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
         scope2.Resolve<FuncConsumer1461>();
@@ -486,10 +488,10 @@ public class GeneratedFactoriesTests
         using var scope3 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
         scope3.Resolve<FuncConsumer1461>();
 
-        // Resolving the same Func<T> from additional sibling scopes must not add new cache entries;
-        // the count must remain stable after the first scope warms the entry.
-        var countAfterAllScopes = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.Count;
-        Assert.Equal(countAfterFirstScope, countAfterAllScopes);
+        // The cached delegate for this key must be the same object reference after sibling scope
+        // resolutions — proving no recompilation occurred for the already-cached key.
+        Assert.True(cache.TryGetValue(cacheKey, out var cachedGeneratorAfterAllScopes));
+        Assert.Same(cachedGeneratorAfterScope1, cachedGeneratorAfterAllScopes);
     }
 
     [Fact]
@@ -644,19 +646,42 @@ public class GeneratedFactoriesTests
     {
         // #1461: The generated-factory caches must participate in ReflectionCacheSet.Clear()
         // so that types from collectible AssemblyLoadContexts can be fully unloaded.
-        var builder = new ContainerBuilder();
-        builder.RegisterType<Dependency1461>();
-        using var container = builder.Build();
+        // Uses a fresh ReflectionCacheSet instance to avoid mutating process-global shared state.
+        var set = new ReflectionCacheSet();
 
-        using var scope = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
-        scope.Resolve<FuncConsumer1461>();
+        var cache = set.Internal.GeneratedFactoryServiceRegistrationGenerators;
+        var key = (typeof(Func<Dependency1461>), Autofac.Features.GeneratedFactories.ParameterMapping.ByType);
+        cache[key] = null!;
 
-        var serviceRegCache = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators;
+        Assert.NotEmpty(cache);
 
-        Assert.NotEmpty(serviceRegCache);
+        set.Clear();
 
-        ReflectionCacheSet.Shared.Clear();
+        Assert.Empty(cache);
+    }
 
-        Assert.Empty(serviceRegCache);
+    [Fact]
+    public void FactoryDelegate_CompiledGeneratorCache_ClearedByReflectionCacheSetPredicateClear()
+    {
+        // #1461: The generated-factory caches must also participate in predicate-based
+        // ReflectionCacheSet.Clear(predicate), which is the path taken when a collectible
+        // AssemblyLoadContext is unloaded — only types belonging to the unloaded assembly
+        // are removed, leaving unrelated entries intact.
+        // Uses a fresh ReflectionCacheSet instance to avoid mutating process-global shared state.
+        var set = new ReflectionCacheSet();
+
+        var cache = set.Internal.GeneratedFactoryServiceRegistrationGenerators;
+        var matchedKey = (typeof(Dependency1461), Autofac.Features.GeneratedFactories.ParameterMapping.ByType);
+        var unmatchedKey = (typeof(FuncConsumer1461), Autofac.Features.GeneratedFactories.ParameterMapping.ByName);
+        cache[matchedKey] = null!;
+        cache[unmatchedKey] = null!;
+
+        Assert.Equal(2, cache.Count);
+
+        // Simulate assembly-unload predicate: only remove entries whose Type key is Dependency1461.
+        set.Clear((member, _) => member == typeof(Dependency1461));
+
+        Assert.False(cache.ContainsKey(matchedKey));
+        Assert.True(cache.ContainsKey(unmatchedKey));
     }
 }

--- a/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
+++ b/test/Autofac.Test/Features/GeneratedFactories/GeneratedFactoriesTests.cs
@@ -476,9 +476,9 @@ public class GeneratedFactoriesTests
         scope1.Resolve<FuncConsumer1461>();
 
         // After the first resolve, the compiled generator must be present in the cache.
-        Assert.True(Autofac.Features.GeneratedFactories.FactoryGenerator.ServiceRegistrationGeneratorCache.ContainsKey(cacheKey));
+        Assert.True(ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.ContainsKey(cacheKey));
 
-        var countAfterFirstScope = Autofac.Features.GeneratedFactories.FactoryGenerator.ServiceRegistrationGeneratorCache.Count;
+        var countAfterFirstScope = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.Count;
 
         using var scope2 = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
         scope2.Resolve<FuncConsumer1461>();
@@ -488,7 +488,7 @@ public class GeneratedFactoriesTests
 
         // Resolving the same Func<T> from additional sibling scopes must not add new cache entries;
         // the count must remain stable after the first scope warms the entry.
-        var countAfterAllScopes = Autofac.Features.GeneratedFactories.FactoryGenerator.ServiceRegistrationGeneratorCache.Count;
+        var countAfterAllScopes = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators.Count;
         Assert.Equal(countAfterFirstScope, countAfterAllScopes);
     }
 
@@ -637,5 +637,26 @@ public class GeneratedFactoriesTests
         // Within the same scope, calling the factory twice returns the same instance.
         Assert.Same(result1, f1());
         Assert.Same(result2, f2());
+    }
+
+    [Fact]
+    public void FactoryDelegate_CompiledGeneratorCache_ClearedByReflectionCacheSetClear()
+    {
+        // #1461: The generated-factory caches must participate in ReflectionCacheSet.Clear()
+        // so that types from collectible AssemblyLoadContexts can be fully unloaded.
+        var builder = new ContainerBuilder();
+        builder.RegisterType<Dependency1461>();
+        using var container = builder.Build();
+
+        using var scope = container.BeginLifetimeScope(c => c.RegisterType<FuncConsumer1461>());
+        scope.Resolve<FuncConsumer1461>();
+
+        var serviceRegCache = ReflectionCacheSet.Shared.Internal.GeneratedFactoryServiceRegistrationGenerators;
+
+        Assert.NotEmpty(serviceRegCache);
+
+        ReflectionCacheSet.Shared.Clear();
+
+        Assert.Empty(serviceRegCache);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1461. Resolving a factory delegate (`Func<T>`, `Func<X,T>`, custom delegates) in a child lifetime scope — where the product `T` is registered in the parent — caused Autofac to recompile the delegate's expression tree on **every** child scope creation. `GeneratedFactoryRegistrationSource.RegistrationsFor` runs again for each new child scope and constructs a new `FactoryGenerator`, whose constructor unconditionally called `Expression.Lambda(...).Compile()`. Because each produced registration gets a fresh `Guid`, the `InstancePerLifetimeScope` share cache never hit across sibling scopes, so structurally identical delegates were recompiled repeatedly. (Despite the title, this is not `IStartable`-specific — any `Func<T>` consumer in a child scope reproduces it.)

## Fix

The compiled generator (the result of `Expression.Lambda(...).Compile()`) is now cached and reused for structurally identical factory delegates instead of being recompiled per scope.

- **Cache key:** `(delegateType, effectiveParameterMapping)` — fully determines the structure of the compiled lambda. `Adaptive` is resolved to `ByType`/`ByName` *before* keying, so it never appears in the key.
- **Context kept out of the cached delegate:** the previously baked-in `Expression.Constant` values (`service`, `productRegistration`) are now `Expression.Parameter`s supplied at invocation time, so the cached delegate carries no instance state and is safe to share across registrations and scopes. The per-`FactoryGenerator` closure supplies the instance-specific `service`/`productRegistration` at call time.
- **Two separate caches** for the two constructor overloads (resolve-via-`ResolveService` vs resolve-via-`ResolveComponent`) prevent any cross-overload collision.
- The Issue #269 duplicate-parameter-type guard is preserved in both compile paths.

### Cache lifetime / collectible-assembly unload

The caches live in the existing `ReflectionCacheSet` infrastructure (via two `InternalReflectionCaches` properties), exactly like every other `Type`-keyed cache in Autofac — so they participate in `ReflectionCacheSet.Clear()` and `Clear(predicate)`. This means types from a collectible `AssemblyLoadContext` are released on unload rather than being pinned forever by a process-static dictionary.

A new internal cache type, `ReflectionCacheTypeKeyedDictionary<TDiscriminator, TValue>`, holds the `(Type, TDiscriminator)` key shape (the existing `ReflectionCacheDictionary`/`ReflectionCacheTupleDictionary` require `MemberInfo` keys; `ParameterMapping` is an enum). Its `Clear(predicate)` matches on the `Type` component of the key. `Usage = All` because these generators are needed at resolve time and must survive container build.

No public API surface growth beyond the internal cache type.

## Tests

All tagged `#1461`, two-segment scenario names, no AAA comments:

- The issue's `LifetimeWithConsumer` repro across sibling scopes.
- **Generator reuse:** resolving the same `Func<T>` from sibling scopes returns the *same cached compiled delegate* (`Assert.Same` on the specific key's value — robust to parallel tests, no global-count dependence).
- **Collision matrix:** different product types for the same delegate type each resolve their own product; `ByType` and `ByName` parameter mapping; `InstancePerDependency` / `InstancePerLifetimeScope` / `SingleInstance` semantics preserved; per-scope context binding.
- **Unload clearing:** a fresh `ReflectionCacheSet` proves the new cache participates in `Clear()` and in `Clear(predicate)` (selective assembly-unload eviction on the `Type` component) — without mutating the process-global `ReflectionCacheSet.Shared`.

Zero warnings; full `Autofac.Test` passes on net8.0 and net10.0; format clean.

## Benchmark

Adds `GeneratedFactoryChildScopeBenchmark` (`bench/Autofac.Benchmarks/`, registered in `BenchmarkSet.All`) modeling the exact issue scenario: a component registered in a child scope that depends on `Func<T>` where `T` is registered in the parent, resolved across many child scopes. Run against a pre-fix baseline:

```
dotnet run -c Release --project bench/Autofac.Benchmarks -- --baseline-version 9.1.0 --filter *GeneratedFactoryChildScopeBenchmark*
```

Measured (Source = this fix vs Package-9.1.0 = pre-fix):

| ScopeCount | 9.1.0 Mean | Fixed Mean | Ratio | 9.1.0 Alloc | Fixed Alloc | Alloc Ratio |
|-----------:|-----------:|-----------:|------:|------------:|------------:|------------:|
| 100  | 15,315 µs | 546 µs   | **0.04 (~25× faster)** | 3.25 MB  | 2.12 MB  | 0.65 |
| 1000 | 153,554 µs | 5,495 µs | **0.04 (~25× faster)** | 32.49 MB | 21.21 MB | 0.65 |

The ~25× speedup and 35% allocation reduction come from eliminating the per-child-scope `Expression.Compile()`. The benchmark is the permanent guard against regressing this.